### PR TITLE
feat: update all examples for blECSd 0.3.0 API compatibility

### DIFF
--- a/3d-backends/package-lock.json
+++ b/3d-backends/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "3d-backends-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/3d-backends/package.json
+++ b/3d-backends/package.json
@@ -10,7 +10,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/3d-backends/pnpm-lock.yaml
+++ b/3d-backends/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/3d-cube/package-lock.json
+++ b/3d-cube/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "3d-cube-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/3d-cube/package.json
+++ b/3d-cube/package.json
@@ -10,7 +10,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/3d-cube/pnpm-lock.yaml
+++ b/3d-cube/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/3d-obj-viewer/package-lock.json
+++ b/3d-obj-viewer/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "3d-obj-viewer-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/3d-obj-viewer/package.json
+++ b/3d-obj-viewer/package.json
@@ -10,7 +10,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/3d-obj-viewer/pnpm-lock.yaml
+++ b/3d-obj-viewer/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ A physics-based animation with thousands of bouncing panels and collision detect
 
 ![dvdBounce](https://github.com/user-attachments/assets/ba80c94a-4fe6-45d8-acb0-f147f25529d2)
 
+### Claude Chat Simulator
+
+A non-interactive animated demo that simulates the Claude Code CLI interface, streaming a realistic multi-step release workflow with spinners, tool calls, and rich formatting.
+
 ## More Examples
 
 The `demos/` directory contains 68 additional demos covering individual widgets, systems, and features. See the [demos README](./demos/) for the full list.

--- a/agent-orchestrator/agents/healthCheck.test.ts
+++ b/agent-orchestrator/agents/healthCheck.test.ts
@@ -68,6 +68,7 @@ function makeState(workerPane: AgentPane): AppState {
 		orchestratorKind: 'claude',
 		workspacePath: '/workspace',
 		dbPath: './orchestrator.db',
+		mcpConfigPath: null,
 		startTime: Date.now(),
 		nextAgentId: 0,
 	};

--- a/agent-orchestrator/agents/worker.test.ts
+++ b/agent-orchestrator/agents/worker.test.ts
@@ -76,6 +76,7 @@ function makeState(): AppState {
 		orchestratorKind: 'claude',
 		workspacePath: '/workspace',
 		dbPath: './orchestrator.db',
+		mcpConfigPath: null,
 		startTime: Date.now(),
 		nextAgentId: 0,
 	};

--- a/agent-orchestrator/agents/worker.ts
+++ b/agent-orchestrator/agents/worker.ts
@@ -61,12 +61,18 @@ export function addWorker(state: AppState, spec: string): AgentPane {
 		}
 	}
 
+	// Build args, including MCP config for Claude agents
+	const workerArgs: string[] = [...preset.args];
+	if (state.mcpConfigPath && preset.kind === 'claude') {
+		workerArgs.push('--mcp-config', state.mcpConfigPath);
+	}
+
 	// Spawn the worker
 	const pane = spawnAgent(state, {
 		kind: preset.kind,
 		label: `${preset.label} (Worker)`,
 		command: preset.command,
-		args: preset.args,
+		args: workerArgs,
 		cwd,
 		env: preset.env,
 		mock: state.mockMode,

--- a/agent-orchestrator/helpers/cleanup.test.ts
+++ b/agent-orchestrator/helpers/cleanup.test.ts
@@ -56,6 +56,7 @@ function makeState(): AppState {
 		orchestratorKind: 'claude',
 		workspacePath: '/workspace',
 		dbPath: './orchestrator.db',
+		mcpConfigPath: null,
 		startTime: Date.now(),
 		nextAgentId: 0,
 	};

--- a/agent-orchestrator/index.ts
+++ b/agent-orchestrator/index.ts
@@ -187,6 +187,7 @@ async function mainBlecsd(): Promise<void> {
 		const toolHandlers = createToolHandlers(backend, 'blecsd-0', memoryDepsHolder);
 		mcpState = await startMcpServer(toolDefs, toolHandlers);
 		mcpConfigPath = writeMcpConfig(cliArgs.workspace, mcpState.port);
+		state.mcpConfigPath = mcpConfigPath;
 	} catch (err) {
 		warn('MCP server failed to start, tools will be unavailable', err, 'mcp');
 	}

--- a/agent-orchestrator/input/commandPalette.test.ts
+++ b/agent-orchestrator/input/commandPalette.test.ts
@@ -42,6 +42,7 @@ function makeState(): AppState {
 		orchestratorKind: 'claude',
 		workspacePath: '/workspace',
 		dbPath: './orchestrator.db',
+		mcpConfigPath: null,
 		startTime: Date.now(),
 		nextAgentId: 0,
 	};

--- a/agent-orchestrator/input/handlers.test.ts
+++ b/agent-orchestrator/input/handlers.test.ts
@@ -80,6 +80,7 @@ function makeState(): AppState {
 		orchestratorKind: 'claude',
 		workspacePath: '/workspace',
 		dbPath: './orchestrator.db',
+		mcpConfigPath: null,
 		startTime: Date.now(),
 		nextAgentId: 0,
 	};

--- a/agent-orchestrator/package.json
+++ b/agent-orchestrator/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"better-sqlite3": "^11.0.0",
-		"blecsd": "^0.2.0",
+		"blecsd": "file:../../blECSd",
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {

--- a/agent-orchestrator/pnpm-lock.yaml
+++ b/agent-orchestrator/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^11.0.0
         version: 11.10.0
       blecsd:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: file:../../blECSd
+        version: file:../../blECSd
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -366,8 +366,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  blecsd@0.2.0:
-    resolution: {integrity: sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==}
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -904,7 +904,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  blecsd@0.2.0:
+  blecsd@file:../../blECSd:
     dependencies:
       bitecs: 0.4.0
       zod: 4.3.6

--- a/agent-orchestrator/state/appState.ts
+++ b/agent-orchestrator/state/appState.ts
@@ -84,6 +84,9 @@ export function createAppState(world: World, cliArgs: CliArgs): AppState {
 		// Timing
 		startTime: Date.now(),
 
+		// MCP
+		mcpConfigPath: null,
+
 		// Counters
 		nextAgentId: 0,
 	};

--- a/agent-orchestrator/types.ts
+++ b/agent-orchestrator/types.ts
@@ -150,6 +150,9 @@ export interface AppState {
 	readonly workspacePath: string;
 	readonly dbPath: string;
 
+	/** MCP config file path (set after MCP server starts, used by workers). */
+	mcpConfigPath: string | null;
+
 	// Timing
 	readonly startTime: number;
 

--- a/agent-orchestrator/ui/render.ts
+++ b/agent-orchestrator/ui/render.ts
@@ -156,8 +156,9 @@ export function renderAgentPane(
  * @param state - Application state
  */
 export function renderFrame(state: AppState): void {
-	// Clear screen + hide cursor + move to home
-	let output = '\x1b[?25l\x1b[2J\x1b[H';
+	// Begin synchronized output (prevents partial frame display)
+	// The terminal holds all output until \x1b[?2026l, then displays atomically (no flicker)
+	let output = '\x1b[?2026h\x1b[?25l\x1b[H\x1b[2J';
 
 	// 0. Render header bar at row 1
 	output += renderHeaderBar(state.screenWidth, '');
@@ -231,7 +232,8 @@ export function renderFrame(state: AppState): void {
 		}
 	}
 
-	// Write to stdout
+	// End synchronized output and write to stdout
+	output += '\x1b[?2026l';
 	process.stdout.write(output);
 }
 

--- a/ascii-clock/package-lock.json
+++ b/ascii-clock/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "ascii-clock-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/ascii-clock/package.json
+++ b/ascii-clock/package.json
@@ -10,7 +10,7 @@
 		"dev": "tsx src/index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/ascii-clock/pnpm-lock.yaml
+++ b/ascii-clock/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/ascii-clock/src/index.ts
+++ b/ascii-clock/src/index.ts
@@ -10,6 +10,7 @@ import {
 	cleanup as cleanupOutput,
 	clearBuffer,
 	clearScreen,
+	createDirtyTracker,
 	createDoubleBuffer,
 	createInputHandler,
 	createScreenEntity,
@@ -222,7 +223,8 @@ const initialHeight = Math.max(15, process.stdout.rows ?? DEFAULT_HEIGHT);
 createScreenEntity(world, { width: initialWidth, height: initialHeight });
 
 let doubleBuffer = createDoubleBuffer(initialWidth, initialHeight);
-setRenderBuffer(doubleBuffer);
+let dirtyTracker = createDirtyTracker(initialWidth, initialHeight);
+setRenderBuffer(dirtyTracker, doubleBuffer.backBuffer);
 setOutputBuffer(doubleBuffer);
 setOutputStream(process.stdout);
 
@@ -326,7 +328,8 @@ async function main(): Promise<void> {
 		const resized = getOutputBuffer();
 		if (resized) {
 			doubleBuffer = resized;
-			setRenderBuffer(doubleBuffer);
+			dirtyTracker = createDirtyTracker(doubleBuffer.width, doubleBuffer.height);
+			setRenderBuffer(dirtyTracker, doubleBuffer.backBuffer);
 		}
 
 		updateLayout();

--- a/balatro/package-lock.json
+++ b/balatro/package-lock.json
@@ -8,7 +8,7 @@
       "name": "balatro-example",
       "version": "0.0.1",
       "dependencies": {
-        "blecsd": "^0.1.1"
+        "blecsd": "^0.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.2.1",
@@ -1040,9 +1040,9 @@
       "license": "MPL-2.0"
     },
     "node_modules/blecsd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-      "integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+      "integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
       "license": "MIT",
       "dependencies": {
         "bitecs": "^0.4.0",

--- a/balatro/package.json
+++ b/balatro/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "blecsd": "^0.1.1"
+    "blecsd": "file:../../blECSd"
   },
   "devDependencies": {
     "@types/node": "^25.2.1",

--- a/balatro/pnpm-lock.yaml
+++ b/balatro/pnpm-lock.yaml
@@ -1,0 +1,1280 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.3)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  assertion-error@2.0.1: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chai@6.2.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
+
+  object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      tsx: 4.21.0
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.0.18(@types/node@25.2.3)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.2.3)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@4.3.6: {}

--- a/big-text/index.ts
+++ b/big-text/index.ts
@@ -12,6 +12,7 @@ import { addEntity, createWorld } from 'blecsd';
 import {
 	cleanup as cleanupOutput,
 	clearScreen,
+	createDirtyTracker,
 	createDoubleBuffer,
 	createScreenEntity,
 	enterAlternateScreen,
@@ -42,7 +43,8 @@ async function main(): Promise<void> {
 	createScreenEntity(world, { width, height });
 
 	const doubleBuffer = createDoubleBuffer(width, height);
-	setRenderBuffer(doubleBuffer);
+	const dirtyTracker = createDirtyTracker(width, height);
+	setRenderBuffer(dirtyTracker, doubleBuffer.backBuffer);
 	setOutputBuffer(doubleBuffer);
 	setOutputStream(process.stdout);
 

--- a/big-text/package-lock.json
+++ b/big-text/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "big-text-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/big-text/package.json
+++ b/big-text/package.json
@@ -10,7 +10,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/big-text/pnpm-lock.yaml
+++ b/big-text/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/claude-chat/index.ts
+++ b/claude-chat/index.ts
@@ -1,0 +1,865 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Chat Simulator
+ *
+ * A scrollable, animated demo that simulates the Claude Code CLI interface.
+ * Starts with thousands of pre-populated chat messages in a VirtualizedList,
+ * then streams new messages as an animated script plays out.
+ *
+ * Demonstrates:
+ * - VirtualizedList widget handling thousands of lines efficiently
+ * - Cursor-navigable virtualized scrolling
+ * - Multi-line text input with cursor
+ * - Mouse wheel scrolling
+ * - Live content appending with follow mode
+ * - FPS counter
+ * - Rich ANSI color formatting
+ *
+ * Controls:
+ *   Mouse wheel     - scroll chat up/down
+ *   Tab             - toggle focus between chat list and input
+ *   Up/Down arrows  - scroll chat (when list focused) or move input cursor
+ *   PgUp/PgDn       - scroll chat by pages
+ *   Enter           - submit input / newline with Shift+Enter
+ *   Ctrl+C          - quit
+ *
+ * @module examples/claude-chat
+ */
+
+import { createWorld, parseMouseSequence, isMouseBuffer } from 'blecsd';
+import type { ParsedMouseEvent } from 'blecsd';
+import { createVirtualizedList, handleVirtualizedListKey } from 'blecsd/widgets';
+
+// =============================================================================
+// ANSI COLOR HELPERS
+// =============================================================================
+
+const R = '\x1b[0m';
+const BOLD = '\x1b[1m';
+
+function fgRgb(r: number, g: number, b: number): string {
+	return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+function bgRgb(r: number, g: number, b: number): string {
+	return `\x1b[48;2;${r};${g};${b}m`;
+}
+
+// Theme foreground colors
+const PURPLE = fgRgb(187, 154, 247);
+const ORANGE = fgRgb(255, 158, 100);
+const CYAN = fgRgb(125, 207, 255);
+const GREEN = fgRgb(158, 206, 106);
+const YELLOW = fgRgb(224, 175, 104);
+const DIM = fgRgb(86, 95, 137);
+const TEXT = fgRgb(200, 208, 224);
+const BRIGHT = `${BOLD}${fgRgb(226, 232, 240)}`;
+const BORDER_FG = fgRgb(59, 66, 97);
+
+// Background colors
+const STATUS_BG = bgRgb(36, 40, 59);
+const CURSOR_BG = bgRgb(42, 46, 66);
+const INPUT_BG = bgRgb(30, 30, 50);
+const INPUT_BORDER = fgRgb(59, 66, 97);
+
+// =============================================================================
+// SPINNER
+// =============================================================================
+
+const SPINNER_CHARS = [
+	'\u280B', '\u2819', '\u2839', '\u2838', '\u283C',
+	'\u2834', '\u2826', '\u2827', '\u2807', '\u280F',
+];
+
+// =============================================================================
+// MULTI-LINE INPUT STATE
+// =============================================================================
+
+const INPUT_HEIGHT = 3; // Visible rows for the text input area
+
+interface InputState {
+	lines: string[];
+	cursorRow: number;
+	cursorCol: number;
+	scrollRow: number; // First visible line when content exceeds INPUT_HEIGHT
+}
+
+function createInputState(): InputState {
+	return { lines: [''], cursorRow: 0, cursorCol: 0, scrollRow: 0 };
+}
+
+function inputInsertChar(input: InputState, ch: string): void {
+	const line = input.lines[input.cursorRow] ?? '';
+	input.lines[input.cursorRow] =
+		line.slice(0, input.cursorCol) + ch + line.slice(input.cursorCol);
+	input.cursorCol += ch.length;
+}
+
+function inputNewline(input: InputState): void {
+	const line = input.lines[input.cursorRow] ?? '';
+	const before = line.slice(0, input.cursorCol);
+	const after = line.slice(input.cursorCol);
+	input.lines[input.cursorRow] = before;
+	input.lines.splice(input.cursorRow + 1, 0, after);
+	input.cursorRow++;
+	input.cursorCol = 0;
+	ensureInputVisible(input);
+}
+
+function inputBackspace(input: InputState): void {
+	if (input.cursorCol > 0) {
+		const line = input.lines[input.cursorRow] ?? '';
+		input.lines[input.cursorRow] =
+			line.slice(0, input.cursorCol - 1) + line.slice(input.cursorCol);
+		input.cursorCol--;
+	} else if (input.cursorRow > 0) {
+		const currentLine = input.lines[input.cursorRow] ?? '';
+		input.lines.splice(input.cursorRow, 1);
+		input.cursorRow--;
+		const prevLine = input.lines[input.cursorRow] ?? '';
+		input.cursorCol = prevLine.length;
+		input.lines[input.cursorRow] = prevLine + currentLine;
+		ensureInputVisible(input);
+	}
+}
+
+function inputDelete(input: InputState): void {
+	const line = input.lines[input.cursorRow] ?? '';
+	if (input.cursorCol < line.length) {
+		input.lines[input.cursorRow] =
+			line.slice(0, input.cursorCol) + line.slice(input.cursorCol + 1);
+	} else if (input.cursorRow < input.lines.length - 1) {
+		const nextLine = input.lines[input.cursorRow + 1] ?? '';
+		input.lines[input.cursorRow] = line + nextLine;
+		input.lines.splice(input.cursorRow + 1, 1);
+	}
+}
+
+function inputMoveLeft(input: InputState): void {
+	if (input.cursorCol > 0) {
+		input.cursorCol--;
+	} else if (input.cursorRow > 0) {
+		input.cursorRow--;
+		input.cursorCol = (input.lines[input.cursorRow] ?? '').length;
+		ensureInputVisible(input);
+	}
+}
+
+function inputMoveRight(input: InputState): void {
+	const line = input.lines[input.cursorRow] ?? '';
+	if (input.cursorCol < line.length) {
+		input.cursorCol++;
+	} else if (input.cursorRow < input.lines.length - 1) {
+		input.cursorRow++;
+		input.cursorCol = 0;
+		ensureInputVisible(input);
+	}
+}
+
+function inputMoveUp(input: InputState): void {
+	if (input.cursorRow > 0) {
+		input.cursorRow--;
+		const line = input.lines[input.cursorRow] ?? '';
+		input.cursorCol = Math.min(input.cursorCol, line.length);
+		ensureInputVisible(input);
+	}
+}
+
+function inputMoveDown(input: InputState): void {
+	if (input.cursorRow < input.lines.length - 1) {
+		input.cursorRow++;
+		const line = input.lines[input.cursorRow] ?? '';
+		input.cursorCol = Math.min(input.cursorCol, line.length);
+		ensureInputVisible(input);
+	}
+}
+
+function inputMoveHome(input: InputState): void {
+	input.cursorCol = 0;
+}
+
+function inputMoveEnd(input: InputState): void {
+	input.cursorCol = (input.lines[input.cursorRow] ?? '').length;
+}
+
+function ensureInputVisible(input: InputState): void {
+	if (input.cursorRow < input.scrollRow) {
+		input.scrollRow = input.cursorRow;
+	} else if (input.cursorRow >= input.scrollRow + INPUT_HEIGHT) {
+		input.scrollRow = input.cursorRow - INPUT_HEIGHT + 1;
+	}
+}
+
+function inputGetText(input: InputState): string {
+	return input.lines.join('\n');
+}
+
+function inputClear(input: InputState): void {
+	input.lines = [''];
+	input.cursorRow = 0;
+	input.cursorCol = 0;
+	input.scrollRow = 0;
+}
+
+// =============================================================================
+// CHAT CONTENT BUILDERS
+// =============================================================================
+
+/** Build one repeatable chat conversation chunk (~26 lines). */
+function buildChatChunk(idx: number): string[] {
+	const n = idx + 1;
+	return [
+		'',
+		`${PURPLE}>${R} ${BRIGHT}Fix the authentication bug in the login handler (task #${n})${R}`,
+		'',
+		`  ${TEXT}I'll fix the authentication bug. Let me look at the login handler.${R}`,
+		'',
+		`  ${ORANGE}Read${R}${DIM}(${R}${CYAN}src/auth/login.ts${R}${DIM})${R}`,
+		`    ${DIM}  1  import { verifyPassword } from './crypto';${R}`,
+		`    ${DIM}  2  import { createSession } from './session';${R}`,
+		`    ${DIM}  3${R}`,
+		`    ${DIM}  4  export async function handleLogin(req, res) {${R}`,
+		`    ${DIM}  5    const { email, password } = req.body;${R}`,
+		`    ${DIM}  ...${R}`,
+		'',
+		`  ${ORANGE}Edit${R}${DIM}(${R}${CYAN}src/auth/login.ts${R}${DIM})${R}`,
+		`    ${DIM}  Applied 3 changes to login handler${R}`,
+		'',
+		`  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"pnpm test src/auth/ 2>&1"${R}${DIM})${R}`,
+		`    ${DIM}$ pnpm test src/auth/${R}`,
+		`    ${DIM} PASS  src/auth/login.test.ts (6 tests)${R}`,
+		`    ${DIM} PASS  src/auth/session.test.ts (4 tests)${R}`,
+		`    ${GREEN}  \u2714 All 10 tests passed${R}`,
+		'',
+		`  ${TEXT}Fixed the authentication bug. The issue was a missing await on the${R}`,
+		`  ${TEXT}password verification, causing early session creation.${R}`,
+		'',
+		`  ${BORDER_FG}${'─'.repeat(50)}${R}`,
+	];
+}
+
+/** Build the welcome box header. */
+function buildWelcomeLines(width: number): string[] {
+	const boxW = Math.min(60, width - 4);
+	const inner = boxW - 2;
+	const pad = (s: string, w: number) => {
+		const l = Math.floor((w - s.length) / 2);
+		return ' '.repeat(Math.max(0, l)) + s + ' '.repeat(Math.max(0, w - s.length - l));
+	};
+
+	return [
+		'',
+		`  ${BORDER_FG}\u256D${'\u2500'.repeat(inner)}\u256E${R}`,
+		`  ${BORDER_FG}\u2502${' '.repeat(inner)}\u2502${R}`,
+		`  ${BORDER_FG}\u2502${R}${PURPLE}${pad('Claude Code', inner)}${R}${BORDER_FG}\u2502${R}`,
+		`  ${BORDER_FG}\u2502${R}${DIM}${pad('v1.0.31', inner)}${R}${BORDER_FG}\u2502${R}`,
+		`  ${BORDER_FG}\u2502${' '.repeat(inner)}\u2502${R}`,
+		`  ${BORDER_FG}\u2502${R}${DIM}${pad('Model: claude-opus-4-6', inner)}${R}${BORDER_FG}\u2502${R}`,
+		`  ${BORDER_FG}\u2502${R}${DIM}${pad('CWD: /home/user/projects/blECSd', inner)}${R}${BORDER_FG}\u2502${R}`,
+		`  ${BORDER_FG}\u2502${' '.repeat(inner)}\u2502${R}`,
+		`  ${BORDER_FG}\u2570${'\u2500'.repeat(inner)}\u256F${R}`,
+		'',
+		`  ${DIM}Tips: ${CYAN}/help${R} ${DIM}for commands, ${CYAN}Shift+Tab${R} ${DIM}to switch modes${R}`,
+		'',
+	];
+}
+
+// =============================================================================
+// ANIMATED SCRIPT
+// =============================================================================
+
+interface ScriptEvent {
+	delay: number;
+	lines?: string[];
+	spinnerStart?: string;
+	spinnerStop?: string;
+}
+
+function buildScript(width: number): ScriptEvent[] {
+	return [
+		{ delay: 0, lines: buildWelcomeLines(width) },
+
+		// User prompt
+		{
+			delay: 2000,
+			lines: [
+				'',
+				`${PURPLE}>${R} ${BRIGHT}Ship the v0.2.0 release. Run all checks, merge the PR, publish to npm, and create a GitHub release.${R}`,
+				'',
+			],
+		},
+
+		// Planning
+		{ delay: 800, spinnerStart: 'Thinking...' },
+		{
+			delay: 1500,
+			spinnerStop: `${GREEN}\u2714${R} Done`,
+			lines: [
+				`  ${TEXT}I'll ship the v0.2.0 release. Let me run through the full checklist:${R}`,
+				'',
+				`  ${YELLOW}  1.${R} ${TEXT}Run typecheck, tests, lint, and build${R}`,
+				`  ${YELLOW}  2.${R} ${TEXT}Merge the PR via squash${R}`,
+				`  ${YELLOW}  3.${R} ${TEXT}Publish to npm${R}`,
+				`  ${YELLOW}  4.${R} ${TEXT}Create GitHub release with changelog${R}`,
+				'',
+				`  ${TEXT}Let's start with the checks.${R}`,
+			],
+		},
+
+		// Typecheck
+		{
+			delay: 600,
+			lines: ['', `  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"pnpm typecheck 2>&1"${R}${DIM})${R}`],
+		},
+		{ delay: 200, spinnerStart: 'Running typecheck...' },
+		{
+			delay: 2200,
+			spinnerStop: `${GREEN}\u2714${R} Typecheck completed`,
+			lines: [
+				`    ${DIM}$ pnpm typecheck${R}`,
+				`    ${DIM}> blecsd@0.2.0 typecheck${R}`,
+				`    ${DIM}> tsc --noEmit${R}`,
+				`    ${GREEN}  \u2714 0 errors, 0 warnings${R}`,
+			],
+		},
+
+		// Tests
+		{
+			delay: 400,
+			lines: ['', `  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"pnpm test 2>&1"${R}${DIM})${R}`],
+		},
+		{ delay: 200, spinnerStart: 'Running tests...' },
+		{
+			delay: 3000,
+			spinnerStop: `${GREEN}\u2714${R} Tests passed`,
+			lines: [
+				`    ${DIM}$ pnpm test${R}`,
+				`    ${DIM} PASS  src/ecs/world.test.ts (12 tests)${R}`,
+				`    ${DIM} PASS  src/ecs/query.test.ts (8 tests)${R}`,
+				`    ${DIM} PASS  src/rendering/buffer.test.ts (15 tests)${R}`,
+				`    ${DIM} PASS  src/rendering/ansi.test.ts (22 tests)${R}`,
+				`    ${DIM} PASS  src/widgets/text.test.ts (9 tests)${R}`,
+				`    ${DIM}  ... +15 more suites${R}`,
+				'',
+				`    ${DIM}Tests: 147 passed, 147 total  |  Time: 3.412s${R}`,
+				`    ${GREEN}  \u2714 All 147 tests passed${R}`,
+			],
+		},
+
+		// Lint
+		{
+			delay: 400,
+			lines: ['', `  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"pnpm lint 2>&1"${R}${DIM})${R}`],
+		},
+		{ delay: 200, spinnerStart: 'Running linter...' },
+		{
+			delay: 1800,
+			spinnerStop: `${GREEN}\u2714${R} Lint clean`,
+			lines: [
+				`    ${DIM}$ pnpm lint${R}`,
+				`    ${DIM}> eslint src/ --max-warnings=0${R}`,
+				`    ${GREEN}  \u2714 0 errors, 0 warnings${R}`,
+			],
+		},
+
+		// Build
+		{
+			delay: 400,
+			lines: ['', `  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"pnpm build 2>&1"${R}${DIM})${R}`],
+		},
+		{ delay: 200, spinnerStart: 'Building...' },
+		{
+			delay: 2500,
+			spinnerStop: `${GREEN}\u2714${R} Build succeeded`,
+			lines: [
+				`    ${DIM}$ pnpm build${R}`,
+				`    ${DIM}> tsup src/index.ts --format esm,cjs --dts${R}`,
+				`    ${DIM}  CJS  dist/index.cjs        42.1 kB${R}`,
+				`    ${DIM}  ESM  dist/index.js          38.7 kB${R}`,
+				`    ${DIM}  DTS  dist/index.d.ts        12.3 kB${R}`,
+				`    ${GREEN}  \u2714 Build: 3 files, 93.1 kB total${R}`,
+			],
+		},
+
+		// Checks summary
+		{
+			delay: 600,
+			lines: ['', `  ${TEXT}All checks passed. Merging the PR now.${R}`],
+		},
+
+		// PR Merge
+		{
+			delay: 500,
+			lines: [
+				'',
+				`  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"gh pr merge 921 --squash --admin 2>&1"${R}${DIM})${R}`,
+			],
+		},
+		{ delay: 200, spinnerStart: 'Merging PR...' },
+		{
+			delay: 2000,
+			spinnerStop: `${GREEN}\u2714${R} PR merged`,
+			lines: [
+				`    ${DIM}\u2714 Squashed and merged pull request #921${R}`,
+				`    ${DIM}  feat: v0.2.0 - new layout engine, widget improvements${R}`,
+			],
+		},
+
+		// npm publish
+		{
+			delay: 500,
+			lines: [
+				'',
+				`  ${TEXT}Main is up to date. Publishing to npm.${R}`,
+				'',
+				`  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"npm publish --access public 2>&1"${R}${DIM})${R}`,
+			],
+		},
+		{ delay: 200, spinnerStart: 'Publishing to npm...' },
+		{
+			delay: 3500,
+			spinnerStop: `${GREEN}\u2714${R} Published`,
+			lines: [
+				`    ${DIM}npm notice  blecsd@0.2.0${R}`,
+				`    ${DIM}npm notice   42.1kB  dist/index.cjs${R}`,
+				`    ${DIM}npm notice   38.7kB  dist/index.js${R}`,
+				`    ${DIM}npm notice   12.3kB  dist/index.d.ts${R}`,
+				`    ${DIM}  ... +81 more lines${R}`,
+				`    ${DIM}+ blecsd@0.2.0${R}`,
+				`    ${GREEN}  \u2714 Published blecsd@0.2.0 to npm${R}`,
+			],
+		},
+
+		// GitHub release
+		{
+			delay: 500,
+			lines: [
+				'',
+				`  ${TEXT}Package published. Creating the GitHub release.${R}`,
+				'',
+				`  ${ORANGE}Bash${R}${DIM}(${R}${CYAN}"gh release create v0.2.0 --title \\"v0.2.0\\" --notes-file CHANGELOG.md"${R}${DIM})${R}`,
+			],
+		},
+		{ delay: 200, spinnerStart: 'Creating release...' },
+		{
+			delay: 2000,
+			spinnerStop: `${GREEN}\u2714${R} Release created`,
+			lines: [
+				`    ${DIM}https://github.com/user/blECSd/releases/tag/v0.2.0${R}`,
+				`    ${GREEN}  \u2714 Created GitHub release v0.2.0${R}`,
+			],
+		},
+
+		// Final summary
+		{
+			delay: 600,
+			lines: [
+				'',
+				`  ${BORDER_FG}${'─'.repeat(50)}${R}`,
+				'',
+				`  ${BRIGHT}Release Summary${R}`,
+				'',
+				`    ${GREEN}\u2714${R} ${TEXT}Typecheck: 0 errors${R}`,
+				`    ${GREEN}\u2714${R} ${TEXT}Tests: 147/147 passed${R}`,
+				`    ${GREEN}\u2714${R} ${TEXT}Lint: clean${R}`,
+				`    ${GREEN}\u2714${R} ${TEXT}Build: 93.1 kB (3 files)${R}`,
+				`    ${GREEN}\u2714${R} ${TEXT}PR #921: squash-merged to main${R}`,
+				`    ${GREEN}\u2714${R} ${TEXT}npm: blecsd@0.2.0 published${R}`,
+				`    ${GREEN}\u2714${R} ${TEXT}GitHub: v0.2.0 release created${R}`,
+				'',
+				`  ${TEXT}The v0.2.0 release is shipped. The package is live on npm and the${R}`,
+				`  ${TEXT}GitHub release is up with the full changelog.${R}`,
+				'',
+				`  ${BORDER_FG}${'─'.repeat(50)}${R}`,
+				'',
+			],
+		},
+	];
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
+async function main(): Promise<void> {
+	const stdout = process.stdout;
+	const stdin = process.stdin;
+	const width = stdout.columns ?? 80;
+	const height = stdout.rows ?? 24;
+
+	const world = createWorld();
+
+	// -------------------------------------------------------------------------
+	// Pre-populate chat history: 200 copies of the chunk = ~5200 lines
+	// -------------------------------------------------------------------------
+	const HISTORY_COPIES = 200;
+	const initialLines: string[] = [];
+	for (let i = 0; i < HISTORY_COPIES; i++) {
+		initialLines.push(...buildChatChunk(i));
+	}
+
+	// -------------------------------------------------------------------------
+	// Layout: chat area + input area + status bar
+	// Input area = 1 border + INPUT_HEIGHT lines + 1 border = INPUT_HEIGHT + 2
+	// Status bar = 1
+	// Chat area = remaining
+	// -------------------------------------------------------------------------
+	const inputBoxHeight = INPUT_HEIGHT + 2; // top border + lines + bottom border
+	const statusBarHeight = 1;
+	const chatHeight = Math.max(3, height - inputBoxHeight - statusBarHeight);
+
+	const list = createVirtualizedList(world, {
+		width,
+		height: chatHeight,
+		lines: initialLines,
+	});
+
+	list.scrollToBottom();
+	list.follow(true);
+
+	// -------------------------------------------------------------------------
+	// Input state
+	// -------------------------------------------------------------------------
+	const input = createInputState();
+	let focusInput = true; // Start with input focused
+
+	// -------------------------------------------------------------------------
+	// Script state
+	// -------------------------------------------------------------------------
+	const script = buildScript(width);
+	let scriptIdx = 0;
+	let nextEventAt = Date.now() + (script[0]?.delay ?? 0);
+	let spinnerText: string | null = null;
+	let spinnerFrame = 0;
+	let lastSpinnerTick = 0;
+
+	// -------------------------------------------------------------------------
+	// FPS tracking
+	// -------------------------------------------------------------------------
+	let frameCount = 0;
+	let lastFpsUpdate = Date.now();
+	let fps = 0;
+
+	// -------------------------------------------------------------------------
+	// Terminal setup
+	// -------------------------------------------------------------------------
+	stdout.write('\x1b[?1049h'); // Alt screen
+	stdout.write('\x1b[?1003h'); // Enable any-event mouse tracking
+	stdout.write('\x1b[?1006h'); // Enable SGR mouse protocol
+	stdin.setRawMode?.(true);
+	stdin.resume();
+
+	let running = true;
+
+	// -------------------------------------------------------------------------
+	// Submit handler: append user message to chat
+	// -------------------------------------------------------------------------
+	function submitInput(): void {
+		const text = inputGetText(input).trim();
+		if (!text) return;
+
+		// Append as a user prompt
+		const msgLines = [
+			'',
+			`${PURPLE}>${R} ${BRIGHT}${text}${R}`,
+			'',
+		];
+		list.appendLines(msgLines);
+		list.follow(true);
+		inputClear(input);
+	}
+
+	// -------------------------------------------------------------------------
+	// Input handling
+	// -------------------------------------------------------------------------
+	const SCROLL_LINES = 3;
+
+	stdin.on('data', (data: Buffer) => {
+		// Mouse events
+		const buf = new Uint8Array(data);
+		if (isMouseBuffer(buf)) {
+			const result = parseMouseSequence(buf);
+			if (result && result.type === 'mouse') {
+				const ev = result.event;
+				if (ev.action === 'wheel') {
+					if (ev.button === 'wheelUp') {
+						list.scrollBy(-SCROLL_LINES);
+						list.follow(false);
+					} else if (ev.button === 'wheelDown') {
+						list.scrollBy(SCROLL_LINES);
+						const info = list.getScrollInfo();
+						if (info?.atBottom) list.follow(true);
+					}
+				}
+			}
+			return;
+		}
+
+		const ch = data.toString();
+
+		// Ctrl+C always quits
+		if (ch === '\x03') {
+			running = false;
+			return;
+		}
+
+		// Tab toggles focus
+		if (ch === '\t') {
+			focusInput = !focusInput;
+			return;
+		}
+
+		// Route input based on focus
+		if (focusInput) {
+			handleInputKey(ch, data);
+		} else {
+			handleListKey(ch);
+		}
+	});
+
+	function handleInputKey(ch: string, data: Buffer): void {
+		if (ch === '\r' || ch === '\n') {
+			// Enter = submit
+			submitInput();
+		} else if (ch === '\x1b[A') {
+			// Up arrow
+			inputMoveUp(input);
+		} else if (ch === '\x1b[B') {
+			// Down arrow
+			inputMoveDown(input);
+		} else if (ch === '\x1b[C') {
+			// Right arrow
+			inputMoveRight(input);
+		} else if (ch === '\x1b[D') {
+			// Left arrow
+			inputMoveLeft(input);
+		} else if (ch === '\x1b[H' || ch === '\x1bOH') {
+			// Home
+			inputMoveHome(input);
+		} else if (ch === '\x1b[F' || ch === '\x1bOF') {
+			// End
+			inputMoveEnd(input);
+		} else if (ch === '\x7f' || ch === '\b') {
+			// Backspace
+			inputBackspace(input);
+		} else if (ch === '\x1b[3~') {
+			// Delete
+			inputDelete(input);
+		} else if (ch === '\x1b[5~') {
+			// PgUp: scroll chat even when input focused
+			list.scrollPage(-1);
+			list.follow(false);
+		} else if (ch === '\x1b[6~') {
+			// PgDn: scroll chat even when input focused
+			list.scrollPage(1);
+			const info = list.getScrollInfo();
+			if (info?.atBottom) list.follow(true);
+		} else if (ch === '\x15') {
+			// Ctrl+U: clear input
+			inputClear(input);
+		} else if (ch === '\x0a' || ch === '\x1b\r' || ch === '\x1b\n') {
+			// Alt+Enter or Shift+Enter: newline
+			inputNewline(input);
+		} else if (ch.length === 1 && ch >= ' ') {
+			// Printable character
+			inputInsertChar(input, ch);
+		} else if (!ch.startsWith('\x1b') && ch.length > 0) {
+			// Multi-byte printable (unicode)
+			for (const c of ch) {
+				if (c >= ' ') inputInsertChar(input, c);
+			}
+		}
+	}
+
+	function handleListKey(ch: string): void {
+		if (ch === 'q' || ch === 'Q') {
+			running = false;
+			return;
+		}
+
+		if (ch === '\x1b[A') {
+			list.cursorUp();
+			list.follow(false);
+		} else if (ch === '\x1b[B') {
+			list.cursorDown();
+			const info = list.getScrollInfo();
+			if (info?.atBottom) list.follow(true);
+		} else if (ch === '\x1b[5~') {
+			list.scrollPage(-1);
+			list.follow(false);
+		} else if (ch === '\x1b[6~') {
+			list.scrollPage(1);
+			const info = list.getScrollInfo();
+			if (info?.atBottom) list.follow(true);
+		} else if (ch === '\x1b[H' || ch === '\x1bOH') {
+			list.scrollToTop();
+			list.follow(false);
+		} else if (ch === '\x1b[F' || ch === '\x1bOF') {
+			list.scrollToBottom();
+			list.follow(true);
+		} else {
+			handleVirtualizedListKey(list, ch);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Resize handling
+	// -------------------------------------------------------------------------
+	stdout.on('resize', () => {
+		const w = stdout.columns ?? 80;
+		const h = stdout.rows ?? 24;
+		const ch = Math.max(3, h - inputBoxHeight - statusBarHeight);
+		list.setDimensions(w, ch);
+	});
+
+	// -------------------------------------------------------------------------
+	// Render loop (~30 FPS)
+	// -------------------------------------------------------------------------
+	const FRAME_TIME = 1000 / 30;
+
+	function render(): void {
+		if (!running) {
+			stdout.write('\x1b[?1006l\x1b[?1003l\x1b[?25h\x1b[?1049l\x1b[0m');
+			process.exit(0);
+		}
+
+		const now = Date.now();
+		const w = stdout.columns ?? 80;
+		const h = stdout.rows ?? 24;
+		const chatH = Math.max(3, h - inputBoxHeight - statusBarHeight);
+
+		// Process script events
+		while (scriptIdx < script.length && now >= nextEventAt) {
+			const ev = script[scriptIdx]!;
+
+			if (ev.spinnerStop) spinnerText = null;
+			if (ev.lines) list.appendLines(ev.lines);
+			if (ev.spinnerStart) spinnerText = ev.spinnerStart;
+
+			scriptIdx++;
+			if (scriptIdx < script.length) {
+				nextEventAt = now + (script[scriptIdx]?.delay ?? 0);
+			}
+		}
+
+		// Spinner animation tick
+		if (spinnerText && now - lastSpinnerTick >= 80) {
+			spinnerFrame++;
+			lastSpinnerTick = now;
+		}
+
+		// FPS counter
+		frameCount++;
+		if (now - lastFpsUpdate >= 1000) {
+			fps = frameCount;
+			frameCount = 0;
+			lastFpsUpdate = now;
+		}
+
+		// Read list state
+		const scrollInfo = list.getScrollInfo();
+		const firstVisible = scrollInfo?.currentLine ?? 0;
+		const cursor = list.getCursor();
+		const total = list.getLineCount();
+		const scrollPct = Math.round(scrollInfo?.scrollPercent ?? 0);
+		const following = list.isFollowing();
+		const showCursor = !following;
+
+		// =====================================================================
+		// Build frame output
+		// =====================================================================
+		let out = '\x1b[H';
+
+		// --- Chat area ---
+		for (let i = 0; i < chatH; i++) {
+			const lineIdx = firstVisible + i;
+			const content = list.getLine(lineIdx);
+			const isCursorLine = showCursor && lineIdx === cursor;
+
+			if (content === undefined) {
+				out += `${R} \x1b[K`;
+			} else if (isCursorLine) {
+				out += `${CURSOR_BG}${YELLOW}>${R} ${content}${R}\x1b[K`;
+			} else {
+				out += `${R}  ${content}${R}\x1b[K`;
+			}
+
+			out += '\n';
+		}
+
+		// --- Input box ---
+		const inputTopRow = chatH + 1;
+		const borderColor = focusInput ? PURPLE : INPUT_BORDER;
+		const innerW = w - 2;
+
+		// Top border with label
+		const label = focusInput ? ' Input (Enter=send, Ctrl+U=clear) ' : ' Input (Tab to focus) ';
+		const labelLen = label.length;
+		const borderAfter = Math.max(0, innerW - labelLen);
+		out += `\x1b[${inputTopRow};1H${borderColor}\u256D${label}${'─'.repeat(borderAfter)}\u256E${R}\x1b[K`;
+
+		// Input content rows
+		for (let i = 0; i < INPUT_HEIGHT; i++) {
+			const row = inputTopRow + 1 + i;
+			const lineIdx = input.scrollRow + i;
+			const lineText = input.lines[lineIdx] ?? '';
+			const display = lineText.slice(0, innerW).padEnd(innerW, ' ');
+
+			out += `\x1b[${row};1H${borderColor}\u2502${R}${INPUT_BG}${focusInput ? fgRgb(200, 208, 224) : DIM}${display}${R}${borderColor}\u2502${R}\x1b[K`;
+		}
+
+		// Bottom border
+		const bottomRow = inputTopRow + INPUT_HEIGHT + 1;
+		out += `\x1b[${bottomRow};1H${borderColor}\u2570${'─'.repeat(innerW)}\u256F${R}\x1b[K`;
+
+		// --- Status bar ---
+		const statusRow = h;
+		out += `\x1b[${statusRow};1H${STATUS_BG}\x1b[K`;
+
+		// Left: app name
+		out += `${STATUS_BG}${PURPLE} claude-chat${R}`;
+
+		// Center: spinner or follow indicator
+		const midText = spinnerText
+			? ` ${SPINNER_CHARS[spinnerFrame % SPINNER_CHARS.length]} ${spinnerText} `
+			: following
+				? ' [following] '
+				: '';
+		if (midText) {
+			const midCol = Math.max(1, Math.floor((w - midText.length) / 2));
+			const midColor = spinnerText ? YELLOW : DIM;
+			out += `\x1b[${statusRow};${midCol}H${STATUS_BG}${midColor}${midText}${R}`;
+		}
+
+		// Right: stats
+		const rightText = `${total} lines | FPS: ${fps} | ${scrollPct}% `;
+		const rightCol = Math.max(1, w - rightText.length + 1);
+		out += `\x1b[${statusRow};${rightCol}H${STATUS_BG}${DIM}${rightText}${R}`;
+
+		// --- Position cursor in the input area ---
+		if (focusInput) {
+			const curVisRow = input.cursorRow - input.scrollRow;
+			if (curVisRow >= 0 && curVisRow < INPUT_HEIGHT) {
+				const termRow = inputTopRow + 1 + curVisRow;
+				const termCol = input.cursorCol + 2; // +1 for border, +1 for 1-indexed
+				out += `\x1b[?25h\x1b[${termRow};${termCol}H`; // Show and position cursor
+			} else {
+				out += '\x1b[?25l';
+			}
+		} else {
+			out += '\x1b[?25l'; // Hide cursor when list is focused
+		}
+
+		stdout.write(out);
+
+		setTimeout(render, FRAME_TIME);
+	}
+
+	render();
+}
+
+main().catch((err) => {
+	process.stdout.write('\x1b[?1006l\x1b[?1003l\x1b[?25h\x1b[?1049l\x1b[0m');
+	console.error('Error:', err);
+	process.exit(1);
+});

--- a/claude-chat/package-lock.json
+++ b/claude-chat/package-lock.json
@@ -1,0 +1,1575 @@
+{
+	"name": "claude-chat-example",
+	"version": "0.0.1",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "claude-chat-example",
+			"version": "0.0.1",
+			"dependencies": {
+				"blecsd": "^0.2.0"
+			},
+			"bin": {
+				"claude-chat": "dist/index.js"
+			},
+			"devDependencies": {
+				"@types/node": "^25.2.1",
+				"tsup": "^8.5.1",
+				"tsx": "^4.19.3",
+				"typescript": "^5.8.2"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+			"integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+			"integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+			"integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+			"integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+			"integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+			"integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+			"integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+			"integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+			"integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+			"integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+			"integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+			"integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+			"integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+			"integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+			"integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+			"integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+			"integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+			"integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+			"integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+			"integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+			"integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+			"integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+			"integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+			"integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+			"integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.2.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
+			"integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.16.0"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/bitecs": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.4.0.tgz",
+			"integrity": "sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==",
+			"license": "MPL-2.0"
+		},
+		"node_modules/blecsd": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bitecs": "^0.4.0",
+				"zod": "^4.3.6"
+			},
+			"bin": {
+				"blecsd": "dist/cli/init.js"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/bundle-require": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+			"integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"load-tsconfig": "^0.2.3"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"esbuild": ">=0.18"
+			}
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/confbox": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/consola": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.3",
+				"@esbuild/android-arm": "0.27.3",
+				"@esbuild/android-arm64": "0.27.3",
+				"@esbuild/android-x64": "0.27.3",
+				"@esbuild/darwin-arm64": "0.27.3",
+				"@esbuild/darwin-x64": "0.27.3",
+				"@esbuild/freebsd-arm64": "0.27.3",
+				"@esbuild/freebsd-x64": "0.27.3",
+				"@esbuild/linux-arm": "0.27.3",
+				"@esbuild/linux-arm64": "0.27.3",
+				"@esbuild/linux-ia32": "0.27.3",
+				"@esbuild/linux-loong64": "0.27.3",
+				"@esbuild/linux-mips64el": "0.27.3",
+				"@esbuild/linux-ppc64": "0.27.3",
+				"@esbuild/linux-riscv64": "0.27.3",
+				"@esbuild/linux-s390x": "0.27.3",
+				"@esbuild/linux-x64": "0.27.3",
+				"@esbuild/netbsd-arm64": "0.27.3",
+				"@esbuild/netbsd-x64": "0.27.3",
+				"@esbuild/openbsd-arm64": "0.27.3",
+				"@esbuild/openbsd-x64": "0.27.3",
+				"@esbuild/openharmony-arm64": "0.27.3",
+				"@esbuild/sunos-x64": "0.27.3",
+				"@esbuild/win32-arm64": "0.27.3",
+				"@esbuild/win32-ia32": "0.27.3",
+				"@esbuild/win32-x64": "0.27.3"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fix-dts-default-cjs-exports": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+			"integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"magic-string": "^0.30.17",
+				"mlly": "^1.7.4",
+				"rollup": "^4.34.8"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.6",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+			"integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/joycon": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/load-tsconfig": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+			"integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/mlly": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+			"integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"pathe": "^2.0.3",
+				"pkg-types": "^1.3.1",
+				"ufo": "^1.6.1"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.1.8",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/postcss-load-config": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+			"integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"lilconfig": "^3.1.1"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"jiti": ">=1.21.0",
+				"postcss": ">=8.0.9",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+			"integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.57.1",
+				"@rollup/rollup-android-arm64": "4.57.1",
+				"@rollup/rollup-darwin-arm64": "4.57.1",
+				"@rollup/rollup-darwin-x64": "4.57.1",
+				"@rollup/rollup-freebsd-arm64": "4.57.1",
+				"@rollup/rollup-freebsd-x64": "4.57.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+				"@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.57.1",
+				"@rollup/rollup-linux-arm64-musl": "4.57.1",
+				"@rollup/rollup-linux-loong64-gnu": "4.57.1",
+				"@rollup/rollup-linux-loong64-musl": "4.57.1",
+				"@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+				"@rollup/rollup-linux-ppc64-musl": "4.57.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+				"@rollup/rollup-linux-riscv64-musl": "4.57.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.57.1",
+				"@rollup/rollup-linux-x64-gnu": "4.57.1",
+				"@rollup/rollup-linux-x64-musl": "4.57.1",
+				"@rollup/rollup-openbsd-x64": "4.57.1",
+				"@rollup/rollup-openharmony-arm64": "4.57.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.57.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.57.1",
+				"@rollup/rollup-win32-x64-gnu": "4.57.1",
+				"@rollup/rollup-win32-x64-msvc": "4.57.1",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+			"integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/sucrase": {
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+			"integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"commander": "^4.0.0",
+				"lines-and-columns": "^1.1.6",
+				"mz": "^2.7.0",
+				"pirates": "^4.0.1",
+				"tinyglobby": "^0.2.11",
+				"ts-interface-checker": "^0.1.9"
+			},
+			"bin": {
+				"sucrase": "bin/sucrase",
+				"sucrase-node": "bin/sucrase-node"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"tree-kill": "cli.js"
+			}
+		},
+		"node_modules/ts-interface-checker": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/tsup": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+			"integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-require": "^5.1.0",
+				"cac": "^6.7.14",
+				"chokidar": "^4.0.3",
+				"consola": "^3.4.0",
+				"debug": "^4.4.0",
+				"esbuild": "^0.27.0",
+				"fix-dts-default-cjs-exports": "^1.0.0",
+				"joycon": "^3.1.1",
+				"picocolors": "^1.1.1",
+				"postcss-load-config": "^6.0.1",
+				"resolve-from": "^5.0.0",
+				"rollup": "^4.34.8",
+				"source-map": "^0.7.6",
+				"sucrase": "^3.35.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.11",
+				"tree-kill": "^1.2.2"
+			},
+			"bin": {
+				"tsup": "dist/cli-default.js",
+				"tsup-node": "dist/cli-node.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@microsoft/api-extractor": "^7.36.0",
+				"@swc/core": "^1",
+				"postcss": "^8.4.12",
+				"typescript": ">=4.5.0"
+			},
+			"peerDependenciesMeta": {
+				"@microsoft/api-extractor": {
+					"optional": true
+				},
+				"@swc/core": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/ufo": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		}
+	}
+}

--- a/claude-chat/package.json
+++ b/claude-chat/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "claude-chat-example",
+  "version": "0.0.1",
+  "description": "Claude Code CLI chat simulator - animated demo of the Claude Code interface",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "claude-chat": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsup index.ts --format esm --dts",
+    "start": "node dist/index.js",
+    "dev": "tsx index.ts"
+  },
+  "dependencies": {
+    "blecsd": "file:../../blECSd"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.1",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/claude-chat/pnpm-lock.yaml
+++ b/claude-chat/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/claude-chat/tsconfig.json
+++ b/claude-chat/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"outDir": "dist",
+		"rootDir": "."
+	},
+	"include": ["*.ts"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "blecsd-demos",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -475,9 +475,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/demos/package.json
+++ b/demos/package.json
@@ -75,7 +75,7 @@
 		"visibility": "tsx visibility-demo.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/demos/pnpm-lock.yaml
+++ b/demos/pnpm-lock.yaml
@@ -1,0 +1,366 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/demos/progressbar-demo.ts
+++ b/demos/progressbar-demo.ts
@@ -28,7 +28,7 @@ const bars = [
 
 for (const bar of bars) {
 	attachProgressBarBehavior(world, bar.eid);
-	onProgressComplete(bar.eid, () => { bar.auto = false; });
+	onProgressComplete(world, bar.eid, () => { bar.auto = false; });
 }
 
 let focusIdx = 0;
@@ -41,11 +41,11 @@ function render(): void {
 
 	for (let i = 0; i < bars.length; i++) {
 		const bar = bars[i]!;
-		const pct = getProgressPercentage(bar.eid);
-		const done = isProgressComplete(bar.eid);
+		const pct = getProgressPercentage(world, bar.eid);
+		const done = isProgressComplete(world, bar.eid);
 		const focused = i === focusIdx;
 		const indicator = focused ? '>' : ' ';
-		const barStr = renderProgressString(bar.eid, 30);
+		const barStr = renderProgressString(world, bar.eid, 30);
 		const status = done ? '\x1b[32m DONE\x1b[0m' : bar.auto ? '\x1b[36m AUTO\x1b[0m' : '';
 		const row = 5 + i * 3;
 		const color = focused ? '\x1b[1;33m' : '\x1b[0m';
@@ -73,7 +73,7 @@ render();
 timer = setInterval(() => {
 	let changed = false;
 	for (const bar of bars) {
-		if (bar.auto && !isProgressComplete(bar.eid)) {
+		if (bar.auto && !isProgressComplete(world, bar.eid)) {
 			incrementProgress(world, bar.eid, 1 + Math.random() * 2);
 			changed = true;
 		}

--- a/demos/select-demo.ts
+++ b/demos/select-demo.ts
@@ -46,8 +46,8 @@ for (const sel of selects) {
 let focusIdx = 0;
 let lastChange = '';
 
-onSelectChange(selects[0]!.eid, (val) => { lastChange = `Color: ${val}`; });
-onSelectChange(selects[1]!.eid, (val) => { lastChange = `Size: ${val}`; });
+onSelectChange(world, selects[0]!.eid, (val) => { lastChange = `Color: ${val}`; });
+onSelectChange(world, selects[1]!.eid, (val) => { lastChange = `Size: ${val}`; });
 
 function render(): void {
 	const { height } = getTerminalSize();
@@ -59,8 +59,8 @@ function render(): void {
 		const sel = selects[i]!;
 		const focused = i === focusIdx;
 		const open = isSelectOpen(world, sel.eid);
-		const selected = getSelectedLabel(sel.eid) ?? '(none)';
-		const hlIdx = getHighlightedIndex(sel.eid);
+		const selected = getSelectedLabel(world, sel.eid) ?? '(none)';
+		const hlIdx = getHighlightedIndex(world, sel.eid);
 		const row = 5 + i * 5 + (i > 0 && isSelectOpen(world, selects[0]!.eid) ? selects[0]!.options.length + 1 : 0);
 		const border = focused ? '\x1b[1;33m' : '\x1b[0m';
 		const arrow = open ? '▲' : '▼';

--- a/demos/slider-demo.ts
+++ b/demos/slider-demo.ts
@@ -31,7 +31,7 @@ let focusIdx = 0;
 let lastChange = '';
 
 for (const sl of sliders) {
-	onSliderChange(sl.eid, (val) => { lastChange = `${sl.label}: ${val}`; });
+	onSliderChange(world, sl.eid, (val) => { lastChange = `${sl.label}: ${val}`; });
 }
 
 function render(): void {
@@ -43,9 +43,9 @@ function render(): void {
 	for (let i = 0; i < sliders.length; i++) {
 		const sl = sliders[i]!;
 		const focused = i === focusIdx;
-		const val = getSliderValue(sl.eid);
-		const pct = getSliderPercentage(sl.eid);
-		const bar = renderSliderString(sl.eid, 25);
+		const val = getSliderValue(world, sl.eid);
+		const pct = getSliderPercentage(world, sl.eid);
+		const bar = renderSliderString(world, sl.eid, 25);
 		const row = 6 + i * 3;
 		const color = focused ? '\x1b[1;33m' : '\x1b[0m';
 		const indicator = focused ? '>' : ' ';

--- a/demos/table-demo.ts
+++ b/demos/table-demo.ts
@@ -8,7 +8,7 @@
  * @module demos/table
  */
 import { createWorld, addEntity } from 'blecsd';
-import { attachTableBehavior, setHeaders, appendRow, getData, getDataRows, renderTableLines, getColumns, removeRow, setTableDisplay } from 'blecsd/components';
+import { attachTableBehavior, setHeaders, appendRow, getDataRows, renderTableLines, removeRow, setTableDisplay } from 'blecsd/components';
 import { setupTerminal, shutdownTerminal, setupSignalHandlers, formatHelpBar, formatTitle, isQuitKey, getTerminalSize, moveTo, parseArrowKey } from './demo-utils';
 
 const world = createWorld();

--- a/demos/table-demo.ts
+++ b/demos/table-demo.ts
@@ -16,7 +16,7 @@ const table = addEntity(world);
 attachTableBehavior(world, table);
 
 // Configure display
-setTableDisplay(table, {});
+setTableDisplay(world, table, {});
 
 // Set headers
 setHeaders(world, table, [
@@ -45,12 +45,12 @@ function render(): void {
 	const { width, height } = getTerminalSize();
 	const out: string[] = ['\x1b[2J\x1b[H'];
 	out.push(formatTitle('Table Demo') + '\n');
-	const rows = getDataRows(table);
+	const rows = getDataRows(world, table);
 	out.push(`  Rows: \x1b[36m${rows.length}\x1b[0m  Selected: \x1b[33m${selectedRow + 1}\x1b[0m\n`);
 	out.push('  ' + '\u2500'.repeat(Math.min(width - 4, 55)) + '\n\n');
 
 	// Render table lines
-	const lines = renderTableLines(table, Math.min(width - 4, 55));
+	const lines = renderTableLines(world, table, Math.min(width - 4, 55));
 	for (let i = 0; i < lines.length; i++) {
 		const isDataRow = i > 2 && i < lines.length - 1; // Skip header+separator rows
 		const dataIdx = i - 3;
@@ -77,7 +77,7 @@ process.stdin.on('data', (data: Buffer) => {
 	if (isQuitKey(data)) { shutdown(); return; }
 	const ch = data.toString();
 	const dir = parseArrowKey(data);
-	const rows = getDataRows(table);
+	const rows = getDataRows(world, table);
 	if (dir === 'up') selectedRow = Math.max(0, selectedRow - 1);
 	if (dir === 'down') selectedRow = Math.min(rows.length - 1, selectedRow + 1);
 	if (ch === 'a') {
@@ -88,9 +88,9 @@ process.stdin.on('data', (data: Buffer) => {
 	if (ch === 'd' && rows.length > 0) { removeRow(world, table, selectedRow); selectedRow = Math.min(selectedRow, rows.length - 2); }
 	if (ch === 'r') {
 		// Re-randomize all levels
-		const data = getDataRows(table);
+		const data = getDataRows(world, table);
 		// Remove all and re-add with random levels
-		while (getDataRows(table).length > 0) removeRow(world, table, 0);
+		while (getDataRows(world, table).length > 0) removeRow(world, table, 0);
 		for (const row of data) {
 			const cells = row.map((c) => c.value ?? '');
 			cells[2] = String(Math.random() * 99 | 0);

--- a/doom/game/death.ts
+++ b/doom/game/death.ts
@@ -17,6 +17,7 @@ import type { MapData } from '../wad/types.js';
 import type { PlayerState } from './player.js';
 import { createPlayer } from './player.js';
 import { createWeaponState, type WeaponState } from './weapons.js';
+import { applyDamage as applyPaletteDamage, type PaletteState } from '../render/paletteEffects.js';
 
 // ─── Game Phase ─────────────────────────────────────────────────
 
@@ -91,11 +92,13 @@ export function createGameState(lives?: number): GameState {
  * @param gs - Mutable game state
  * @param player - Mutable player state
  * @param damage - Raw damage amount before armor
+ * @param paletteState - Optional palette state for damage tint effect
  */
 export function damagePlayer(
 	gs: GameState,
 	player: PlayerState,
 	damage: number,
+	paletteState?: PaletteState,
 ): void {
 	if (gs.phase !== GamePhase.PLAYING) return;
 	if (damage <= 0) return;
@@ -112,6 +115,11 @@ export function damagePlayer(
 
 	const actualDamage = damage - saved;
 	player.health -= actualDamage;
+
+	// Trigger palette damage tint
+	if (paletteState) {
+		applyPaletteDamage(paletteState, actualDamage);
+	}
 
 	if (player.health <= 0) {
 		player.health = 0;

--- a/doom/game/input.ts
+++ b/doom/game/input.ts
@@ -1,64 +1,92 @@
 /**
- * Keyboard input state management for the Doom game loop.
+ * Input state management for the Doom game loop.
  *
- * Sets up raw stdin and tracks which keys are currently held down
- * per-frame using the blecsd key parser.
+ * Sets up raw stdin and tracks keyboard + mouse input per-frame
+ * using the blecsd key and mouse parsers.
+ *
+ * Key hold tracking: Uses a timestamp map to bridge gaps between
+ * terminal key repeat events. Keys expire after KEY_HOLD_MS without
+ * a new press event, providing smooth held-key movement.
+ *
+ * Mouse look: Enables SGR 1006 mouse reporting and tracks
+ * horizontal mouse delta for turning.
  *
  * @module game/input
  */
 
-import { parseKeyBuffer, type KeyEvent, type KeyName } from 'blecsd';
+import { parseKeyBuffer, parseMouseSequence, isMouseBuffer, type KeyName } from 'blecsd';
 
-/** Set of currently pressed key names. */
+/** How long a key stays "held" after last press event (ms). */
+const KEY_HOLD_MS = 120;
+
+/** Set of currently pressed key names plus mouse delta. */
 export interface InputState {
 	readonly keys: Set<KeyName>;
 	readonly ctrl: boolean;
 	readonly shift: boolean;
+	readonly mouseDeltaX: number;
 }
 
 /** Mutable state for input tracking between frames. */
 interface InputTracker {
-	keys: Set<KeyName>;
+	/** Key name -> timestamp of last press. */
+	keyTimestamps: Map<KeyName, number>;
 	ctrl: boolean;
 	shift: boolean;
-	buffer: Buffer | null;
+	mouseDeltaX: number;
+	lastMouseX: number;
+	mouseInitialized: boolean;
 }
 
 const tracker: InputTracker = {
-	keys: new Set(),
+	keyTimestamps: new Map(),
 	ctrl: false,
 	shift: false,
-	buffer: null,
+	mouseDeltaX: 0,
+	lastMouseX: 0,
+	mouseInitialized: false,
 };
 
 /**
- * Set up raw stdin for keyboard input.
+ * Set up raw stdin for keyboard and mouse input.
  * Must be called once at startup.
- *
- * @example
- * ```typescript
- * setupInput();
- * // In frame loop:
- * const input = pollInput();
- * if (input.keys.has('w')) { // move forward }
- * ```
  */
 export function setupInput(): void {
 	if (process.stdin.isTTY) {
 		process.stdin.setRawMode(true);
 	}
 	process.stdin.resume();
-	process.stdin.setEncoding('utf8');
+
+	// Enable SGR 1006 mouse reporting for mouse look
+	process.stdout.write('\x1b[?1000h'); // enable mouse tracking
+	process.stdout.write('\x1b[?1003h'); // enable any-event tracking
+	process.stdout.write('\x1b[?1006h'); // enable SGR extended mode
 
 	process.stdin.on('data', (data: Buffer | string) => {
 		const buf = typeof data === 'string' ? Buffer.from(data) : data;
-		tracker.buffer = buf;
+		const uint8 = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 
-		const events = parseKeyBuffer(new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength));
+		// Check for mouse sequence first
+		if (isMouseBuffer(uint8)) {
+			const result = parseMouseSequence(uint8);
+			if (result?.type === 'mouse') {
+				const event = result.event;
+				if (event.action === 'move' || event.action === 'press') {
+					if (tracker.mouseInitialized) {
+						tracker.mouseDeltaX += event.x - tracker.lastMouseX;
+					}
+					tracker.lastMouseX = event.x;
+					tracker.mouseInitialized = true;
+				}
+			}
+			return;
+		}
 
-		// Update held keys
+		const now = Date.now();
+		const events = parseKeyBuffer(uint8);
+
 		for (const event of events) {
-			tracker.keys.add(event.name);
+			tracker.keyTimestamps.set(event.name, now);
 			if (event.ctrl) tracker.ctrl = true;
 			if (event.shift) tracker.shift = true;
 		}
@@ -66,23 +94,38 @@ export function setupInput(): void {
 }
 
 /**
- * Poll current input state and clear the per-frame buffer.
+ * Poll current input state and clear per-frame accumulators.
  * Call once per frame before processing input.
  *
- * @returns Current input state (keys pressed this frame)
+ * Keys are considered held if they were pressed within KEY_HOLD_MS.
+ * This bridges gaps in terminal key repeat for smooth movement.
+ *
+ * @returns Current input state
  */
 export function pollInput(): InputState {
+	const now = Date.now();
+	const activeKeys = new Set<KeyName>();
+
+	// Collect keys that haven't expired
+	for (const [key, timestamp] of tracker.keyTimestamps) {
+		if (now - timestamp < KEY_HOLD_MS) {
+			activeKeys.add(key);
+		} else {
+			tracker.keyTimestamps.delete(key);
+		}
+	}
+
 	const state: InputState = {
-		keys: new Set(tracker.keys),
+		keys: activeKeys,
 		ctrl: tracker.ctrl,
 		shift: tracker.shift,
+		mouseDeltaX: tracker.mouseDeltaX,
 	};
 
-	// Clear for next frame
-	tracker.keys.clear();
+	// Clear per-frame accumulators (but keep key timestamps)
 	tracker.ctrl = false;
 	tracker.shift = false;
-	tracker.buffer = null;
+	tracker.mouseDeltaX = 0;
 
 	return state;
 }
@@ -91,6 +134,11 @@ export function pollInput(): InputState {
  * Clean up input (restore terminal state).
  */
 export function cleanupInput(): void {
+	// Disable mouse reporting
+	process.stdout.write('\x1b[?1006l');
+	process.stdout.write('\x1b[?1003l');
+	process.stdout.write('\x1b[?1000l');
+
 	if (process.stdin.isTTY) {
 		process.stdin.setRawMode(false);
 	}

--- a/doom/game/player.test.ts
+++ b/doom/game/player.test.ts
@@ -12,7 +12,7 @@ beforeAll(() => {
 
 // ─── Minimal Mocks ──────────────────────────────────────────────────
 
-const noInput: InputState = { keys: new Set(), ctrl: false, shift: false };
+const noInput: InputState = { keys: new Set(), ctrl: false, shift: false, mouseDeltaX: 0 };
 
 function createMockMapData(things: MapData['things'] = []): MapData {
 	const buf = new ArrayBuffer(4);
@@ -143,6 +143,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['left']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -161,6 +162,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['a']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -178,6 +180,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['right']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -196,6 +199,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['d']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -213,6 +217,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['up']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -233,6 +238,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['w']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -264,6 +270,7 @@ describe('updatePlayer', () => {
 			keys: new Set(['down']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 		updatePlayer(player, input, map);
 
@@ -331,7 +338,7 @@ describe('momentum and friction', () => {
 		player.momx = 10 * FRACUNIT;
 		player.momy = 0;
 
-		const input: InputState = { keys: new Set(), ctrl: false, shift: false };
+		const input: InputState = { keys: new Set(), ctrl: false, shift: false, mouseDeltaX: 0 };
 		updatePlayer(player, input, map);
 
 		// After one tick with friction, momx should be reduced
@@ -348,7 +355,7 @@ describe('momentum and friction', () => {
 		player.momx = 5 * FRACUNIT;
 		player.momy = 0;
 
-		const input: InputState = { keys: new Set(), ctrl: false, shift: false };
+		const input: InputState = { keys: new Set(), ctrl: false, shift: false, mouseDeltaX: 0 };
 
 		// Run many ticks with no input
 		for (let i = 0; i < 50; i++) {
@@ -365,12 +372,12 @@ describe('momentum and friction', () => {
 		const player = createPlayer(map);
 
 		// Apply thrust for one tick
-		const moveInput: InputState = { keys: new Set(['up']), ctrl: false, shift: false };
+		const moveInput: InputState = { keys: new Set(['up']), ctrl: false, shift: false, mouseDeltaX: 0 };
 		updatePlayer(player, moveInput, map);
 		const posAfterThrust = player.x;
 
 		// Release input, player should still move due to momentum
-		const noKeys: InputState = { keys: new Set(), ctrl: false, shift: false };
+		const noKeys: InputState = { keys: new Set(), ctrl: false, shift: false, mouseDeltaX: 0 };
 		updatePlayer(player, noKeys, map);
 
 		expect(player.x).toBeGreaterThan(posAfterThrust);
@@ -388,7 +395,7 @@ describe('momentum and friction', () => {
 		player.momx = 0x0fff;
 		player.momy = 0x0fff;
 
-		const input: InputState = { keys: new Set(), ctrl: false, shift: false };
+		const input: InputState = { keys: new Set(), ctrl: false, shift: false, mouseDeltaX: 0 };
 		updatePlayer(player, input, map);
 
 		// After friction, the small values should be zeroed

--- a/doom/game/player.ts
+++ b/doom/game/player.ts
@@ -133,7 +133,15 @@ export function updatePlayer(
 	input: InputState,
 	map: MapData,
 ): void {
-	// Rotation
+	// Mouse look: convert pixel delta to BAM angle change
+	if (input.mouseDeltaX !== 0) {
+		// Sensitivity: each pixel of mouse movement = this many BAM units
+		const MOUSE_SENSITIVITY = 0x400000; // ~1.4 degrees per pixel
+		const bamDelta = input.mouseDeltaX * MOUSE_SENSITIVITY;
+		player.angle = ((player.angle - bamDelta) >>> 0);
+	}
+
+	// Keyboard rotation
 	if (input.keys.has('left') || input.keys.has('a')) {
 		player.angle = ((player.angle + player.turnSpeed) >>> 0);
 	}

--- a/doom/game/psprite.ts
+++ b/doom/game/psprite.ts
@@ -8,7 +8,6 @@
  * @module game/psprite
  */
 
-import { three } from 'blecsd';
 import { FRACBITS } from '../math/fixed.js';
 import type { RenderState } from '../render/defs.js';
 import type { SpriteStore } from '../wad/spriteData.js';
@@ -111,14 +110,20 @@ export function drawWeaponSprite(
 	// Determine light level (brighter during muzzle flash)
 	const flashBright = ws.flashTics > 0;
 
-	// Render column by column
+	// Precompute colormap for weapon sprite
+	const weaponColormapIdx = flashBright ? 0 : Math.min(15, Math.max(0, 8));
+	const weaponCmap = rs.colormap[weaponColormapIdx];
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+
+	// Render column by column with direct buffer writes
 	for (let sx = 0; sx < spriteWidth; sx++) {
 		const texCol = Math.floor(sx / WEAPON_SCALE);
 		const column = pic.columns[texCol];
 		if (!column) continue;
 
 		const px = drawX + sx;
-		if (px < 0 || px >= rs.screenWidth) continue;
+		if (px < 0 || px >= w) continue;
 
 		for (const post of column) {
 			for (let p = 0; p < post.pixels.length; p++) {
@@ -130,20 +135,17 @@ export function drawWeaponSprite(
 					if (py < 0 || py >= rs.screenHeight) continue;
 
 					const paletteIdx = post.pixels[p]!;
-					let colormapIdx = 0;
-					if (!flashBright) {
-						// Apply light diminishing based on sector light
-						colormapIdx = Math.min(15, Math.max(0, 8));
-					}
-
-					const colormap = rs.colormap[colormapIdx];
-					const mappedIdx = colormap ? colormap[paletteIdx] ?? paletteIdx : paletteIdx;
+					const mappedIdx = weaponCmap ? weaponCmap[paletteIdx] ?? paletteIdx : paletteIdx;
 					const color = rs.palette[mappedIdx];
 					const r = color ? color.r : 0;
 					const g = color ? color.g : 0;
 					const b = color ? color.b : 0;
 
-					three.setPixelUnsafe(rs.fb, px, py, r, g, b, 255);
+					const offset = (py * w + px) << 2;
+					buf[offset] = r;
+					buf[offset + 1] = g;
+					buf[offset + 2] = b;
+					buf[offset + 3] = 255;
 				}
 			}
 		}
@@ -177,10 +179,16 @@ function drawFallbackWeapon(
 	}
 
 	const statusBarTop = rs.screenHeight - 32;
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
 
 	for (let y = Math.max(0, drawY); y < Math.min(statusBarTop, drawY + weaponHeight); y++) {
-		for (let x = Math.max(0, drawX); x < Math.min(rs.screenWidth, drawX + weaponWidth); x++) {
-			three.setPixelUnsafe(rs.fb, x, y, r, g, b, 255);
+		for (let x = Math.max(0, drawX); x < Math.min(w, drawX + weaponWidth); x++) {
+			const offset = (y * w + x) << 2;
+			buf[offset] = r;
+			buf[offset + 1] = g;
+			buf[offset + 2] = b;
+			buf[offset + 3] = 255;
 		}
 	}
 
@@ -191,8 +199,12 @@ function drawFallbackWeapon(
 	const barrelY = drawY - barrelHeight;
 
 	for (let y = Math.max(0, barrelY); y < Math.min(statusBarTop, barrelY + barrelHeight); y++) {
-		for (let x = Math.max(0, barrelX); x < Math.min(rs.screenWidth, barrelX + barrelWidth); x++) {
-			three.setPixelUnsafe(rs.fb, x, y, r - 20, g - 20, b - 20, 255);
+		for (let x = Math.max(0, barrelX); x < Math.min(w, barrelX + barrelWidth); x++) {
+			const offset = (y * w + x) << 2;
+			buf[offset] = r - 20;
+			buf[offset + 1] = g - 20;
+			buf[offset + 2] = b - 20;
+			buf[offset + 3] = 255;
 		}
 	}
 }

--- a/doom/index.ts
+++ b/doom/index.ts
@@ -18,6 +18,7 @@
  *   D/Right  - Turn right
  *   Q/,      - Strafe left
  *   E/.      - Strafe right
+ *   Mouse    - Look left/right
  *   Ctrl+C   - Quit
  *
  * @module doom
@@ -71,20 +72,21 @@ import {
 	isInTransition,
 	isEpisodeComplete,
 	doLoadLevel,
-	carryOverPlayerState,
 	mapExists,
 	TransitionPhase,
 } from './game/levelTransition.js';
 import { createSpecialsState, useLines, checkWalkTriggers, runSectorThinkers } from './game/specials.js';
 import { drawIntermission } from './render/intermission.js';
+import { createKittyRenderer } from './render/kittyProtocol.js';
+import { setupTerminal, cleanupTerminal } from './render/terminal.js';
+import { createPaletteState, tickPalette, getPaletteIndex } from './render/paletteEffects.js';
 
 // ─── Configuration ─────────────────────────────────────────────────
 
 const SCREEN_WIDTH = 320;
 const SCREEN_HEIGHT = 200;
-const TARGET_FPS = 30;
 const TICRATE = 35;
-const FRAME_TIME = 1000 / TARGET_FPS;
+const TIC_MS = 1000 / TICRATE;
 
 // ─── Main ──────────────────────────────────────────────────────────
 
@@ -133,7 +135,6 @@ function main(): void {
 		(wad.directory.find((e) => e.name === 'COLORMAP')?.filepos ?? 0) +
 		(wad.directory.find((e) => e.name === 'COLORMAP')?.size ?? 0),
 	));
-	const palette = playpal[0]!;
 
 	// Load textures
 	console.log('Loading textures...');
@@ -161,13 +162,17 @@ function main(): void {
 	const hasTitlePic = loadTitlePic(wad);
 	console.log(`Title screen: ${hasTitlePic ? 'TITLEPIC loaded' : 'fallback'}`);
 
-	// Create framebuffer and backend
+	// Create framebuffer and custom Kitty renderer
 	const fb = three.createPixelFramebuffer({
 		width: SCREEN_WIDTH,
 		height: SCREEN_HEIGHT,
 		enableDepthBuffer: true,
 	});
-	const backend = three.createKittyBackend({ imageId: 1, chunkSize: 1024 * 1024 });
+	const kittyRenderer = createKittyRenderer(1, SCREEN_WIDTH, SCREEN_HEIGHT);
+	kittyRendererRef = kittyRenderer;
+
+	// Create palette effects state
+	const paletteState = createPaletteState();
 
 	// Create player
 	const player = createPlayer(map);
@@ -198,62 +203,28 @@ function main(): void {
 		triggerExit(transitionState, mobjs, secret);
 	};
 
-	// Enter alt screen, hide cursor
-	process.stdout.write('\x1b[?1049h'); // alt screen
-	process.stdout.write('\x1b[?25l');   // hide cursor
+	// Set up terminal (alt screen, cursor hiding)
+	setupTerminal();
 
-	// Set up input
+	// Set up input (keyboard + mouse)
 	setupInput();
 
-	// Frame counter
+	// Frame timing state
+	let lastTime = Date.now();
+	let accumulator = 0;
 	let frameCount = 0;
 	let lastFpsTime = Date.now();
 	let fps = 0;
+	let lastInput = pollInput();
 
-	// ─── Frame Loop ────────────────────────────────────────────────
+	// ─── Game Tic ────────────────────────────────────────────────
 
-	function frame(): void {
-		const frameStart = Date.now();
-
-		// Process input
-		const input = pollInput();
-
-		// Check for Ctrl+C quit (always active)
-		if (input.keys.has('c') && input.ctrl) {
-			shutdown();
-			return;
-		}
+	function gameTic(): void {
+		const input = lastInput;
 
 		// ─── Menu Mode ──────────────────────────────────────────
+		// Menu is handled in the frame loop (quit check + rendering).
 		if (isMenuActive(menuState)) {
-			const menuResult = updateMenu(menuState, input.keys);
-
-			if (menuResult.quit) {
-				shutdown();
-				return;
-			}
-
-			// Draw title screen with menu overlays
-			drawTitleScreen(fb, palette, menuState);
-
-			// Encode and output
-			const encoded = backend.encode(fb, 0, 0);
-			if (encoded.escape) {
-				process.stdout.write(`\x1b[1;1H${encoded.escape}`);
-			}
-
-			// Schedule next frame
-			const elapsed = Date.now() - frameStart;
-			const delay = Math.max(1, FRAME_TIME - elapsed);
-			setTimeout(frame, delay);
-			return;
-		}
-
-		// ─── Gameplay Mode ──────────────────────────────────────
-
-		// Escape quits during gameplay
-		if (input.keys.has('escape')) {
-			shutdown();
 			return;
 		}
 
@@ -266,7 +237,6 @@ function main(): void {
 		if (transitionState.phase === TransitionPhase.INTERMISSION) {
 			tickIntermission(transitionState);
 
-			// Space skips count animation or advances past intermission
 			if (input.keys.has('space')) {
 				if (!transitionState.countsFinished) {
 					skipCounts(transitionState);
@@ -274,20 +244,6 @@ function main(): void {
 					advanceToLoading(transitionState);
 				}
 			}
-
-			// Draw intermission screen
-			drawIntermission(fb, palette, transitionState);
-
-			// Encode and output
-			const encoded = backend.encode(fb, 0, 0);
-			if (encoded.escape) {
-				process.stdout.write(`\x1b[1;1H${encoded.escape}`);
-			}
-
-			// Schedule next frame (skip gameplay rendering)
-			const elapsed = Date.now() - frameStart;
-			const delay = Math.max(1, FRAME_TIME - elapsed);
-			setTimeout(frame, delay);
 			return;
 		}
 
@@ -296,7 +252,6 @@ function main(): void {
 			const nextMapName = transitionState.nextMap;
 
 			if (!nextMapName || isEpisodeComplete(transitionState) || !mapExists(wad, nextMapName)) {
-				// Episode complete or no next map: reset to title
 				completeTransition(transitionState, transitionState.currentMap, mobjs);
 				shutdown();
 				return;
@@ -362,8 +317,6 @@ function main(): void {
 
 			// Complete transition
 			completeTransition(transitionState, nextMapName, mobjs);
-
-			console.log(`Loaded map: ${nextMapName}`);
 		}
 
 		// ─── Gameplay ───────────────────────────────────────────
@@ -377,7 +330,6 @@ function main(): void {
 		tickDeath(gameState, player);
 
 		// Update player and weapons only when alive
-		let extralight = 0;
 		if (canPlayerAct(gameState) && !isInTransition(transitionState)) {
 			updatePlayer(player, input, map);
 			updateHud(hudState, input);
@@ -407,10 +359,10 @@ function main(): void {
 					}
 				}
 			}
-
-			// Apply muzzle flash extralight
-			extralight = weaponState.flashTics > 0 ? 2 : 0;
 		}
+
+		// Tick palette effects
+		tickPalette(paletteState);
 
 		// Run enemy AI thinkers (still run while dying for ambient animation)
 		runThinkers(mobjs, player, gameState, map);
@@ -420,9 +372,36 @@ function main(): void {
 
 		// Run sector movers (doors, lifts, platforms, crushers)
 		runSectorThinkers(specialsState, map);
+	}
 
-		// Set up render state
-		const rs = createRenderState(fb, map, textures, palette, colormap);
+	// ─── Render Frame ───────────────────────────────────────────
+
+	function renderFrame(): void {
+		// Select active palette based on effects (read-only, no mutation)
+		const paletteIdx = getPaletteIndex(paletteState);
+		const activePalette = playpal[paletteIdx] ?? playpal[0]!;
+
+		// ─── Menu Rendering ──────────────────────────────────────
+		if (isMenuActive(menuState)) {
+			drawTitleScreen(fb, activePalette, menuState);
+			kittyRenderer.renderFrame(fb);
+			return;
+		}
+
+		// ─── Intermission Rendering ──────────────────────────────
+		if (transitionState.phase === TransitionPhase.INTERMISSION) {
+			drawIntermission(fb, activePalette, transitionState);
+			kittyRenderer.renderFrame(fb);
+			return;
+		}
+
+		// ─── Gameplay Rendering ──────────────────────────────────
+
+		// Apply muzzle flash extralight
+		const extralight = (canPlayerAct(gameState) && weaponState.flashTics > 0) ? 2 : 0;
+
+		// Set up render state with active palette
+		const rs = createRenderState(fb, map, textures, activePalette, colormap);
 		rs.viewx = player.x;
 		rs.viewy = player.y;
 		rs.viewz = player.viewz;
@@ -433,11 +412,19 @@ function main(): void {
 		rs.viewsin = finesine[fineAngle] ?? 0;
 		rs.extralight = extralight;
 
-		// Recalculate flat scales for current view angle (matching R_ClearPlanes)
+		// Recalculate flat scales for current view angle
 		updateFlatScales(player.angle);
 
 		// Clear framebuffer
-		three.clearFramebuffer(fb, { r: 0, g: 0, b: 0, a: 255 });
+		const buf = fb.colorBuffer;
+		const totalPixels = SCREEN_WIDTH * SCREEN_HEIGHT;
+		for (let i = 0; i < totalPixels; i++) {
+			const off = i << 2;
+			buf[off] = 0;
+			buf[off + 1] = 0;
+			buf[off + 2] = 0;
+			buf[off + 3] = 255;
+		}
 
 		// Render BSP (walls)
 		if (map.nodes.length > 0) {
@@ -465,26 +452,62 @@ function main(): void {
 			drawGameOverOverlay(rs);
 		}
 
-		// Encode and output
-		const encoded = backend.encode(fb, 0, 0);
-		if (encoded.escape) {
-			// Position at top-left and write
-			process.stdout.write(`\x1b[1;1H${encoded.escape}`);
+		// Output frame via custom Kitty protocol
+		kittyRenderer.renderFrame(fb);
+	}
+
+	// ─── Frame Loop (Fixed Timestep) ────────────────────────────
+
+	function frame(): void {
+		const now = Date.now();
+		accumulator += now - lastTime;
+		lastTime = now;
+
+		// Poll input once per frame
+		lastInput = pollInput();
+
+		// Check for Ctrl+C quit (always active)
+		if (lastInput.keys.has('c') && lastInput.ctrl) {
+			shutdown();
+			return;
 		}
+
+		// Check for quit conditions
+		if (isMenuActive(menuState)) {
+			const menuResult = updateMenu(menuState, lastInput.keys);
+			if (menuResult.quit) {
+				shutdown();
+				return;
+			}
+		} else if (lastInput.keys.has('escape')) {
+			shutdown();
+			return;
+		}
+
+		// Run game tics at fixed 35 Hz
+		// Cap accumulator to prevent spiral of death
+		if (accumulator > TIC_MS * 4) {
+			accumulator = TIC_MS * 4;
+		}
+
+		while (accumulator >= TIC_MS) {
+			gameTic();
+			accumulator -= TIC_MS;
+		}
+
+		// Render at display rate
+		renderFrame();
 
 		// FPS counter
 		frameCount++;
-		const now = Date.now();
 		if (now - lastFpsTime >= 1000) {
 			fps = frameCount;
 			frameCount = 0;
 			lastFpsTime = now;
 		}
 
-		// Schedule next frame
-		const elapsed = Date.now() - frameStart;
-		const delay = Math.max(1, FRAME_TIME - elapsed);
-		setTimeout(frame, delay);
+		// Schedule next frame using setImmediate for lower latency
+		setImmediate(frame);
 	}
 
 	// Start the loop
@@ -494,15 +517,18 @@ function main(): void {
 
 // ─── Death / Game Over Overlays ─────────────────────────────────────
 
+interface OverlayTarget {
+	fb: { colorBuffer: Uint8ClampedArray };
+	screenWidth: number;
+	screenHeight: number;
+}
+
 /**
  * Draw a red-tinted "YOU DIED" overlay with respawn prompt.
- * Shows remaining lives and "Press SPACE to respawn".
  */
-function drawDeathOverlay(rs: { fb: ReturnType<typeof three.createPixelFramebuffer>; screenWidth: number; screenHeight: number }, lives: number): void {
-	// Red tint over entire screen
+function drawDeathOverlay(rs: OverlayTarget, lives: number): void {
 	applyRedTint(rs);
 
-	// Center text: "YOU DIED" and "PRESS SPACE TO RESPAWN"
 	const cx = Math.floor(rs.screenWidth / 2);
 	const cy = Math.floor(rs.screenHeight / 2) - 20;
 
@@ -514,8 +540,7 @@ function drawDeathOverlay(rs: { fb: ReturnType<typeof three.createPixelFramebuff
 /**
  * Draw a "GAME OVER" overlay.
  */
-function drawGameOverOverlay(rs: { fb: ReturnType<typeof three.createPixelFramebuffer>; screenWidth: number; screenHeight: number }): void {
-	// Deep red tint
+function drawGameOverOverlay(rs: OverlayTarget): void {
 	applyRedTint(rs);
 
 	const cx = Math.floor(rs.screenWidth / 2);
@@ -527,10 +552,9 @@ function drawGameOverOverlay(rs: { fb: ReturnType<typeof three.createPixelFrameb
 /**
  * Apply a red tint to the framebuffer by blending red into every pixel.
  */
-function applyRedTint(rs: { fb: ReturnType<typeof three.createPixelFramebuffer>; screenWidth: number; screenHeight: number }): void {
+function applyRedTint(rs: OverlayTarget): void {
 	const data = rs.fb.colorBuffer;
 	for (let i = 0; i < data.length; i += 4) {
-		// Blend toward red: increase red channel, reduce green and blue
 		const r = data[i] ?? 0;
 		const g = data[i + 1] ?? 0;
 		const b = data[i + 2] ?? 0;
@@ -542,10 +566,9 @@ function applyRedTint(rs: { fb: ReturnType<typeof three.createPixelFramebuffer>;
 
 /**
  * Draw simple text at a position using 3x5 minimal font.
- * Each character is 4px wide (3px char + 1px gap).
  */
 function drawOverlayText(
-	rs: { fb: ReturnType<typeof three.createPixelFramebuffer>; screenWidth: number; screenHeight: number },
+	rs: OverlayTarget,
 	x: number,
 	y: number,
 	text: string,
@@ -567,7 +590,12 @@ function drawOverlayText(
 				const px = cx + col;
 				const py = y + row;
 				if (px >= 0 && px < rs.screenWidth && py >= 0 && py < rs.screenHeight) {
-					three.setPixelUnsafe(rs.fb, px, py, r, g, b, 255);
+					const offset = (py * rs.screenWidth + px) << 2;
+					const buf = rs.fb.colorBuffer;
+					buf[offset] = r;
+					buf[offset + 1] = g;
+					buf[offset + 2] = b;
+					buf[offset + 3] = 255;
 				}
 			}
 		}
@@ -610,10 +638,11 @@ const OVERLAY_FONT: Readonly<Record<string, readonly string[]>> = {
 
 // ─── Shutdown ──────────────────────────────────────────────────────
 
+let kittyRendererRef: ReturnType<typeof createKittyRenderer> | null = null;
+
 function shutdown(): void {
 	cleanupInput();
-	process.stdout.write('\x1b[?25h');   // show cursor
-	process.stdout.write('\x1b[?1049l'); // exit alt screen
+	cleanupTerminal(kittyRendererRef ?? undefined);
 	console.log('Terminal Doom exited.');
 	process.exit(0);
 }

--- a/doom/package-lock.json
+++ b/doom/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "doom-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -1040,9 +1040,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/doom/package.json
+++ b/doom/package.json
@@ -13,7 +13,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/doom/pnpm-lock.yaml
+++ b/doom/pnpm-lock.yaml
@@ -1,0 +1,1280 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.3)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  assertion-error@2.0.1: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chai@6.2.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
+
+  object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      tsx: 4.21.0
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      tsx: 4.21.0
+
+  vitest@4.0.18(@types/node@25.2.3)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.2.3)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@4.3.6: {}

--- a/doom/render/automap.ts
+++ b/doom/render/automap.ts
@@ -8,7 +8,6 @@
  * @module render/automap
  */
 
-import { three } from 'blecsd';
 import { FRACBITS } from '../math/fixed.js';
 import type { PlayerState } from '../game/player.js';
 import type { RenderState } from './defs.js';
@@ -81,9 +80,16 @@ function drawLine(
 	const sy = cy0 < cy1 ? 1 : -1;
 	let err = dx - dy;
 
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+
 	for (;;) {
-		if (cx0 >= 0 && cx0 < rs.screenWidth && cy0 >= clipTop && cy0 < clipBottom) {
-			three.setPixelUnsafe(rs.fb, cx0, cy0, r, g, b, 255);
+		if (cx0 >= 0 && cx0 < w && cy0 >= clipTop && cy0 < clipBottom) {
+			const offset = (cy0 * w + cx0) << 2;
+			buf[offset] = r;
+			buf[offset + 1] = g;
+			buf[offset + 2] = b;
+			buf[offset + 3] = 255;
 		}
 
 		if (cx0 === cx1 && cy0 === cy1) break;
@@ -112,12 +118,6 @@ function drawLine(
  * @param player - Player state for centering and arrow direction
  * @param hudState - HUD state containing automap zoom level
  * @param map - Map data with linedefs and vertices
- *
- * @example
- * ```typescript
- * import { drawAutomap } from './automap.js';
- * drawAutomap(renderState, player, hudState, map);
- * ```
  */
 export function drawAutomap(
 	rs: RenderState,
@@ -130,21 +130,45 @@ export function drawAutomap(
 	const centerX = rs.screenWidth / 2;
 	const centerY = AUTOMAP_TOP + viewportHeight / 2;
 
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+
 	// Draw dark background overlay
 	for (let y = AUTOMAP_TOP; y < viewportBottom; y++) {
-		for (let x = 0; x < rs.screenWidth; x++) {
-			three.setPixelUnsafe(rs.fb, x, y, BG_R, BG_G, BG_B, 255);
+		let off = (y * w) << 2;
+		for (let x = 0; x < w; x++) {
+			buf[off] = BG_R;
+			buf[off + 1] = BG_G;
+			buf[off + 2] = BG_B;
+			buf[off + 3] = 255;
+			off += 4;
 		}
 	}
 
 	// Draw border
-	for (let x = 0; x < rs.screenWidth; x++) {
-		three.setPixelUnsafe(rs.fb, x, AUTOMAP_TOP, BORDER_R, BORDER_G, BORDER_B, 255);
-		three.setPixelUnsafe(rs.fb, x, viewportBottom - 1, BORDER_R, BORDER_G, BORDER_B, 255);
+	for (let x = 0; x < w; x++) {
+		const topOff = (AUTOMAP_TOP * w + x) << 2;
+		buf[topOff] = BORDER_R;
+		buf[topOff + 1] = BORDER_G;
+		buf[topOff + 2] = BORDER_B;
+		buf[topOff + 3] = 255;
+		const botOff = ((viewportBottom - 1) * w + x) << 2;
+		buf[botOff] = BORDER_R;
+		buf[botOff + 1] = BORDER_G;
+		buf[botOff + 2] = BORDER_B;
+		buf[botOff + 3] = 255;
 	}
 	for (let y = AUTOMAP_TOP; y < viewportBottom; y++) {
-		three.setPixelUnsafe(rs.fb, 0, y, BORDER_R, BORDER_G, BORDER_B, 255);
-		three.setPixelUnsafe(rs.fb, rs.screenWidth - 1, y, BORDER_R, BORDER_G, BORDER_B, 255);
+		const leftOff = (y * w) << 2;
+		buf[leftOff] = BORDER_R;
+		buf[leftOff + 1] = BORDER_G;
+		buf[leftOff + 2] = BORDER_B;
+		buf[leftOff + 3] = 255;
+		const rightOff = (y * w + w - 1) << 2;
+		buf[rightOff] = BORDER_R;
+		buf[rightOff + 1] = BORDER_G;
+		buf[rightOff + 2] = BORDER_B;
+		buf[rightOff + 3] = 255;
 	}
 
 	// Player position in map units (convert from fixed-point)

--- a/doom/render/drawColumn.ts
+++ b/doom/render/drawColumn.ts
@@ -2,15 +2,18 @@
  * Low-level pixel drawing: converts palette-indexed pixels to RGB
  * via COLORMAP and PLAYPAL, then writes to the framebuffer.
  *
+ * Uses direct colorBuffer writes instead of per-pixel function calls
+ * for maximum performance in hot rendering paths.
+ *
  * @module render/drawColumn
  */
 
-import { three } from 'blecsd';
 import type { RenderState } from './defs.js';
 
 /**
  * Draw a single pixel at (x, y) using palette-indexed color with
- * light diminishing via colormap.
+ * light diminishing via colormap. Writes directly to the framebuffer's
+ * colorBuffer for zero function-call overhead.
  *
  * @param rs - Render state (contains framebuffer, palette, colormap)
  * @param x - Screen X coordinate
@@ -33,12 +36,18 @@ export function drawColumn(
 	const color = rs.palette[shadedIdx];
 	if (!color) return;
 
-	three.setPixelUnsafe(rs.fb, x, y, color.r, color.g, color.b, 255);
+	const offset = (y * rs.screenWidth + x) << 2;
+	const buf = rs.fb.colorBuffer;
+	buf[offset] = color.r;
+	buf[offset + 1] = color.g;
+	buf[offset + 2] = color.b;
+	buf[offset + 3] = 255;
 }
 
 /**
  * Draw a vertical run of a single palette color.
  * Optimized for drawing untextured wall columns.
+ * Uses direct buffer writes with precomputed stride.
  *
  * @param rs - Render state
  * @param x - Screen X coordinate
@@ -66,8 +75,15 @@ export function drawColumnRun(
 
 	const startY = Math.max(0, y1);
 	const endY = Math.min(rs.screenHeight - 1, y2);
+	const buf = rs.fb.colorBuffer;
+	const stride = rs.screenWidth << 2;
+	let offset = (startY * rs.screenWidth + x) << 2;
 
 	for (let y = startY; y <= endY; y++) {
-		three.setPixelUnsafe(rs.fb, x, y, r, g, b, 255);
+		buf[offset] = r;
+		buf[offset + 1] = g;
+		buf[offset + 2] = b;
+		buf[offset + 3] = 255;
+		offset += stride;
 	}
 }

--- a/doom/render/hud.test.ts
+++ b/doom/render/hud.test.ts
@@ -136,7 +136,7 @@ function createMockPlayer(): PlayerState {
 	};
 }
 
-const noInput: InputState = { keys: new Set(), ctrl: false, shift: false };
+const noInput: InputState = { keys: new Set(), ctrl: false, shift: false, mouseDeltaX: 0 };
 
 // ─── Tests ──────────────────────────────────────────────────────────
 
@@ -170,6 +170,7 @@ describe('updateHud', () => {
 			keys: new Set(['tab']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 
 		updateHud(hud, tabInput);
@@ -187,6 +188,7 @@ describe('updateHud', () => {
 			keys: new Set(['w', 'a']),
 			ctrl: false,
 			shift: false,
+			mouseDeltaX: 0,
 		};
 
 		updateHud(hud, otherInput);

--- a/doom/render/hud.ts
+++ b/doom/render/hud.ts
@@ -8,7 +8,6 @@
  * @module render/hud
  */
 
-import { three } from 'blecsd';
 import { FRACBITS } from '../math/fixed.js';
 import type { PlayerState } from '../game/player.js';
 import type { InputState } from '../game/input.js';
@@ -156,6 +155,8 @@ function drawDigit(
 ): void {
 	const pattern = DIGIT_PATTERNS[digit];
 	if (!pattern) return;
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
 
 	for (let row = 0; row < DIGIT_HEIGHT; row++) {
 		const line = pattern[row];
@@ -164,8 +165,12 @@ function drawDigit(
 			if (line[col] === '#') {
 				const px = x + col;
 				const py = y + row;
-				if (px >= 0 && px < rs.screenWidth && py >= 0 && py < rs.screenHeight) {
-					three.setPixelUnsafe(rs.fb, px, py, r, g, b, 255);
+				if (px >= 0 && px < w && py >= 0 && py < rs.screenHeight) {
+					const offset = (py * w + px) << 2;
+					buf[offset] = r;
+					buf[offset + 1] = g;
+					buf[offset + 2] = b;
+					buf[offset + 3] = 255;
 				}
 			}
 		}
@@ -186,6 +191,8 @@ function drawChar(
 ): void {
 	const pattern = CHAR_PATTERNS[ch];
 	if (!pattern) return;
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
 
 	for (let row = 0; row < DIGIT_HEIGHT; row++) {
 		const line = pattern[row];
@@ -194,8 +201,12 @@ function drawChar(
 			if (line[col] === '#') {
 				const px = x + col;
 				const py = y + row;
-				if (px >= 0 && px < rs.screenWidth && py >= 0 && py < rs.screenHeight) {
-					three.setPixelUnsafe(rs.fb, px, py, r, g, b, 255);
+				if (px >= 0 && px < w && py >= 0 && py < rs.screenHeight) {
+					const offset = (py * w + px) << 2;
+					buf[offset] = r;
+					buf[offset + 1] = g;
+					buf[offset + 2] = b;
+					buf[offset + 3] = 255;
 				}
 			}
 		}
@@ -278,15 +289,29 @@ export function drawHud(
 	}
 
 	// Draw status bar background
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
 	for (let y = barTop; y < rs.screenHeight; y++) {
-		for (let x = 0; x < rs.screenWidth; x++) {
-			three.setPixelUnsafe(rs.fb, x, y, BAR_R, BAR_G, BAR_B, 255);
+		let off = (y * w) << 2;
+		for (let x = 0; x < w; x++) {
+			buf[off] = BAR_R;
+			buf[off + 1] = BAR_G;
+			buf[off + 2] = BAR_B;
+			buf[off + 3] = 255;
+			off += 4;
 		}
 	}
 
 	// Draw top border line
-	for (let x = 0; x < rs.screenWidth; x++) {
-		three.setPixelUnsafe(rs.fb, x, barTop, BORDER_R, BORDER_G, BORDER_B, 255);
+	{
+		let off = (barTop * w) << 2;
+		for (let x = 0; x < w; x++) {
+			buf[off] = BORDER_R;
+			buf[off + 1] = BORDER_G;
+			buf[off + 2] = BORDER_B;
+			buf[off + 3] = 255;
+			off += 4;
+		}
 	}
 
 	// Layout positions (vertically centered within status bar)
@@ -333,36 +358,31 @@ function drawKeySlot(
 	g: number,
 	b: number,
 ): void {
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+
+	const setPixel = (px: number, py: number, cr: number, cg: number, cb: number) => {
+		if (px >= 0 && px < w && py >= 0 && py < rs.screenHeight) {
+			const off = (py * w + px) << 2;
+			buf[off] = cr;
+			buf[off + 1] = cg;
+			buf[off + 2] = cb;
+			buf[off + 3] = 255;
+		}
+	};
+
 	// Draw outline
 	for (let i = 0; i < size; i++) {
-		// Top and bottom edges
-		if (x + i >= 0 && x + i < rs.screenWidth) {
-			if (y >= 0 && y < rs.screenHeight) {
-				three.setPixelUnsafe(rs.fb, x + i, y, r, g, b, 255);
-			}
-			if (y + size - 1 >= 0 && y + size - 1 < rs.screenHeight) {
-				three.setPixelUnsafe(rs.fb, x + i, y + size - 1, r, g, b, 255);
-			}
-		}
-		// Left and right edges
-		if (y + i >= 0 && y + i < rs.screenHeight) {
-			if (x >= 0 && x < rs.screenWidth) {
-				three.setPixelUnsafe(rs.fb, x, y + i, r, g, b, 255);
-			}
-			if (x + size - 1 >= 0 && x + size - 1 < rs.screenWidth) {
-				three.setPixelUnsafe(rs.fb, x + size - 1, y + i, r, g, b, 255);
-			}
-		}
+		setPixel(x + i, y, r, g, b);
+		setPixel(x + i, y + size - 1, r, g, b);
+		setPixel(x, y + i, r, g, b);
+		setPixel(x + size - 1, y + i, r, g, b);
 	}
 
 	// Fill interior with empty color
 	for (let iy = 1; iy < size - 1; iy++) {
 		for (let ix = 1; ix < size - 1; ix++) {
-			const px = x + ix;
-			const py = y + iy;
-			if (px >= 0 && px < rs.screenWidth && py >= 0 && py < rs.screenHeight) {
-				three.setPixelUnsafe(rs.fb, px, py, KEY_EMPTY_R, KEY_EMPTY_G, KEY_EMPTY_B, 255);
-			}
+			setPixel(x + ix, y + iy, KEY_EMPTY_R, KEY_EMPTY_G, KEY_EMPTY_B);
 		}
 	}
 }

--- a/doom/render/intermission.ts
+++ b/doom/render/intermission.ts
@@ -7,7 +7,7 @@
  * @module render/intermission
  */
 
-import { three } from 'blecsd';
+import { type three } from 'blecsd';
 import type { TransitionState } from '../game/levelTransition.js';
 import { PAR_TIMES, formatTime } from '../game/levelTransition.js';
 import type { Palette } from '../wad/types.js';
@@ -31,60 +31,78 @@ export function drawIntermission(
 	palette: Palette,
 	ts: TransitionState,
 ): void {
-	// Dark background
-	three.clearFramebuffer(fb, { r: 0, g: 0, b: 0, a: 255 });
+	// Dark background - clear entire framebuffer to black
+	const buf = fb.colorBuffer;
+	const totalPixels = SCREEN_WIDTH * SCREEN_HEIGHT;
+	for (let i = 0; i < totalPixels; i++) {
+		const off = i << 2;
+		buf[off] = 0;
+		buf[off + 1] = 0;
+		buf[off + 2] = 0;
+		buf[off + 3] = 255;
+	}
 
 	const cx = Math.floor(SCREEN_WIDTH / 2);
 
 	// Title: "FINISHED"
-	drawText(fb, cx - 28, 16, 'FINISHED', 200, 200, 200);
+	drawText(buf, cx - 28, 16, 'FINISHED', 200, 200, 200);
 
 	// Map name
 	const mapLabel = ts.currentMap;
-	drawText(fb, cx - (mapLabel.length * 4) / 2, 30, mapLabel, 255, 200, 50);
+	drawText(buf, cx - (mapLabel.length * 4) / 2, 30, mapLabel, 255, 200, 50);
 
 	// Divider line
+	let divOff = (44 * SCREEN_WIDTH + 40) << 2;
 	for (let x = 40; x < SCREEN_WIDTH - 40; x++) {
-		three.setPixelUnsafe(fb, x, 44, 80, 80, 80, 255);
+		buf[divOff] = 80;
+		buf[divOff + 1] = 80;
+		buf[divOff + 2] = 80;
+		buf[divOff + 3] = 255;
+		divOff += 4;
 	}
 
 	// Kill percentage
 	const killPctStr = `${ts.displayKillPct}`;
-	drawText(fb, 60, 56, 'KILLS', 200, 200, 200);
-	drawRightAlignedText(fb, 240, 56, `${killPctStr}%`, 255, 255, 100);
+	drawText(buf, 60, 56, 'KILLS', 200, 200, 200);
+	drawRightAlignedText(buf, 240, 56, `${killPctStr}%`, 255, 255, 100);
 
 	// Time
 	const timeStr = formatTime(ts.displayTime);
-	drawText(fb, 60, 74, 'TIME', 200, 200, 200);
-	drawRightAlignedText(fb, 240, 74, timeStr, 255, 255, 100);
+	drawText(buf, 60, 74, 'TIME', 200, 200, 200);
+	drawRightAlignedText(buf, 240, 74, timeStr, 255, 255, 100);
 
 	// Par time
 	const parTime = PAR_TIMES[ts.currentMap];
 	if (parTime !== undefined) {
 		const parStr = formatTime(parTime);
-		drawText(fb, 60, 92, 'PAR', 200, 200, 200);
-		drawRightAlignedText(fb, 240, 92, parStr, 255, 255, 100);
+		drawText(buf, 60, 92, 'PAR', 200, 200, 200);
+		drawRightAlignedText(buf, 240, 92, parStr, 255, 255, 100);
 	}
 
 	// Divider line
+	divOff = (110 * SCREEN_WIDTH + 40) << 2;
 	for (let x = 40; x < SCREEN_WIDTH - 40; x++) {
-		three.setPixelUnsafe(fb, x, 110, 80, 80, 80, 255);
+		buf[divOff] = 80;
+		buf[divOff + 1] = 80;
+		buf[divOff + 2] = 80;
+		buf[divOff + 3] = 255;
+		divOff += 4;
 	}
 
 	// Next map
 	if (ts.nextMap) {
-		drawText(fb, 60, 122, 'ENTERING', 200, 200, 200);
+		drawText(buf, 60, 122, 'ENTERING', 200, 200, 200);
 		const nextLabel = ts.nextMap;
-		drawText(fb, cx - (nextLabel.length * 4) / 2, 136, nextLabel, 255, 200, 50);
+		drawText(buf, cx - (nextLabel.length * 4) / 2, 136, nextLabel, 255, 200, 50);
 	} else {
-		drawText(fb, cx - 40, 122, 'EPISODE COMPLETE', 255, 100, 100);
+		drawText(buf, cx - 40, 122, 'EPISODE COMPLETE', 255, 100, 100);
 	}
 
 	// Prompt
 	if (ts.countsFinished) {
 		// Blink the prompt
 		if ((ts.intermissionTics >> 4) & 1) {
-			drawText(fb, cx - 48, 170, 'PRESS SPACE TO CONTINUE', 160, 160, 160);
+			drawText(buf, cx - 48, 170, 'PRESS SPACE TO CONTINUE', 160, 160, 160);
 		}
 	}
 }
@@ -95,7 +113,7 @@ export function drawIntermission(
  * Draw text using a 3x5 bitmap font (4px per character with gap).
  */
 function drawText(
-	fb: ReturnType<typeof three.createPixelFramebuffer>,
+	buf: Uint8ClampedArray,
 	x: number,
 	y: number,
 	text: string,
@@ -117,7 +135,11 @@ function drawText(
 				const px = cx + col;
 				const py = y + row;
 				if (px >= 0 && px < SCREEN_WIDTH && py >= 0 && py < SCREEN_HEIGHT) {
-					three.setPixelUnsafe(fb, px, py, r, g, b, 255);
+					const offset = (py * SCREEN_WIDTH + px) << 2;
+					buf[offset] = r;
+					buf[offset + 1] = g;
+					buf[offset + 2] = b;
+					buf[offset + 3] = 255;
 				}
 			}
 		}
@@ -128,7 +150,7 @@ function drawText(
  * Draw text right-aligned to the given X position.
  */
 function drawRightAlignedText(
-	fb: ReturnType<typeof three.createPixelFramebuffer>,
+	buf: Uint8ClampedArray,
 	rightX: number,
 	y: number,
 	text: string,
@@ -137,7 +159,7 @@ function drawRightAlignedText(
 	b: number,
 ): void {
 	const textWidth = text.length * 4;
-	drawText(fb, rightX - textWidth, y, text, r, g, b);
+	drawText(buf, rightX - textWidth, y, text, r, g, b);
 }
 
 /** Minimal 3x5 font for intermission text. */

--- a/doom/render/kittyProtocol.ts
+++ b/doom/render/kittyProtocol.ts
@@ -1,0 +1,124 @@
+/**
+ * Custom Kitty graphics protocol renderer.
+ *
+ * Bypasses blECSd's standard backend to use Kitty animation mode
+ * (`a=f` + `a=a`) with RGB24 output for maximum throughput.
+ * This avoids full image retransmission each frame and saves 25%
+ * bandwidth by dropping the alpha channel.
+ *
+ * @module render/kittyProtocol
+ */
+
+import { type three } from 'blecsd';
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const CHUNK_SIZE = 4096;
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface KittyRenderer {
+	renderFrame(fb: three.PixelFramebuffer): void;
+	cleanup(): void;
+}
+
+// ─── Implementation ─────────────────────────────────────────────
+
+/**
+ * Create a Kitty protocol renderer that uses animation mode
+ * for efficient frame updates.
+ *
+ * First frame: transmit + display (`a=T`)
+ * Subsequent frames: upload frame (`a=f`) then animate (`a=a`)
+ *
+ * @param imageId - Kitty image ID to use
+ * @param width - Framebuffer width in pixels
+ * @param height - Framebuffer height in pixels
+ */
+export function createKittyRenderer(
+	imageId: number,
+	width: number,
+	height: number,
+): KittyRenderer {
+	let firstFrame = true;
+	const rgb24 = new Uint8Array(width * height * 3);
+
+	return {
+		renderFrame(fb: three.PixelFramebuffer): void {
+			// Convert RGBA to RGB24
+			const rgba = fb.colorBuffer;
+			const totalPixels = width * height;
+			let rgbOff = 0;
+			let rgbaOff = 0;
+			for (let i = 0; i < totalPixels; i++) {
+				rgb24[rgbOff] = rgba[rgbaOff] ?? 0;
+				rgb24[rgbOff + 1] = rgba[rgbaOff + 1] ?? 0;
+				rgb24[rgbOff + 2] = rgba[rgbaOff + 2] ?? 0;
+				rgbOff += 3;
+				rgbaOff += 4;
+			}
+
+			// Base64 encode the RGB24 buffer
+			const b64 = Buffer.from(rgb24.buffer, rgb24.byteOffset, rgb24.byteLength).toString('base64');
+
+			// Build the output string
+			let output = '\x1b[1;1H';
+
+			if (firstFrame) {
+				// Transmit and display: a=T, f=24 (RGB), suppress response with q=2
+				output += buildChunkedPayload(
+					b64,
+					`a=T,f=24,s=${width},v=${height},i=${imageId},q=2`,
+				);
+				firstFrame = false;
+			} else {
+				// Upload new frame: a=f, r=1 replaces previous frame data
+				output += buildChunkedPayload(
+					b64,
+					`a=f,r=1,i=${imageId},f=24,s=${width},v=${height},q=2`,
+				);
+				// Animate (display the uploaded frame)
+				output += `\x1b_Ga=a,i=${imageId},q=2\x1b\\`;
+			}
+
+			process.stdout.write(output);
+		},
+
+		cleanup(): void {
+			// Delete image and suppress response
+			process.stdout.write(`\x1b_Ga=d,d=I,i=${imageId},q=2\x1b\\`);
+		},
+	};
+}
+
+/**
+ * Build a chunked Kitty graphics protocol payload.
+ *
+ * Splits base64 data into CHUNK_SIZE pieces, using m=1 for
+ * continuation chunks and m=0 for the final chunk.
+ */
+function buildChunkedPayload(b64Data: string, header: string): string {
+	const parts: string[] = [];
+	let offset = 0;
+	const total = b64Data.length;
+
+	if (total <= CHUNK_SIZE) {
+		// Single chunk, no continuation needed
+		parts.push(`\x1b_G${header},m=0;${b64Data}\x1b\\`);
+	} else {
+		// First chunk with header and m=1
+		parts.push(`\x1b_G${header},m=1;${b64Data.slice(0, CHUNK_SIZE)}\x1b\\`);
+		offset = CHUNK_SIZE;
+
+		// Middle chunks (no header fields needed, just continuation)
+		while (offset + CHUNK_SIZE < total) {
+			parts.push(`\x1b_Gm=1;${b64Data.slice(offset, offset + CHUNK_SIZE)}\x1b\\`);
+			offset += CHUNK_SIZE;
+		}
+
+		// Final chunk with m=0
+		parts.push(`\x1b_Gm=0;${b64Data.slice(offset)}\x1b\\`);
+	}
+
+	return parts.join('');
+}

--- a/doom/render/paletteEffects.ts
+++ b/doom/render/paletteEffects.ts
@@ -1,0 +1,169 @@
+/**
+ * Palette effects: damage tint, item pickup, radiation suit, berserk.
+ *
+ * The PLAYPAL lump contains 14 palettes. Palette 0 is the normal
+ * palette; palettes 1-13 provide screen-wide color effects:
+ *
+ *   0      Normal
+ *   1-8    Damage tint (increasing red intensity)
+ *   9      Item pickup (gold tint)
+ *   10-12  Radiation suit (green tint, cycling)
+ *   13     Berserk (deep red)
+ *
+ * This module manages a PaletteState that tracks active effects
+ * and returns the correct palette index each tic.
+ *
+ * @module render/paletteEffects
+ */
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export interface PaletteState {
+	/** Remaining tics of damage red flash (0 = no damage tint). */
+	damageCount: number;
+	/** Remaining tics of bonus gold flash (0 = no pickup tint). */
+	bonusCount: number;
+	/** Whether radiation suit is active. */
+	radSuit: boolean;
+	/** Radiation suit palette cycling counter. */
+	radTic: number;
+	/** Whether berserk is active. */
+	berserk: boolean;
+}
+
+// ─── Constants ──────────────────────────────────────────────────
+
+/** How quickly damage tint fades per tic. */
+const DAMAGE_FADE_RATE = 1;
+
+/** How quickly bonus tint fades per tic. */
+const BONUS_FADE_RATE = 1;
+
+/** Maximum damage count (maps to palette 8). */
+const MAX_DAMAGE_COUNT = 64;
+
+/** Maximum bonus count (maps to palette 9). */
+const MAX_BONUS_COUNT = 16;
+
+/** Radiation suit palette cycle length. */
+const RAD_CYCLE = 3;
+
+// ─── State Management ───────────────────────────────────────────
+
+/**
+ * Create a default palette state with no active effects.
+ */
+export function createPaletteState(): PaletteState {
+	return {
+		damageCount: 0,
+		bonusCount: 0,
+		radSuit: false,
+		radTic: 0,
+		berserk: false,
+	};
+}
+
+/**
+ * Tick the palette state and return the current palette index (0-13).
+ *
+ * Priority order (highest to lowest):
+ *   1. Damage red flash (palettes 1-8)
+ *   2. Item pickup gold flash (palette 9)
+ *   3. Radiation suit green tint (palettes 10-12)
+ *   4. Berserk red tint (palette 13)
+ *   5. Normal (palette 0)
+ */
+export function tickPalette(state: PaletteState): number {
+	// Fade active effects
+	if (state.damageCount > 0) {
+		state.damageCount = Math.max(0, state.damageCount - DAMAGE_FADE_RATE);
+	}
+	if (state.bonusCount > 0) {
+		state.bonusCount = Math.max(0, state.bonusCount - BONUS_FADE_RATE);
+	}
+
+	// Tick radiation suit cycling
+	if (state.radSuit) {
+		state.radTic++;
+	}
+
+	// Determine palette index by priority
+	if (state.damageCount > 0) {
+		// Map damageCount (1-64) to palette (1-8)
+		const palIdx = Math.ceil((state.damageCount / MAX_DAMAGE_COUNT) * 8);
+		return Math.min(8, Math.max(1, palIdx));
+	}
+
+	if (state.bonusCount > 0) {
+		return 9;
+	}
+
+	if (state.radSuit) {
+		// Cycle through palettes 10, 11, 12
+		return 10 + (Math.floor(state.radTic / 8) % RAD_CYCLE);
+	}
+
+	if (state.berserk) {
+		return 13;
+	}
+
+	return 0;
+}
+
+/**
+ * Get the current palette index without ticking (read-only).
+ * Use this in rendering code to select the active palette.
+ */
+export function getPaletteIndex(state: PaletteState): number {
+	if (state.damageCount > 0) {
+		const palIdx = Math.ceil((state.damageCount / MAX_DAMAGE_COUNT) * 8);
+		return Math.min(8, Math.max(1, palIdx));
+	}
+	if (state.bonusCount > 0) {
+		return 9;
+	}
+	if (state.radSuit) {
+		return 10 + (Math.floor(state.radTic / 8) % RAD_CYCLE);
+	}
+	if (state.berserk) {
+		return 13;
+	}
+	return 0;
+}
+
+// ─── Effect Triggers ────────────────────────────────────────────
+
+/**
+ * Apply damage to the palette effect state.
+ * Higher damage values produce a more intense red flash.
+ *
+ * @param state - Palette state to modify
+ * @param damage - Amount of damage taken
+ */
+export function applyDamage(state: PaletteState, damage: number): void {
+	state.damageCount = Math.min(MAX_DAMAGE_COUNT, state.damageCount + damage);
+}
+
+/**
+ * Trigger the item pickup gold flash.
+ */
+export function applyBonus(state: PaletteState): void {
+	state.bonusCount = MAX_BONUS_COUNT;
+}
+
+/**
+ * Set the radiation suit effect on or off.
+ */
+export function setRadSuit(state: PaletteState, active: boolean): void {
+	state.radSuit = active;
+	if (!active) {
+		state.radTic = 0;
+	}
+}
+
+/**
+ * Set the berserk effect on or off.
+ */
+export function setBerserk(state: PaletteState, active: boolean): void {
+	state.berserk = active;
+}

--- a/doom/render/planes.ts
+++ b/doom/render/planes.ts
@@ -8,7 +8,6 @@
  * @module render/planes
  */
 
-import { three } from 'blecsd';
 import {
 	ANGLETOFINESHIFT,
 	FINEMASK,
@@ -318,6 +317,9 @@ function drawFlatSpan(
 	const colormapIdx = rs.fixedcolormap ?? (lightTable?.[zIdx] ?? 0);
 	const cmap = rs.colormap[colormapIdx];
 
+	const buf = rs.fb.colorBuffer;
+	let offset = (y * rs.screenWidth + x1) << 2;
+
 	for (let x = x1; x <= x2; x++) {
 		const tx = ((xfrac >> FRACBITS) & 63);
 		const ty = ((yfrac >> FRACBITS) & 63);
@@ -326,9 +328,13 @@ function drawFlatSpan(
 		const shadedIdx = cmap ? (cmap[paletteIdx] ?? paletteIdx) : paletteIdx;
 		const color = rs.palette[shadedIdx];
 		if (color) {
-			three.setPixelUnsafe(rs.fb, x, y, color.r, color.g, color.b, 255);
+			buf[offset] = color.r;
+			buf[offset + 1] = color.g;
+			buf[offset + 2] = color.b;
+			buf[offset + 3] = 255;
 		}
 
+		offset += 4;
 		xfrac += xstep;
 		yfrac += ystep;
 	}
@@ -376,6 +382,9 @@ function drawSkyPlane(rs: RenderState, plane: Visplane): void {
  * Fallback sky gradient when SKY1 texture is not found.
  */
 function drawSkyGradient(rs: RenderState, plane: Visplane): void {
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+
 	for (let x = plane.minx; x <= plane.maxx; x++) {
 		const top = plane.top[x];
 		const bottom = plane.bottom[x];
@@ -384,10 +393,11 @@ function drawSkyGradient(rs: RenderState, plane: Visplane): void {
 		for (let y = top; y <= bottom; y++) {
 			if (y < 0 || y >= rs.screenHeight) continue;
 			const t = y / rs.screenHeight;
-			const r = Math.round(20 + t * 40);
-			const g = Math.round(30 + t * 50);
-			const b = Math.round(80 + t * 120);
-			three.setPixelUnsafe(rs.fb, x, y, r, g, b, 255);
+			const offset = (y * w + x) << 2;
+			buf[offset] = Math.round(20 + t * 40);
+			buf[offset + 1] = Math.round(30 + t * 50);
+			buf[offset + 2] = Math.round(80 + t * 120);
+			buf[offset + 3] = 255;
 		}
 	}
 }
@@ -396,6 +406,9 @@ function drawSkyGradient(rs: RenderState, plane: Visplane): void {
  * Draw a solid-colored plane (fallback when flat texture is missing).
  */
 function drawSolidPlane(rs: RenderState, plane: Visplane): void {
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+
 	// Dark gray for missing flats
 	for (let x = plane.minx; x <= plane.maxx; x++) {
 		const top = plane.top[x];
@@ -404,7 +417,11 @@ function drawSolidPlane(rs: RenderState, plane: Visplane): void {
 
 		for (let y = top; y <= bottom; y++) {
 			if (y < 0 || y >= rs.screenHeight) continue;
-			three.setPixelUnsafe(rs.fb, x, y, 40, 40, 40, 255);
+			const offset = (y * w + x) << 2;
+			buf[offset] = 40;
+			buf[offset + 1] = 40;
+			buf[offset + 2] = 40;
+			buf[offset + 3] = 255;
 		}
 	}
 }

--- a/doom/render/sprites.ts
+++ b/doom/render/sprites.ts
@@ -8,7 +8,6 @@
  * @module render/sprites
  */
 
-import { three } from 'blecsd';
 import { ANGLETOFINESHIFT, FINEMASK, finecosine, finesine, pointToAngle2 } from '../math/angles.js';
 import { FRACBITS, FRACUNIT, fixedDiv, fixedMul } from '../math/fixed.js';
 import { centerxfrac, centery, projection, viewwidth } from '../math/tables.js';
@@ -24,7 +23,6 @@ import {
 	NUMCOLORMAPS,
 	scalelight,
 } from '../math/tables.js';
-import { drawColumn } from './drawColumn.js';
 
 // ─── Vissprite ────────────────────────────────────────────────────
 
@@ -273,6 +271,9 @@ function drawSpriteColumn(
 	clipBot: number,
 ): void {
 	const invScale = fixedDiv(FRACUNIT, scale);
+	const buf = rs.fb.colorBuffer;
+	const w = rs.screenWidth;
+	const cmap = rs.colormap[colormapIdx];
 
 	for (const post of column) {
 		// Compute screen Y range for this post
@@ -290,7 +291,7 @@ function drawSpriteColumn(
 
 		if (drawTop > drawBot) continue;
 
-		// Draw each pixel in the post
+		// Draw each pixel in the post with direct buffer writes
 		for (let y = drawTop; y <= drawBot; y++) {
 			if (y < 0 || y >= rs.screenHeight) continue;
 
@@ -305,7 +306,15 @@ function drawSpriteColumn(
 			const paletteIdx = post.pixels[postPixelIdx];
 			if (paletteIdx === undefined) continue;
 
-			drawColumn(rs, x, y, paletteIdx, colormapIdx);
+			const shadedIdx = cmap ? (cmap[paletteIdx] ?? paletteIdx) : paletteIdx;
+			const color = rs.palette[shadedIdx];
+			if (!color) continue;
+
+			const offset = (y * w + x) << 2;
+			buf[offset] = color.r;
+			buf[offset + 1] = color.g;
+			buf[offset + 2] = color.b;
+			buf[offset + 3] = 255;
 		}
 	}
 }

--- a/doom/render/terminal.ts
+++ b/doom/render/terminal.ts
@@ -1,0 +1,74 @@
+/**
+ * Terminal detection and lifecycle management.
+ *
+ * Detects Kitty graphics protocol support, consolidates terminal
+ * setup (alt screen, cursor hiding, mouse capture) and cleanup
+ * (image deletion, cursor restore, alt screen exit) into single
+ * functions with double-cleanup protection.
+ *
+ * @module render/terminal
+ */
+
+import type { KittyRenderer } from './kittyProtocol.js';
+
+// ─── Terminal Detection ──────────────────────────────────────────
+
+/** Known terminal emulators that support the Kitty graphics protocol. */
+const KITTY_TERMINALS = new Set([
+	'kitty',
+	'wezterm',
+	'ghostty',
+]);
+
+/**
+ * Check whether the current terminal supports the Kitty graphics protocol.
+ *
+ * Inspects `TERM_PROGRAM` environment variable for known Kitty-capable
+ * terminals. Falls back to checking `TERM` for "xterm-kitty".
+ */
+export function isKittySupported(): boolean {
+	const termProgram = process.env['TERM_PROGRAM']?.toLowerCase() ?? '';
+	if (KITTY_TERMINALS.has(termProgram)) return true;
+
+	const term = process.env['TERM']?.toLowerCase() ?? '';
+	if (term === 'xterm-kitty') return true;
+
+	return false;
+}
+
+// ─── Terminal Setup / Cleanup ────────────────────────────────────
+
+let shuttingDown = false;
+
+/**
+ * Set up the terminal for rendering.
+ *
+ * Enters the alternate screen buffer, hides the cursor, and
+ * enables raw mode for keyboard input.
+ */
+export function setupTerminal(): void {
+	shuttingDown = false;
+	process.stdout.write('\x1b[?1049h'); // alt screen
+	process.stdout.write('\x1b[?25l');   // hide cursor
+}
+
+/**
+ * Clean up the terminal, restoring it to its previous state.
+ *
+ * Deletes any Kitty image, shows the cursor, and exits the
+ * alternate screen buffer. Guarded against double-cleanup.
+ *
+ * @param kittyRenderer - Optional Kitty renderer to clean up images
+ */
+export function cleanupTerminal(kittyRenderer?: KittyRenderer): void {
+	if (shuttingDown) return;
+	shuttingDown = true;
+
+	// Delete Kitty image if renderer exists
+	if (kittyRenderer) {
+		kittyRenderer.cleanup();
+	}
+
+	process.stdout.write('\x1b[?25h');   // show cursor
+	process.stdout.write('\x1b[?1049l'); // exit alt screen
+}

--- a/doom/render/titleScreen.ts
+++ b/doom/render/titleScreen.ts
@@ -8,7 +8,7 @@
  * @module render/titleScreen
  */
 
-import { three } from 'blecsd';
+import { type three } from 'blecsd';
 import type { WadFile, Palette } from '../wad/types.js';
 import { findLump, getLumpData } from '../wad/wad.js';
 import { parsePicture, renderPictureToFlat } from '../wad/pictureFormat.js';
@@ -116,6 +116,8 @@ function drawFontChar(
 ): void {
 	const pattern = FONT[ch];
 	if (!pattern) return;
+	const buf = fb.colorBuffer;
+	const w = fb.width;
 
 	for (let row = 0; row < CHAR_HEIGHT; row++) {
 		const line = pattern[row];
@@ -124,8 +126,12 @@ function drawFontChar(
 			if (line[col] === '#') {
 				const px = x + col;
 				const py = y + row;
-				if (px >= 0 && px < fb.width && py >= 0 && py < fb.height) {
-					three.setPixelUnsafe(fb, px, py, r, g, b, 255);
+				if (px >= 0 && px < w && py >= 0 && py < fb.height) {
+					const offset = (py * w + px) << 2;
+					buf[offset] = r;
+					buf[offset + 1] = g;
+					buf[offset + 2] = b;
+					buf[offset + 3] = 255;
 				}
 			}
 		}
@@ -182,23 +188,29 @@ function fillRect(
 	b: number,
 	a: number,
 ): void {
+	const buf = fb.colorBuffer;
+	const fbw = fb.width;
+
 	for (let py = y; py < y + h && py < fb.height; py++) {
 		if (py < 0) continue;
-		for (let px = x; px < x + w && px < fb.width; px++) {
+		for (let px = x; px < x + w && px < fbw; px++) {
 			if (px < 0) continue;
+			const offset = (py * fbw + px) << 2;
 			if (a >= 255) {
-				three.setPixelUnsafe(fb, px, py, r, g, b, 255);
+				buf[offset] = r;
+				buf[offset + 1] = g;
+				buf[offset + 2] = b;
+				buf[offset + 3] = 255;
 			} else {
 				// Alpha blend
-				const idx = (py * fb.width + px) * 4;
-				const sr = fb.colorBuffer[idx] ?? 0;
-				const sg = fb.colorBuffer[idx + 1] ?? 0;
-				const sb = fb.colorBuffer[idx + 2] ?? 0;
+				const sr = buf[offset] ?? 0;
+				const sg = buf[offset + 1] ?? 0;
+				const sb = buf[offset + 2] ?? 0;
 				const alpha = a / 255;
-				const outR = Math.round(sr * (1 - alpha) + r * alpha);
-				const outG = Math.round(sg * (1 - alpha) + g * alpha);
-				const outB = Math.round(sb * (1 - alpha) + b * alpha);
-				three.setPixelUnsafe(fb, px, py, outR, outG, outB, 255);
+				buf[offset] = Math.round(sr * (1 - alpha) + r * alpha);
+				buf[offset + 1] = Math.round(sg * (1 - alpha) + g * alpha);
+				buf[offset + 2] = Math.round(sb * (1 - alpha) + b * alpha);
+				buf[offset + 3] = 255;
 			}
 		}
 	}
@@ -216,23 +228,36 @@ export function drawTitlePic(
 	fb: three.PixelFramebuffer,
 	palette: Palette,
 ): void {
+	const buf = fb.colorBuffer;
+	const w = fb.width;
+
 	if (!titlePicPixels) {
 		// No TITLEPIC, fill with dark red
 		for (let y = 0; y < fb.height; y++) {
-			for (let x = 0; x < fb.width; x++) {
-				three.setPixelUnsafe(fb, x, y, 80, 0, 0, 255);
+			let off = (y * w) << 2;
+			for (let x = 0; x < w; x++) {
+				buf[off] = 80;
+				buf[off + 1] = 0;
+				buf[off + 2] = 0;
+				buf[off + 3] = 255;
+				off += 4;
 			}
 		}
 		return;
 	}
 
 	for (let y = 0; y < fb.height && y < titlePicHeight; y++) {
-		for (let x = 0; x < fb.width && x < titlePicWidth; x++) {
+		let off = (y * w) << 2;
+		for (let x = 0; x < w && x < titlePicWidth; x++) {
 			const palIdx = titlePicPixels[y * titlePicWidth + x] ?? 0;
 			const color = palette[palIdx];
 			if (color) {
-				three.setPixelUnsafe(fb, x, y, color.r, color.g, color.b, 255);
+				buf[off] = color.r;
+				buf[off + 1] = color.g;
+				buf[off + 2] = color.b;
+				buf[off + 3] = 255;
 			}
+			off += 4;
 		}
 	}
 }

--- a/dvd-bounce/package-lock.json
+++ b/dvd-bounce/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "dvd-bounce-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"bin": {
 				"dvd-bounce": "dist/index.js"
@@ -895,9 +895,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/dvd-bounce/package.json
+++ b/dvd-bounce/package.json
@@ -13,7 +13,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/dvd-bounce/pnpm-lock.yaml
+++ b/dvd-bounce/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/file-manager/package-lock.json
+++ b/file-manager/package-lock.json
@@ -8,7 +8,7 @@
       "name": "file-manager-example",
       "version": "0.0.1",
       "dependencies": {
-        "blecsd": "^0.1.1"
+        "blecsd": "^0.2.0"
       },
       "devDependencies": {
         "@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
       "license": "MPL-2.0"
     },
     "node_modules/blecsd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-      "integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+      "integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
       "license": "MIT",
       "dependencies": {
         "bitecs": "^0.4.0",

--- a/file-manager/package.json
+++ b/file-manager/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "blecsd": "^0.1.1"
+    "blecsd": "file:../../blECSd"
   },
   "devDependencies": {
     "@types/node": "^25.2.1",

--- a/file-manager/pnpm-lock.yaml
+++ b/file-manager/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/kingdom/.agent1-phase10.txt
+++ b/kingdom/.agent1-phase10.txt
@@ -1,0 +1,151 @@
+Phase 10: Full integration pass - game loop wiring, rendering all new systems, screen flow.
+
+Read types.ts, index.ts, renderer.ts, hud.ts, effects.ts first. Then check what functions exist in
+structures/townCenter.ts, structures/bomb.ts, structures/lighthouse.ts, structures/forge.ts,
+structures/catapult.ts, systems/gems.ts, systems/decay.ts, entities/hermit.ts, entities/statue.ts,
+entities/dog.ts, entities/banker.ts, entities/merchant.ts, entities/pikeman.ts.
+
+You own: renderer.ts, hud.ts, index.ts, types.ts, effects.ts, sound.ts, world/terrain.ts, world/map.ts, world/camera.ts
+
+This phase is about INTEGRATION: making sure index.ts calls all systems, renderer.ts renders everything,
+and the game flows correctly from title screen through gameplay to victory.
+
+TASK 1: GAME LOOP COMPLETENESS IN index.ts
+Verify the main game loop calls ALL systems in the correct order. The full update order should be:
+1. pollInput()
+2. Check pause (consumePause)
+3. updateDayNight(state, dt) - day/night cycle
+4. Compute season: state.season = Math.floor((state.dayCount % 64) / 16)
+5. Set weather based on season (deterministic from dayCount)
+6. Dawn triggers: if just became Day:
+   - applyDawnBonus(state) from economy.ts
+   - applyBankerInterest(state) from banker.ts
+   - Seasonal transitions (spawnWinterBerries / clearWinterBerries)
+   - Blood moon check
+7. updateTownCenter(state, dt) from townCenter.ts
+8. updateMount(state, dt) from mount.ts
+9. updateMonarch(state, dt) from monarch.ts
+10. updateAI(state, dt) from ai.ts - this dispatches all entity updates
+11. updateMovement(state, dt)
+12. updateSpawning(state, dt) from spawn.ts
+13. updateCombat(state, dt) from combat.ts
+14. updateCatapults(state, dt) from catapult.ts
+15. updateBomb(state, dt) from bomb.ts
+16. updateConstruction(state, dt)
+17. updateShrineBuff(state, dt) from shrine.ts
+18. updateStatueBlessings(state, dt) from statue.ts
+19. updatePortalAssault(state, dt) from portal.ts
+20. updateCamera(state)
+21. render(state)
+
+Check each of these is actually imported and called. If any are missing, add them.
+Import anything that's not yet imported.
+
+TASK 2: INITIAL STATE COMPLETENESS IN index.ts
+When creating a new game state (createNewGameState or similar), make sure ALL fields are initialized:
+- season, seasonDay, weather, isBloodMoon
+- townCenterTier, townCenterCooldown
+- gems, gemCapacity
+- hasDog, dogCaptured
+- crownDropped, crownX, crownTimer
+- isPaused, showMinimap
+- islandIndex, islandUnlocked, islandStats
+- mountType, mountsUnlocked
+- All structure arrays (bombs, lighthouses, forges, catapults, etc.)
+- All state flags (portalAssaultActive, boatState, etc.)
+
+Scan types.ts GameState for every field and ensure none are missing from initialization.
+
+TASK 3: RENDER ALL NEW STRUCTURES IN renderer.ts
+Verify renderer draws everything:
+- Town center (per tier visual) - should exist from Phase 6
+- All 5 wall tiers (spikes through iron)
+- All 6 tower tiers (rock platform through quadruplet)
+- Special tower conversions (ballista, fire, bakery, knight, berserker)
+- Catapult (with loaded/unloaded visual)
+- Bomb (with builder pushers)
+- Lighthouse (3 tiers)
+- Forge (with sword ready indicator)
+- Farms (with tier visual and crop stage)
+- Boat (wreck/restoring/ready/launched states)
+- Hermit cottages
+- Statues (active/inactive visual)
+- Teleporters (converted portals)
+- Berry bushes (winter)
+- Gold veins (with depletion)
+- Dog ('d' with bark '!')
+- Merchant camp
+- Banker at town center
+- Dropped tools (bow/hammer/scythe/pike/shield/sword)
+- Bread loaves
+- All mount types on monarch
+
+If any are missing renderers, add a basic rendering section for them.
+
+TASK 4: RENDER ALL GREED TYPES DISTINCTLY
+Each greed type should look different:
+- Greedling: 'g' in purple (0x8833aaff)
+- Masked Greedling: 'G' in darker purple (0x663388ff), show mask break visual
+- Floater: 'f' in purple, rendered 1 row higher than ground (float effect)
+  - When carrying a unit: show unit char above floater
+- Breeder: 'B' in dark red (0xaa2222ff), larger visual (2 chars wide)
+  - Show spawn animation when creating greedlings
+- Crown Stealer: 'c' in bright purple (0xcc44ffff)
+  - When carrying crown: show 'W' above
+- Plague Crawler (challenge island): 'p' in green (0x44aa33ff)
+
+TASK 5: HUD COMPLETENESS IN hud.ts
+Verify HUD shows all relevant info:
+- Primary bar: Coins | Day N | Time icon | Season + day | Weather icon | Island N
+- Secondary bar: Unit counts (A:N B:N F:N K:N P:N) | Tower count | Gem count
+- When near entities, show interaction prompts:
+  - Town center: upgrade cost
+  - Shrine: activation cost and type
+  - Statue: unlock/activate cost
+  - Hermit cottage: coax cost
+  - Merchant: "Pay 1 coin"
+  - Banker: "Deposit/Withdraw"
+  - Forge: sword cost
+  - Boat: restoration/launch/depart cost
+  - Stable: mount switch cost
+  - Teleporter: "Teleport (2 coins)"
+- Blood moon pulsing warning
+- Crown dropped flashing alert
+- Dog bark direction indicator
+- Bomb escape timer countdown
+
+TASK 6: SCREEN FLOW IN index.ts
+Verify proper flow between game phases:
+- Title -> New Game -> Playing (island 1)
+- Title -> Continue -> Playing (loaded state)
+- Playing -> Island Select (when boarding boat)
+- Island Select -> Playing (selected island)
+- Playing -> Game Over (crown lost)
+- Game Over -> Heir Succession -> Playing (same island, decayed)
+- Game Over -> Title (if decline succession or press Q)
+- Playing -> Victory (all portals on island 5 destroyed)
+- Victory -> Title (or continue playing)
+- Playing -> Pause -> Playing (P key toggle)
+
+TASK 7: SEASONAL VISUAL COMPLETENESS IN renderer.ts
+Verify all seasonal effects render:
+- Spring: green terrain, occasional rain overlay, normal sky
+- Summer: bright terrain, no rain, warm sky
+- Autumn: yellow/red terrain (grass 0xbb9944ff, forest 0xcc5533ff)
+- Winter: white/gray terrain (0xccccddff), snow overlay, frozen water (=)
+- Northern lights during winter clear nights
+- Blood moon: red sky, red moon, red ground tint
+
+TASK 8: SOUND COMPLETENESS IN sound.ts
+Verify all sound triggers are wired:
+- Dawn bell (at sunrise)
+- Dusk bell (at sunset)
+- Blood moon warning (40 seconds before midnight)
+- Crown drop alert (continuous while crown on ground)
+- Wall breach (when wall HP reaches 0)
+- Build completion
+- Recruitment
+- Portal destruction
+Wire any that are missing into the appropriate system call sites.
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent1-phase2.txt
+++ b/kingdom/.agent1-phase2.txt
@@ -1,0 +1,16 @@
+Phase 2: Polish the rendering and add a title screen. The game runs but needs visual improvements. Read the current files first (render/renderer.ts, render/hud.ts, render/effects.ts, index.ts, game/input.ts).
+
+Tasks:
+1. Title screen in render/renderer.ts or a new render/titleScreen.ts: Show ASCII art "KINGDOM" title, "Press ENTER to start", flicker effect. Game starts in GamePhase.Title, transitions to Playing on Enter. Update game/input.ts to handle title screen input.
+
+2. Game Over screen: When phase is GameOver, show "THE GREED TOOK YOUR CROWN" in red, show stats (days survived, coins collected), "Press R to restart". Handle restart in input.ts.
+
+3. Improve the HUD in render/hud.ts: Add a message log at the bottom (show last 3 messages from state.messages). Show unit counts (builders, archers, farmers). Show a health bar for outermost walls. Add blood moon warning.
+
+4. Improve render/effects.ts: Make night transition smoother with gradient darkening. Add a "wave incoming" flash at night start. Add coin pickup sparkle effect when coins are collected.
+
+5. Add parallax scrolling to renderer.ts: Background stars/clouds at 0.5x scroll speed behind the sky layer. Foreground grass details at 1.2x. Makes the side-scrolling feel more alive.
+
+6. Fix game/input.ts: The input currently resets flags each frame in index.ts which is wrong since input comes async. Instead, track key-down/key-up states properly. Left/right should be held states, space should be a one-shot trigger.
+
+Write all changes now. Make sure everything typechecks.

--- a/kingdom/.agent1-phase3.txt
+++ b/kingdom/.agent1-phase3.txt
@@ -1,0 +1,16 @@
+Phase 3: Sound cues, persistence, and game feel. Read the current index.ts, render/renderer.ts, render/effects.ts, render/hud.ts, game/input.ts, types.ts first.
+
+Tasks:
+1. Add terminal bell/sound cues in a new file render/sound.ts: Export playBell() using process.stdout.write('\x07'). Export playAlert() using rapid double-bell. Call playBell on coin collect, playAlert when night starts, when walls are breached. Wire these into index.ts.
+
+2. Add save/load persistence in a new file game/persistence.ts: Save state to ~/.kingdom-save.json on clean exit and every 30 seconds. Load on startup if save exists. Save: islandIndex, dayCount, monarchCoins, structure positions/types/hp, unit roles/positions, portal positions. Export saveGame(state), loadGame(): Partial<GameState> | null.
+
+3. Improve game feel in index.ts: Add a brief pause (500ms) on game over before accepting restart. Add screen shake effect (random camera offset for 200ms) when walls are destroyed. Add a "dawn bonus" - collect 2 coins automatically each morning.
+
+4. Add mount system in a new file entities/mount.ts: Monarch starts with a horse. Mount affects speed (horse: 1.5x normal, 2x sprint). Sprint consumes stamina (100 max, depletes at 20/sec, recharges at 10/sec when not sprinting). Horse recharges stamina faster when near grass. Export MountType enum, createMount, updateMount, getMountSpeed, getStamina. Update types.ts to add mount-related fields to GameState if needed.
+
+5. Improve render/renderer.ts: Add animated water (alternate between wave chars every 0.5s). Add tree sway (alternate tree chars slightly). Add cloud layer that drifts slowly across the sky. These small animations make the world feel alive.
+
+6. Update render/hud.ts: Add a stamina bar below coins. Show mount name. Show wave countdown at night (estimated greed remaining). Flash the HUD red during blood moons.
+
+Write all changes now. Make sure everything typechecks.

--- a/kingdom/.agent1-phase4-continue.txt
+++ b/kingdom/.agent1-phase4-continue.txt
@@ -1,0 +1,30 @@
+Phase 4 continuation: You already completed types.ts, world/terrain.ts, world/map.ts, and world/camera.ts in a previous session. Now finish the remaining 2 files.
+
+Read types.ts, render/renderer.ts, index.ts first to understand what changed.
+
+REMAINING CHANGES:
+
+1. Update render/renderer.ts to render the new biomes with distinct colors:
+   - Swamp: darker green ground (0x116622ff), blue-green water (0x227766ff)
+   - Mountains: gray/brown elevated terrain (0x887766ff ground, 0x666655ff rock)
+   - Ruins: dark gray structures (0x444444ff), broken walls using box-drawing chars (┌┐└┘│─)
+   - Settlement campfires should glow (alternate between 0xff6600ff and 0xff8800ff based on totalElapsed)
+   - Consumable spots should sparkle/pulse to attract player attention:
+     - FoodCache: yellow pulsing CHAR_COIN
+     - RestShrine: cyan pulsing star
+     - PowerWell: magenta pulsing diamond
+   - Use the ConsumableType enum from types.ts and the consumableSpots/consumedSpots Maps on GameState
+   - Already-consumed spots should NOT be rendered
+
+2. Update index.ts:
+   - Initialize new GameState fields: consumedSpots: new Set(), consumableSpots: new Map() (populated by generateMap), speedBoostTimer: 0
+   - In the game loop (Playing phase), check if monarch walks over a consumable spot:
+     - Get monarch position, check if consumableSpots.has(Math.round(monarchX))
+     - If not already consumed: activate effect, add to consumedSpots
+     - FoodCache: monarchCoins += 3, message "Found food cache! (+3 coins)"
+     - RestShrine: stamina = maxStamina, message "Rested at shrine! (stamina restored)"
+     - PowerWell: speedBoostTimer = 15, message "Power well activated! (speed boost 15s)"
+   - Decrement speedBoostTimer by dt each frame, apply speed multiplier (1.5x) to monarch when > 0
+   - The consumableSpots Map should be populated during generateMap() - check if map.ts already exports it or if you need to wire it
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent1-phase4.txt
+++ b/kingdom/.agent1-phase4.txt
@@ -1,0 +1,34 @@
+Phase 4: Massive world with multiple settlements and consumable spots.
+
+Read types.ts, world/map.ts, world/terrain.ts, world/camera.ts, render/renderer.ts, index.ts first.
+
+CRITICAL CHANGES:
+
+1. Expand MAP_WIDTH to 1200 in types.ts. The world should feel massive. Update CAMP_CENTER_X to 600.
+
+2. Rewrite world/terrain.ts and world/map.ts to generate a huge varied world:
+   - Multiple biomes: dense forest, plains, swamp (water+dirt), mountains (double-height dirt), ruins
+   - 5 distinct settlement zones spread across the map at roughly x=150, 400, 600, 800, 1050
+   - Each settlement has: a campfire, tool stands, a few initial vagrants
+   - The player starts at the center settlement (x=600)
+   - Forests between settlements with portals at the edges
+   - Add terrain variety: some hills (ground level varies by +/-1), occasional ponds
+
+3. Add consumable spots to the map generation. These are special tiles the monarch walks over to activate:
+   - Food caches (restore 3 coins) - scattered in ruins, one-time use. Use CHAR_COIN with a different color.
+   - Rest shrines (restore stamina to full) - near settlements
+   - Power wells (temporary speed boost for 15 seconds) - deep in forests
+   - Track consumed spots in a Set<number> keyed by x position in GameState. Add a consumedSpots field to GameState in types.ts.
+
+4. Update render/renderer.ts to render the new biomes with distinct colors:
+   - Swamp: darker green ground, blue-green water
+   - Mountains: gray/brown elevated terrain
+   - Ruins: dark gray structures, broken walls (use box-drawing chars)
+   - Settlement campfires should glow (alternate between orange shades)
+   - Consumable spots should sparkle/pulse to attract player attention
+
+5. Update world/camera.ts: Smooth camera with slight look-ahead in the direction the monarch is moving (offset camera 5 tiles in move direction for better visibility).
+
+6. Update index.ts: Initialize the new GameState fields (consumedSpots: new Set()). When monarch walks over a consumable spot, activate its effect and add to consumedSpots. Add a message for each consumption.
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent1-phase5.txt
+++ b/kingdom/.agent1-phase5.txt
@@ -1,0 +1,76 @@
+Phase 5: Rendering fixes - make the game VISIBLE.
+
+Read renderer.ts, hud.ts, types.ts, index.ts first.
+
+The game has critical rendering bugs: animals, dropped coins, blueprints, and NPC subtypes are all INVISIBLE.
+Also the movement system double-applies velocity (index.ts calls updateMovement which applies velocity, but entity updates ALSO apply position directly).
+
+CRITICAL FIXES:
+
+1. renderer.ts - Add missing render sections AFTER section 10 (projectiles) and BEFORE section 11 (night overlay):
+
+   Section 7.5: Render ANIMALS. Import getAnimals from '../entities/animals'.
+   For each animal in getAnimals():
+     - If not isOnScreen, skip
+     - Rabbits: char 'r', fg 0xccaa88ff (tan)
+     - Deer: char 'D', fg 0x886644ff (brown)
+     - Draw at (worldToScreen(animal.x), Math.floor(animal.y))
+     - Animals should be visible ON the ground level
+
+   Section 9.5: Render DROPPED COINS. Import getDroppedCoins from '../systems/combat'.
+   For each coin in getDroppedCoins():
+     - If not isOnScreen, skip
+     - Char: CHAR_COIN, fg: COLOR_COIN with pulse (use sin(totalElapsed * 4) for brightness variation)
+     - Draw at ground level
+
+   Section 5.5: Render CONSTRUCTION BLUEPRINTS. Import getBlueprints from '../systems/construction'.
+   For each blueprint x in getBlueprints():
+     - If not isOnScreen, skip
+     - Char: CHAR_WALL but with a dim/transparent look
+     - Fg: 0x664433aa (dim brown), blinking slowly (alternate with 0x332211ff based on totalElapsed)
+     - Draw at GROUND_Y
+     - ALSO render walls with hp === 0 from state.structures as "under construction" (different from damaged):
+       - In structureChar: if s.hp === 0 && s.maxHp > 0, return a construction char like '.' or dashes
+       - Give them a distinct "building in progress" color (pulsing between dim and bright)
+
+2. renderer.ts - Render NPC subtypes distinctly.
+   Import getNpcOrigin, NpcOrigin from '../entities/villager'.
+   In section 7 (units), for vagrants check getNpcOrigin(unit.eid):
+     - Standard: CHAR_VILLAGER, COLOR_VILLAGER (unchanged)
+     - Warrior: char '\u2694' (crossed swords), fg 0xff4444ff (red)
+     - Scout: char '\u2192' (arrow), fg 0x44ff44ff (green)
+     - Craftsman: char '\u2692' (hammer/pick), fg 0x4488ffff (blue)
+     - Peasant: char '\u2698' (flower), fg 0xffdd44ff (yellow)
+
+3. hud.ts - Display nearby interactable prompt.
+   Import getNearbyInteractable from '../game/economy'.
+   In renderHud, on the secondary bar (row 1), after the stamina bar:
+     - Call getNearbyInteractable()
+     - If it returns a non-null string, display it right-aligned on row 1
+     - Use bright white fg on dark bg so it stands out
+     - This tells the player what pressing Space will do
+
+4. index.ts - FIX DOUBLE MOVEMENT.
+   The game loop calls updateAI (which calls updateMonarch, updateBuilder, etc. - all of which apply position directly)
+   THEN calls updateMovement (which ALSO applies velocity to position).
+
+   The fix: Remove the monarch position update from movement.ts. Let entity-specific code handle its own movement.
+   BUT WAIT - you own index.ts and renderer.ts, not movement.ts (that's Agent 3).
+
+   Instead: In index.ts, REMOVE the updateMovement call entirely. Each entity already handles its own movement.
+   The updateMovement function in movement.ts also handles projectile bounds and unit overlap resolution.
+   So instead of removing updateMovement entirely, the Agent 3 fix should remove the position-from-velocity code.
+
+   YOUR FIX in index.ts: Add a comment noting the double-movement issue but DON'T remove updateMovement yet
+   (Agent 3 will fix movement.ts to not double-apply). Instead, ensure the speed boost in index.ts doesn't
+   compound the double movement. Currently index.ts scales velocity by 1.5 BEFORE updateMovement applies it again.
+   REMOVE the speed boost velocity scaling from index.ts (lines 259-264). The speed boost should be handled
+   in monarch.ts's getMountSpeed or updateMonarch instead. Just pass state.speedBoostTimer > 0 info via state.
+
+5. renderer.ts - Render wall HP bars.
+   For structures that are walls (WallWood/Stone/Iron), show a tiny HP indicator:
+   - If wall hp < maxHp, draw a colored pip one row ABOVE the wall at GROUND_Y - 1
+   - Green pip if hp > 66%, yellow if > 33%, red if <= 33%
+   - This makes wall damage visible at a glance
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent1-phase6.txt
+++ b/kingdom/.agent1-phase6.txt
@@ -1,0 +1,78 @@
+Phase 6: Title screen, seasonal visuals, blood moon visuals, town center rendering.
+
+Read KINGDOM_TODO.md, .research-agent1-rendering.md, renderer.ts, hud.ts, index.ts, types.ts first.
+
+You own: renderer.ts, hud.ts, index.ts, types.ts, effects.ts, sound.ts, world/terrain.ts, world/map.ts, world/camera.ts
+
+TASK 1: ADD SEASON ENUM AND STATE TO types.ts
+- Add Season enum: Spring = 0, Summer = 1, Autumn = 2, Winter = 3
+- Add to GameState: season: Season, seasonDay: number (0-15, days within current season)
+- Seasons cycle every 16 days. Full cycle = 64 days.
+- Season is derived from global dayCount: season = Math.floor((dayCount % 64) / 16)
+- seasonDay = dayCount % 16
+
+TASK 2: ADD TOWN CENTER TIER TO types.ts
+- Add TownCenterTier enum: Ruins=0, Campfire=1, Camp=2, Village=3, TownHall=4, StoneFort=5, Castle=6, IronKeep=7
+- Add to GameState: townCenterTier: TownCenterTier (starts at Campfire=1)
+- Add TOWN_CENTER_COSTS: [0, 1, 4, 8, 12, 15, 18, 20] (coins per tier upgrade)
+- Add TOWN_CENTER_NAMES: ['Ruins', 'Campfire', 'Camp', 'Village', 'Town Hall', 'Stone Fort', 'Castle', 'Iron Keep']
+
+TASK 3: SEASONAL SKY COLORS IN renderer.ts
+Currently the sky uses fixed colors. Make them season-dependent:
+- Spring: Dawn=0x446688ff, Day=0x5599ccff, Dusk=0x884466ff, Night=0x112233ff
+- Summer: Dawn=0x558899ff, Day=0x66aaddff, Dusk=0x995544ff, Night=0x0a1a2aff (brighter days, warmer dusk)
+- Autumn: Dawn=0x665544ff, Day=0x889988ff, Dusk=0x774433ff, Night=0x111122ff (muted, amber tones)
+- Winter: Dawn=0x889999ff, Day=0x99aabbff, Dusk=0x667788ff, Night=0x0a0a1aff (cold, pale blue)
+
+Create a getSkyColor(phase: TimeOfDay, season: Season) function.
+
+For terrain colors:
+- Spring/Summer: green grass (current)
+- Autumn: yellowed grass (0xbb9944ff fg), red-tinted forest (0xcc5533ff)
+- Winter: white/gray grass (0xccccddff), snow on ground (0xddddffff bg for grass tiles)
+
+TASK 4: BLOOD MOON VISUALS IN renderer.ts
+When state.isBloodMoon is true (add to GameState if not there):
+- Sky: override all phases with deep red tints (0x331111ff bg, 0x882222ff for stars area)
+- Moon/stars: render a large red moon character at top of screen
+- Ground: subtle red-orange ambient glow on terrain
+- HUD: show "BLOOD MOON" warning text in bright red, pulsing
+
+TASK 5: TOWN CENTER RENDERING IN renderer.ts
+Render the town center at CAMP_CENTER_X based on townCenterTier:
+- Ruins (0): '.' dim gray
+- Campfire (1): '*' flickering orange/red (already exists, keep it)
+- Camp (2): Two chars wide: '#*' (tent + fire)
+- Village (3): Three chars: '|#|' wood structure
+- Town Hall (4): Four chars: '|##|' with stone color
+- Stone Fort (5): Five chars: '[###]' stone gray
+- Castle (6): Six chars: '|[###]|' with banner char on top
+- Iron Keep (7): Seven chars: '{[###]}' iron-colored
+Use distinct fg colors per tier. Show upgrade cost in HUD when monarch is nearby.
+
+TASK 6: UPDATE HUD FOR SEASON AND TOWN CENTER
+In hud.ts:
+- Show current season name and day-within-season: "Spring D3" or "Winter D12"
+- Show town center tier name when monarch is near center (within 10 tiles)
+- Show upgrade cost: "Upgrade to [NextTier]: [Cost] coins" prompt
+- Show gem count if gems are added to GameState (placeholder for now: state.gems ?? 0)
+
+TASK 7: TITLE SCREEN IN index.ts
+Before the game loop starts, show a title screen:
+- "KINGDOM" in large ASCII art (use simple block letters)
+- "A Terminal Strategy Game"
+- "[N] New Game  [C] Continue  [Q] Quit"
+- If save exists, show "Continue" option
+- Render to the cell buffer, wait for keypress
+- On 'n': start new game. On 'c': load save. On 'q': exit.
+
+TASK 8: GAME OVER AND VICTORY SCREENS
+- GameOver screen: "YOUR CROWN HAS BEEN LOST" centered, red text, "Press R to restart"
+- Victory screen: "THE KINGDOM IS SECURED" centered, gold text, show stats (days survived, greed defeated, islands cleared)
+
+TASK 9: UPDATE index.ts GAME LOOP FOR SEASONS
+- After updateDayNight, compute season from dayCount: state.season = Math.floor((state.dayCount % 64) / 16)
+- state.seasonDay = state.dayCount % 16
+- Pass season info to renderer
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent1-phase7.txt
+++ b/kingdom/.agent1-phase7.txt
@@ -1,0 +1,99 @@
+Phase 7: Tower tiers, weather effects, crown visual, input improvements, island select screen.
+
+Read KINGDOM_TODO.md, types.ts, renderer.ts, hud.ts, index.ts, effects.ts first.
+
+You own: renderer.ts, hud.ts, index.ts, types.ts, effects.ts, sound.ts, world/terrain.ts, world/map.ts, world/camera.ts
+
+TASK 1: TOWER TIER SYSTEM IN types.ts AND renderer.ts
+Currently towers are a single type. Expand to 6 tiers.
+In types.ts:
+- Add TowerTier enum: RockPlatform=1, WoodWatchtower=2, StoneTower=3, TripletTower=4, RoofedTriplet=5, QuadrupletTower=6
+- Add TOWER_COSTS: [0, 3, 5, 7, 9, 12, 15]
+- Add TOWER_ARCHER_CAPACITY: [0, 1, 1, 2, 3, 3, 4] (archers per tower tier)
+- Add TOWER_NAMES: ['None', 'Rock Platform', 'Watchtower', 'Stone Tower', 'Triplet', 'Roofed Triplet', 'Quadruplet']
+- Add towerTier field to StructureData (default 1)
+- Add isRoofed flag to StructureData (true for tier 5+, protects from floaters)
+
+In renderer.ts, update tower rendering:
+- Tier 1 (Rock Platform): '=' single char, brown
+- Tier 2 (Watchtower): 'T' wood color (0x886633ff)
+- Tier 3 (Stone Tower): 'T' stone gray (0x999999ff), taller visual (2 chars high if possible)
+- Tier 4 (Triplet): 'TTT' stone, 3 chars wide
+- Tier 5 (Roofed Triplet): '^T^' with roof char, gray
+- Tier 6 (Quadruplet): '^TT^' 4 chars with roof
+- Show archer count on tower: small number on top
+
+TASK 2: WEATHER EFFECTS IN effects.ts
+Add weather visual overlays:
+- Create WeatherType enum in types.ts: Clear=0, Rain=1, Snow=2, Storm=3
+- Add weather: WeatherType to GameState (default Clear)
+- Rain effect: random '|' or '/' chars falling from top of screen
+  - Render ~20 raindrops per frame at random x positions
+  - Raindrop positions scroll down each frame (use time-based offset)
+  - Color: 0x4488bbff (blue-gray)
+  - Only during spring/autumn occasionally
+- Snow effect: random '*' or '.' chars drifting down slowly
+  - ~15 snowflakes per frame, drift sideways slightly (sinusoidal x offset)
+  - Color: 0xddddffff (pale white-blue)
+  - Only during winter
+- Storm effect: same as rain but denser (40 drops), with occasional flash
+  - Flash: set all sky bg to 0xffffffaa for 2 frames, then back
+  - Only during blood moon or specific events
+- Export: renderWeather(buffer, width, height, weather, time)
+- Call from main render function after sky but before entities
+
+TASK 3: WEATHER STATE LOGIC IN index.ts
+- In game loop, set weather based on season:
+  - Spring: 30% chance of Rain each day (set at dawn)
+  - Summer: always Clear
+  - Autumn: 20% chance of Rain
+  - Winter: 80% chance of Snow, 20% Clear
+  - Blood Moon: always Storm
+- Use a simple deterministic check: (dayCount * 7 + seasonDay * 13) % 100 < threshold
+- Reset weather at dawn each day
+
+TASK 4: CROWN VISUAL IN renderer.ts
+When monarch's crown is knocked off (future mechanic, prepare the visual):
+- Add crownDropped: boolean, crownX: number, crownY: number to GameState
+- Render dropped crown as 'W' in gold (0xffcc00ff) bouncing on ground
+  - Bounce animation: use sin(time * 8) for small y offset (1-2 chars)
+  - Sparkle effect: alternate between 'W' and '*' every 500ms
+- When crown is on monarch's head: render '^' or 'W' above monarch char
+- Currently monarch is rendered as '@'. Add crown above: render 'W' at monarch position, y-1
+
+TASK 5: INPUT IMPROVEMENTS IN game/input.ts
+Add new key bindings:
+- 'e' or Enter: Interact key (recruit NPC, activate shrine, board boat)
+  - Export: consumeInteract(): boolean
+- 'p': Toggle pause
+  - Add isPaused: boolean to GameState
+  - Export: consumePause(): boolean
+- 'Tab': Toggle minimap (future, just add the binding)
+  - Export: consumeTab(): boolean
+- 'q': Open quit menu (future, just add the binding)
+  - Export: consumeQuit(): boolean
+- Number keys '1'-'9': Quick action slots (future)
+  - Export: consumeNumberKey(): number | null
+
+TASK 6: PAUSE SCREEN IN renderer.ts
+When state.isPaused is true:
+- Dim the entire screen (darken all bg colors by 50%)
+- Show centered "PAUSED" text in white
+- Show "Press P to resume" below
+- Show "Press Q to quit" below that
+- Game loop in index.ts should skip all updates when paused (only poll input for P/Q)
+
+TASK 7: HUD IMPROVEMENTS
+- Show weather icon in HUD: Clear=' ', Rain='~', Snow='*', Storm='!'
+- Show tower count and highest tier
+- Show "Crown!" warning when crownDropped is true (flashing red)
+- Improve the blood moon HUD: add pulsing effect (alternate bright/dim red)
+- Show current island number: "Island 1" etc.
+
+TASK 8: UPDATE RENDERER FOR TOWER TIERS
+- In the structure rendering section, check towerTier field
+- Render different tower visuals per tier
+- Show occupied archer count vs capacity: e.g., "2/3" above tower
+- Roofed towers (tier 5+): render with roof char '^' above, use slightly different color
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent1-phase8.txt
+++ b/kingdom/.agent1-phase8.txt
@@ -1,0 +1,118 @@
+Phase 8: Island select screen, mount rendering, hermit cottage visuals, statue rendering, minimap.
+
+Read KINGDOM_TODO.md, types.ts, renderer.ts, hud.ts, index.ts, effects.ts, world/map.ts first.
+
+You own: renderer.ts, hud.ts, index.ts, types.ts, effects.ts, sound.ts, world/terrain.ts, world/map.ts, world/camera.ts
+
+TASK 1: ISLAND SELECT SCREEN IN index.ts
+After title screen, if player presses 'c' or starts new game after island 1:
+- Show island select screen with available islands
+- 5 islands in a horizontal row
+- Each island shown as:
+  Island 1: "Tutorial Isle" [CLEARED/ACTIVE/LOCKED]
+  Island 2: "Stone Coast"   [CLEARED/ACTIVE/LOCKED]
+  Island 3: "Forge Bay"     [CLEARED/ACTIVE/LOCKED]
+  Island 4: "Iron Reach"    [CLEARED/ACTIVE/LOCKED]
+  Island 5: "Crown's End"   [CLEARED/ACTIVE/LOCKED]
+- Arrow keys to highlight, Enter to select
+- Only unlocked islands selectable (unlock next after building boat)
+- Show island stats: days survived, portals destroyed, structures built
+- Add islandSelectPhase to GamePhase enum if not already there
+- Add islandUnlocked: boolean[5] to GameState (default [true, false, false, false, false])
+- Add islandStats: { portalsDestroyed: number, daysVisited: number }[] to GameState
+
+TASK 2: MOUNT TYPE RENDERING IN renderer.ts
+Different mounts should look different:
+- Add MountType enum to types.ts if not present: Horse=0, Stag=1, Griffin=2, Warhorse=3, Bear=4, Lizard=5, Unicorn=6
+- Add mountType: MountType to GameState (default Horse)
+- Rendering per mount type (monarch rides on these):
+  - Horse: '@' on 'H' (current, keep it)
+  - Stag: '@' on 'S' in brown (0xaa6633ff)
+  - Griffin: '@' on 'G' in gold (0xddaa33ff)
+  - Warhorse: '@' on 'W' in dark steel (0x778899ff)
+  - Bear: '@' on 'B' in dark brown (0x664422ff), wider (2 chars for bear body)
+  - Lizard: '@' on 'L' in green (0x55aa33ff)
+  - Unicorn: '@' on 'U' in sparkle white (0xffddffff)
+- Mount-specific idle animation: Bear sways, Griffin flaps (alternate chars)
+
+TASK 3: HERMIT COTTAGE RENDERING IN renderer.ts
+When hermit cottages exist in the world:
+- Add StructureType values for hermit cottages if needed:
+  - HermitCottage (generic, with hermitType field)
+- Render hermit cottage as small house in forest:
+  - 'h' in green (forest-colored) with dim roof char
+  - When hermit is home: show hermit type icon next to cottage
+  - When hermit is away (riding with monarch): cottage dim/empty
+- Hermit types have distinct markers:
+  - Ballista: 'b', Stable: 's', Bakery: 'k', Knight: 'n', Horn: 'o', Fire: 'f', Berserker: 'r'
+
+TASK 4: STATUE RENDERING IN renderer.ts
+Statues are unlockable structures on specific islands:
+- Add StructureType.Statue if not present
+- Statue rendering:
+  - Inactive (not blessed): '|' dim gray, small pedestal
+  - Active (blessed): '!' bright gold (0xffcc00ff), glowing particles around it
+  - Each statue type has a distinct icon above pedestal:
+    - Archer Statue: ')' (bow)
+    - Farmer Statue: '/' (scythe)
+    - Builder Statue: '#' (wall)
+    - Knight Statue: '+' (sword)
+- Blessing active indicator: small particles (dots) radiating outward from statue
+- Show cost to activate in HUD when monarch is within 5 tiles
+
+TASK 5: MINIMAP IN hud.ts
+Add a simple minimap to the HUD:
+- Toggle with Tab key (state.showMinimap boolean)
+- Render in top-right corner of screen, 30x5 chars
+- Map scale: entire map width compressed to 30 chars
+- Color coding:
+  - Blue dots: water/rivers
+  - Green dots: forest
+  - Brown dots: cleared land
+  - Yellow dots: structures (walls, towers, town center)
+  - Red dots: active portals
+  - White dot: monarch position (blinking)
+  - Gray dots: destroyed portals
+- Bordered with '+-|' chars
+- Show current camera viewport as highlighted region
+
+TASK 6: SOUND IMPROVEMENTS IN sound.ts
+Add more terminal bell/beep patterns:
+- Blood moon warning: 3 rapid beeps 40 seconds before midnight
+- Crown drop alert: continuous rapid beeping while crown is on ground
+- Recruitment sound: single short beep
+- Build completion: two short beeps
+- Greed breach: long beep (different from current)
+- Make sounds optional: add soundEnabled: boolean to state (default true)
+- Export: playBloodMoonWarning, playCrownAlert, playRecruit, playBuildComplete
+
+TASK 7: ISLAND-SPECIFIC MAP GENERATION IN world/map.ts
+Different islands should have different map layouts:
+- Island 1 (Tutorial): smallest map (600 tiles), few forest zones, no small portals
+  - 2 dock portals, 1 cliff portal
+  - 3 vagrant camps, merchant area
+- Island 2 (Stone): medium map (800 tiles), gem chest areas
+  - 3 cliff portals, 1 dock portal per side
+  - Dog location (fallen tree)
+  - Stone mine location
+- Island 3 (Forge): larger map (1000 tiles)
+  - 4-6 cliff portals + cave portal
+  - Forge ruin location
+- Island 4 (Iron): large map (1000 tiles), many portals
+  - No merchant, 6+ portals
+  - Bomb workshop area
+- Island 5 (Final): largest map (1200 tiles), maximum difficulty
+  - 8+ portals
+  - All statue locations
+- Export: generateIslandMap(islandIndex): MapData
+- MapData includes: terrain tiles, portal positions, special structure positions, vagrant camp positions
+
+TASK 8: PER-ISLAND SAVE/LOAD IN index.ts
+Expand save system for multi-island:
+- Save structure: { currentIsland: number, globalDayCount: number, gems: number, bankedCoins: number, islands: IslandSaveState[5] }
+- Each IslandSaveState: full GameState snapshot for that island
+- When sailing to new island: save current island state, load or generate destination
+- Cross-island persistent data: gems, globalDayCount, bankedCoins, islandUnlocked, mountType
+- Add saveIslandState(state, islandIndex) and loadIslandState(islandIndex): GameState
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent1-phase9.txt
+++ b/kingdom/.agent1-phase9.txt
@@ -1,0 +1,93 @@
+Phase 9: Polish pass - campfire glow, water animation, constellation warning, northern lights, coin sparkle.
+
+Read types.ts, renderer.ts, hud.ts, effects.ts, world/terrain.ts first.
+
+You own: renderer.ts, hud.ts, index.ts, types.ts, effects.ts, sound.ts, world/terrain.ts, world/map.ts, world/camera.ts
+
+TASK 1: CAMPFIRE GLOW RADIUS IN renderer.ts
+- Town center campfire (and upgraded versions) should emit warm light
+- Light radius based on tier:
+  - Campfire (tier 1): 5 tiles radius
+  - Camp (tier 2): 8 tiles
+  - Village+ (tier 3+): 12 tiles
+- Effect: tiles within radius get warm tint added to bg color
+  - Blend: mix current bg with 0x442200 at 30% opacity
+  - Intensity falls off linearly with distance
+- Only visible at night (dusk/night phases)
+- During blood moon: glow is reddish instead of warm
+
+TASK 2: ANIMATED WATER IN renderer.ts AND world/terrain.ts
+- Water tiles (streams, rivers) should animate:
+  - Alternate between '~' and '-' every 500ms
+  - Color shifts between 0x3366aaff and 0x4477bbff
+- Frozen water in winter: static '=' in white/blue (0xaabbccff)
+- River flow direction: chars scroll right or left based on tile position
+- Water reflection: during night, show dim star reflections in water
+  - Random '.' chars in water at dim brightness
+
+TASK 3: CONSTELLATION WARNING IN renderer.ts
+Before crown stealer's first appearance:
+- 2 days before crown stealer is introduced (around day 28):
+  - Show a special constellation pattern in the night sky
+  - Pattern: 5-7 dim red stars forming a crown/skull shape
+  - Stars appear gradually over 2 nights (1-2 per night, building up)
+  - After crown stealer appears: constellation fades
+- Constellation positions: fixed relative to sky area (top 3 rows)
+- Use dim red color: 0x882222ff for constellation stars vs 0x888888ff for normal stars
+
+TASK 4: COIN SPARKLE EFFECTS IN effects.ts
+When coins are picked up or dropped:
+- Sparkle burst: 3-5 '*' chars radiate outward from coin position
+  - Duration: 300ms
+  - Color: gold 0xffcc00ff fading to dim
+  - Movement: each spark moves 1 tile in random direction per 100ms
+- Track active sparkle effects: sparkles: { x, y, dx, dy, timer }[]
+- Render sparkles in effects layer (above entities, below HUD)
+- Export: createCoinSparkle(x, y), updateSparkles(dt), renderSparkles(buffer)
+
+TASK 5: NORTHERN LIGHTS (WINTER SPECIAL) IN renderer.ts
+During winter nights:
+- Render aurora borealis in the upper sky area (rows 2-5)
+- Wavy bands of color: green (0x33aa66ff) and purple (0x8833aaff)
+- Animation: sine wave pattern shifts horizontally over time
+  - Each column: color = band[floor(sin(x/5 + time) * 3)]
+  - Bands are 2-3 rows tall, wavy
+- Only visible during clear winter nights (not during storms/blood moon)
+- Intensity: start dim at dusk, peak at midnight, fade at dawn
+
+TASK 6: IMPROVED DAY/NIGHT TRANSITION IN renderer.ts
+Smoother transitions between time phases:
+- Currently: abrupt color change between dawn/day/dusk/night
+- Improved: interpolate between phase colors over 30 frames
+  - Track transitionProgress: number (0-1) within each phase
+  - Lerp sky colors: result = colorA * (1-t) + colorB * t per channel
+  - Apply to both fg and bg colors
+- Sun/moon visual:
+  - Sun: 'O' in yellow, arcs across top of screen during day
+    - Position: x based on time within day phase (left to right)
+  - Moon: 'C' in white, arcs during night
+    - Blood moon: 'O' in red, larger
+  - Both use smooth x movement based on phase progress
+
+TASK 7: ENTITY DETAIL RENDERING IN renderer.ts
+Add more visual detail to entities:
+- Monarch: show coin count as small number next to '@' char
+- Builders: show '/' when actively building (hammer animation)
+- Archers: show ')' next to them (bow), '>' when firing
+- Farmers: show '/' (scythe) during day, nothing at night
+- Knights: show '+' (sword), shield '|' in front when defending
+- Pikemen: show '|' (pike), thrust animation 'I' when attacking
+- Squires: show ']' (shield only, no sword)
+- Hermit on mount: small 'h' above monarch
+- Dog: 'd' char, '!' when barking
+
+TASK 8: PERFORMANCE OPTIMIZATION IN renderer.ts
+- Only re-render cells that changed since last frame:
+  - Keep previousBuffer: same size as current CellBuffer
+  - Compare cell by cell, only setCell for changed cells
+  - This reduces terminal output significantly
+- Batch similar color sequences to reduce escape codes
+- Skip rendering entities that are off-screen (outside camera viewport + margin)
+- Use dirty rect tracking: only render sections that have moving entities
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent1-prompt.txt
+++ b/kingdom/.agent1-prompt.txt
@@ -1,0 +1,42 @@
+You are Agent 1: Core + World + Rendering. You are building a Kingdom-style side-scrolling TUI strategy game using blECSd 0.2.0. The project is at /home/kadajett/Dev/gameDev2026/blECSd-Examples/kingdom. Read types.ts first for all shared types/constants. Also look at the dvd-bounce and roguelike examples in sibling directories for blECSd API patterns.
+
+YOUR FILES ONLY (do NOT create or touch any other files):
+- world/map.ts
+- world/camera.ts
+- world/terrain.ts
+- game/dayNight.ts
+- game/input.ts
+- render/renderer.ts
+- render/hud.ts
+- render/effects.ts
+- index.ts
+
+BLECSD API REFERENCE:
+- import { createWorld, addEntity, addComponent, Position, Velocity, setPosition, setVelocity, createCellBuffer } from 'blecsd'
+- CellBuffer: cast to interface with .setCell(x,y,char,fg,bg) and .cells[y][x] and .width/.height
+- Colors are 0xRRGGBBAA format
+- import { parseKeyBuffer } from 'blecsd' for input parsing
+- Terminal setup: process.stdout.write('\x1b[?1049h') alt screen, '\x1b[?25l' hide cursor
+- process.stdin.setRawMode?.(true); process.stdin.resume();
+
+BUILD EACH FILE:
+
+1) world/terrain.ts - Export generateTerrain(width,height): creates TileType[][] grid. Forest at edges (x<40 and x>MAP_WIDTH-40), grass in middle, dirt below GROUND_Y, water at WATER_Y+.
+
+2) world/map.ts - Export generateMap(state): calls generateTerrain, places portals at forest edge positions, places campfire at CAMP_CENTER_X, creates bow/hammer stands near camp. Store results in state.tiles, state.structures, state.portalPositions.
+
+3) world/camera.ts - Export updateCamera(state): follow monarch x position, clamp to [0, MAP_WIDTH - viewWidth]. Smooth lerp toward target.
+
+4) game/input.ts - Export setupInput(state): configure stdin raw mode, parse key events. Arrow keys set state.inputLeft/inputRight, shift sets inputSprint, space sets inputDrop. q/Ctrl-C exits. Export cleanupInput().
+
+5) game/dayNight.ts - Export updateDayNight(state,dt): advance state.dayTime by dt/DAY_LENGTH, wrap at 1.0 incrementing dayCount. Compute state.timeOfDay from DAWN_START/DAY_START/DUSK_START/NIGHT_START thresholds.
+
+6) render/renderer.ts - Export render(state): clear buffer, draw sky (color by timeOfDay), draw terrain tiles with appropriate chars/colors, draw structures (walls/farms/portals/shrines), draw all entities (monarch/units/greeds/projectiles) offset by cameraX, call renderHud, flush to stdout with dirty-rect optimization. Use fillRect helper internally.
+
+7) render/hud.ts - Export renderHud(state,buffer): draw top bar showing coin count, day number, time of day icon, island number. Use COLOR_HUD_BG/COLOR_HUD_TEXT.
+
+8) render/effects.ts - Export applyNightOverlay(buffer,timeOfDay): darken all cells during night/dusk. Export flashEffect(buffer,x,y): brief color inversion for damage.
+
+9) index.ts - Main entry point. Create world, generate map, create monarch entity, spawn initial vagrants, set up input. Game loop at TARGET_FPS: read dt, updateDayNight, updateMovement (from systems/movement), updateAI (from systems/ai), updateCombat (from systems/combat), updateSpawning (from systems/spawn), updateConstruction (from systems/construction), updateCamera, render. Handle resize. Clean shutdown on exit. Import other agent systems even if files dont exist yet - just have the imports ready.
+
+Make sure everything typechecks against types.ts. Use Bundler module resolution (no .ts extensions on imports). Write all files now.

--- a/kingdom/.agent2-phase2.txt
+++ b/kingdom/.agent2-phase2.txt
@@ -1,0 +1,18 @@
+Phase 2: Improve entities and economy. The game runs but needs gameplay depth. Read the current files first (all files in entities/, game/economy.ts, systems/ai.ts, systems/movement.ts).
+
+Tasks:
+1. Fix economy.ts dropCoin: Currently it checks proximity to structures but the structure detection needs to work with the actual state.structures Map (keyed by x position). Make sure dropping coins near vagrants recruits them, near bow stands makes archers, near hammer stands makes builders. Test the proximity logic carefully. The monarch position comes from getPosition(state.world, state.monarch.eid).
+
+2. Add animal hunting to entities/archer.ts: During Day, archers should generate coins periodically (simulating hunting rabbits/deer). Every 8 seconds while patrolling, an archer generates HUNT_REWARD coins via collectCoins. Add a huntTimer to track this.
+
+3. Improve entities/builder.ts: Builders should visually move toward their target structure. When working, they should decrement a buildTimer on the StructureData. Add a buildTimer field to StructureData in types or track it locally. When builders finish, mark the structure as built.
+
+4. Add unit cap and cost scaling: Max 3 archers, 3 builders, 2 farmers per island. Show "No room" message if cap reached. Recruitment cost increases: 2nd unit costs +1, 3rd costs +2.
+
+5. Improve systems/ai.ts: Add proper dusk retreat behavior. At dusk, all units should pathfind toward the nearest wall on their side, then move behind it. At night, archers should position themselves AT wall positions (wall x), not behind them.
+
+6. Add a new file entities/knight.ts: Mid-game unit unlocked on day 5. Knights cost 5 coins, lead a squad of 2 archers toward portals. They can damage portals. Export createKnight, updateKnight.
+
+7. Update systems/movement.ts: Add collision avoidance so units don't stack on the same tile. Spread units with a minimum spacing of 1 tile.
+
+Write all changes now. Make sure everything typechecks.

--- a/kingdom/.agent2-phase3.txt
+++ b/kingdom/.agent2-phase3.txt
@@ -1,0 +1,18 @@
+Phase 3: Gameplay depth and balance. Read all current files in entities/, game/, systems/ first.
+
+Tasks:
+1. Add animal spawning for hunting in a new file entities/animals.ts: Spawn rabbits and deer in forest areas. Rabbits move fast, give 1 coin. Deer move slow, give 3 coins. Animals flee from nearby entities. Archers auto-target animals during day (before greed). Animals respawn over time. Export spawnAnimal, updateAnimals.
+
+2. Balance economy in game/economy.ts: Early game should be tight. Day 1-2: only hunting income. Day 3+: first farm available. Wall costs should escalate. Add inflation tracking - each wall built on the same side costs +1 more. Make shrine costs scale with uses.
+
+3. Improve entities/archer.ts: Add archer levels. After 5 kills, archer gets +1 range. After 10 kills, archer gets faster reload (0.8x cooldown). Track kills on UnitData or locally. Archers should prioritize CrownStealers over other greed.
+
+4. Improve villager wandering in entities/villager.ts: Vagrants should cluster near the campfire. New vagrants arrive from forest edges every 45 seconds (max 8 at a time). They walk slowly toward camp. If a vagrant reaches the camp and no tool stands are available, they sit idle.
+
+5. Improve entities/farmer.ts: Farmers working irrigated/windmill farms should produce more. Farmers at risk (greed nearby) should flee even during day. Add farm destruction - if greed reaches a farm, they destroy it.
+
+6. Update systems/ai.ts: Integrate animal system updates. Add knight squad behavior - knights rally nearby archers. When a portal is vulnerable (no greed guarding it), knights should prioritize attacking it. Add a "panic" state - if walls on one side are all destroyed, all units on that side flee to the other side.
+
+7. Wire animals into the game: Update index.ts to call updateAnimals if it's not already imported. Or export from ai.ts.
+
+Write all changes now. Make sure everything typechecks.

--- a/kingdom/.agent2-phase4.txt
+++ b/kingdom/.agent2-phase4.txt
@@ -1,0 +1,35 @@
+Phase 4: Fix coin interaction, multiple recruit groups, and auto-building.
+
+Read types.ts, game/economy.ts, entities/monarch.ts, entities/villager.ts, entities/builder.ts, entities/archer.ts, entities/farmer.ts, entities/knight.ts, systems/ai.ts, structures/wall.ts first.
+
+CRITICAL FIXES AND FEATURES:
+
+1. FIX game/economy.ts dropCoin - This is the most important fix. Currently dropping coins near structures doesn't work well. Rewrite dropCoin completely:
+   - Get monarch position from getPosition(state.world, state.monarch.eid)
+   - Search state.structures within 3 tiles of monarch for interaction targets
+   - Search state.units within 3 tiles for vagrants to recruit
+   - Priority order: recruit vagrant near tool stand > upgrade wall > build new wall > build farm
+   - When dropping a coin with NO nearby structure and there's open ground, CREATE A NEW WALL BLUEPRINT at monarch position. Builders will auto-build it. This is how the player builds protection.
+   - Add clear messages for every action: "Recruited archer! (2 coins)", "Wall blueprint placed (3 coins)", "Not enough coins!", etc.
+   - The player should feel like dropping coins DOES things.
+
+2. Add multiple recruit groups. Rewrite entities/villager.ts:
+   - Instead of just vagrants, add different NPC types at different settlements:
+     - Warriors (red): found at outer settlements, become knights directly (cost 3)
+     - Scouts (green): found near forests, become archers with +3 range (cost 2)
+     - Craftsmen (blue): found at central settlements, become builders that work 1.5x faster (cost 2)
+     - Peasants (yellow): found everywhere, become farmers with +50% output (cost 1)
+   - Each settlement should spawn its own type of NPC. Track NPC subtype on UnitData or use a module-level map.
+   - Vagrants from different groups should look different (different CHAR or color)
+
+3. Auto-builder AI improvement in entities/builder.ts:
+   - Builders should AUTOMATICALLY place and build walls when enemies are detected nearby (within 20 tiles of outer wall)
+   - During night, if there are no walls between camp and an approaching greed wave, builders should panic-build a temporary barricade
+   - Builders should repair damaged walls before building new ones
+   - Builders should expand walls outward during peaceful day periods (if coins > 15, auto-place wall blueprint 3 tiles outside current outermost wall)
+
+4. Fix entities/monarch.ts: The input handling for coin drop should be a one-shot (drop once per space press, not continuous). Add a visual indicator when near an interactable (structure or vagrant) - set a flag that the HUD can read.
+
+5. Update systems/ai.ts to handle the new NPC subtypes and auto-building behavior. When timeOfDay changes to Dusk and no walls exist on a side, trigger emergency wall building.
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent2-phase5.txt
+++ b/kingdom/.agent2-phase5.txt
@@ -1,0 +1,82 @@
+Phase 5: Fix entity movement, animal spawning, unit caps, and builder logic.
+
+Read monarch.ts, builder.ts, archer.ts, farmer.ts, animals.ts, villager.ts, knight.ts, ai.ts, economy.ts, movement.ts (just to understand) first.
+
+The game has CRITICAL bugs:
+
+BUG 1: DOUBLE MOVEMENT - Every entity moves TWICE per frame.
+Entity updates (updateMonarch, updateBuilder, updateArcher, etc.) all call setPosition directly.
+Then updateMovement in movement.ts ALSO applies velocity to position for all entities.
+Result: everything moves 2x intended speed.
+
+FIX: Remove ALL direct setPosition calls from entity update functions. ONLY use setVelocity.
+Let movement.ts handle all position updates. Specifically:
+
+- monarch.ts: Remove lines 56-57 (const newX = clamp(...); setPosition(...)). Keep setVelocity at line 53.
+  Also handle speed boost: if state.speedBoostTimer > 0, multiply the speed by 1.5 in getMountSpeed or updateMonarch.
+
+- builder.ts: In updateBuilderDay (line 108-109), updateBuilderDusk (line 133-134), updateBuilderNight (line 156-157, 237-238),
+  tryPanicBuild (line 237-238): Remove setPosition calls. Keep setVelocity calls.
+
+- archer.ts: In updateArcherDay (lines 131-132, 136-137), updateArcherDusk (line 162-163),
+  updateArcherNight (line 181-182): Remove setPosition calls. Keep setVelocity calls.
+
+- farmer.ts: In updateFarmerDay (lines 106-107), updateFarmerFlee (lines 130-131),
+  updateFarmerRetreat (lines 156-157): Remove setPosition calls. Keep setVelocity calls.
+
+- villager.ts: In updateVagrant (lines 222-224): Remove setPosition call. Keep setVelocity.
+
+- knight.ts: In updateKnightDay (lines 102-103), updateKnightDusk (lines 129-130),
+  updateKnightNight (lines 147-148): Remove setPosition calls. Keep setVelocity calls.
+
+BUG 2: ANIMALS SPAWN ONLY AT MAP EDGES
+animals.ts has FOREST_LEFT_MIN=10, FOREST_LEFT_MAX=60, FOREST_RIGHT_MIN=1140, FOREST_RIGHT_MAX=1190.
+With the 1200-wide map, there are forests at MANY locations. Animals should spawn in ALL forests.
+
+FIX in animals.ts:
+- Import getBiome, Biome from '../world/terrain'
+- Replace the two hardcoded forest zones with a dynamic list based on biome
+- Define FOREST_ZONES as ranges where getBiome returns DenseForest:
+  [10-60, 180-260, 520-570, 830-940, 1140-1190]
+- spawnRandomAnimal should pick a random forest zone, then random x within it
+- updateAnimalMovement: instead of checking FOREST_LEFT/RIGHT, check if animal is in ANY forest zone via getBiome
+- Increase MAX_ANIMALS from 6 to 12 (more zones = more animals)
+- Reduce RESPAWN_INTERVAL from 20 to 12 seconds
+
+BUG 3: UNIT CAPS WAY TOO LOW
+economy.ts has MAX_ARCHERS=3, MAX_BUILDERS=3, MAX_FARMERS=2, MAX_KNIGHTS=2.
+For 5 settlements and 5 portals across 1200 tiles, this is absurdly low.
+
+FIX in economy.ts:
+- MAX_ARCHERS = 10
+- MAX_BUILDERS = 8
+- MAX_FARMERS = 6
+- MAX_KNIGHTS = 4
+
+BUG 4: BUILDER ENTITY CONFLICTS WITH CONSTRUCTION SYSTEM
+builder.ts manages building by modifying HP directly. construction.ts also manages building via buildProgress.
+Both run every frame on the same builders.
+
+FIX: Simplify builder.ts to only handle MOVEMENT and STATE TRANSITIONS. Remove all direct HP modification from builder.ts.
+The construction system (Agent 3's domain) will handle the actual building logic.
+
+In builder.ts:
+- updateBuilderDay: Find build target (keep findBuildTarget). If close enough (dist < 1.0), set aiState = Working
+  and setVelocity to 0. Do NOT modify target.hp. The construction system will handle HP changes.
+  If not close, set MovingTo and velocity toward target.
+- updateBuilderNight: tryPanicBuild should only place blueprints and move builder, not do HP modification.
+  Remove the rate/hp modification in the rush-build section (lines 224-228). Just set Working state.
+- Remove all `target.hp = Math.min(target.hp + rate * dt, target.maxHp)` lines from builder.ts.
+- Keep the getBuildRate export (construction.ts might need it).
+
+BUG 5: ARCHERS DON'T ACTUALLY KILL GREED (OPTIMISTIC TRACKING)
+archer.ts line 225: `recordKill(unit.eid); // Optimistic kill tracking for greed`
+The archer records a kill when it fires, not when the arrow hits. Arrows are projectiles processed by combat.ts.
+The optimistic kill tracking inflates the archer's kill count.
+
+FIX: Remove line 225 (recordKill in updateArcherNight). Kill tracking for greed should only happen in combat.ts
+when a greed actually dies. Export recordKill from archer.ts and have combat.ts call it when a greed dies from
+an arrow hit (you'd need to track which archer fired the arrow, which is complex - for now just remove the
+optimistic call and leave the kill tracking for animal hunting only, which IS instant).
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent2-phase6.txt
+++ b/kingdom/.agent2-phase6.txt
@@ -1,0 +1,98 @@
+Phase 6: Banker NPC, Merchant NPC, Pikemen, Squire/Knight split, seasonal farming.
+
+Read KINGDOM_TODO.md, .research-agent2-entities.md, economy.ts, types.ts, farmer.ts, knight.ts, ai.ts first.
+
+You own: monarch.ts, villager.ts, builder.ts, archer.ts, farmer.ts, knight.ts, animals.ts, mount.ts, economy.ts, ai.ts
+
+TASK 1: ADD PIKEMAN UNIT TYPE
+Create entities/pikeman.ts (NEW FILE):
+- UnitRole.Pikeman needs to be added to types.ts (add it, value after Knight)
+- Recruitment: 2 coins for pike at pike vendor (requires TownCenterTier >= 5, Stone Fort)
+- Day behavior: fish at nearest river/water tile. Earn 1 coin per fish, drop at fishing spot.
+  - Find water tiles in state.tiles, walk to nearest one, stand and "fish" every 8 seconds
+- Night behavior: defend at outermost wall, same as archers but with pike
+  - Pike thrust: kills all greed within 1.5 tile range (AoE melee)
+  - Only 1 pikeman actively attacks per wall section
+  - Good against floaters and crown stealers (melee range)
+- Carries 0 coins (drops immediately)
+- MAX_PIKEMEN = 6 in economy.ts
+
+Export: createPikeman, updatePikeman
+
+TASK 2: SQUIRE / KNIGHT PROGRESSION
+Modify knight.ts to split into squire and knight tiers:
+- Add UnitRole.Squire to types.ts
+- Squire: 4 coins for shield (at Castle tier, TownCenterTier >= 6)
+  - Commands a squad of up to 4 archers
+  - 3 HP, 5 coin capacity
+  - Can do everything knights do but weaker
+- Knight: promoted from Squire by picking up iron sword (12 coins at forge)
+  - 5 HP, 11 coin capacity
+  - Enhanced combat damage
+  - Full knight capabilities
+- For now, since forge doesn't exist yet, keep knight recruitment as-is but add the Squire role
+  for future use. Squires are recruited first, knights require forge (future phase).
+- Add isSquire flag to UnitData in types.ts (or check role === Squire)
+- Export: createSquire, updateSquire (similar to knight but weaker stats)
+
+TASK 3: BANKER NPC
+Create entities/banker.ts (NEW FILE):
+- Module-level state: bankedCoins = 0, lastInterestDay = 0
+- Banker appears when TownCenterTier >= 4 (Town Hall)
+- Behavior: stands near town center during day, hides at night
+- Deposit: When monarch drops coin near banker (within 2 tiles of town center), banker takes it
+  - Accumulates deposits, walks to castle door at 10+ coins
+- Withdrawal: monarch presses interact near banker
+  - Returns min(floor(bankedCoins / 3), pouch space remaining)
+  - Minimum 7 coins in bank to withdraw
+- Interest: 7% daily (applied at dawn), capped at 8 coins/day for 101+ stored
+  - if bankedCoins >= 3 && bankedCoins <= 100: interest = Math.ceil(bankedCoins * 0.07)
+  - if bankedCoins > 100: interest = 8
+- Coins persist across islands (store in save state)
+- Export: getBankedCoins, depositCoins, withdrawCoins, applyBankerInterest, updateBanker
+
+TASK 4: MERCHANT NPC
+Create entities/merchant.ts (NEW FILE):
+- Appears on islands 1-2 only (state.islandIndex <= 2)
+- Has a camp in the forest (like vagrant camps)
+- Mechanic: monarch drops 1 coin near merchant -> merchant returns 8 coins next dawn
+  - Module state: pendingPayout = 0
+  - At dawn, if pendingPayout > 0: drop 8 coins near town center, pendingPayout = 0
+- Only accepts during daytime, not during danger (no active greed nearby)
+- Merchant camp destroyed if trees around it are cut (not relevant yet, future feature)
+- Position: fixed x position on the map (e.g., x = 100 for island 1)
+- Export: updateMerchant, createMerchant, merchantAcceptCoin
+
+TASK 5: SEASONAL FARMING IN farmer.ts
+Modify farmer.ts for seasonal effects:
+- Spring/Summer: normal production (100%)
+- Autumn: reduced production (75%) - multiply harvest by 0.75
+- Winter: farms produce nothing. Farmers become idle or forage berries.
+  - If Season.Winter: skip farm work entirely
+  - Instead, find nearest berry bush (from resources.ts getResourceAt/harvestResource)
+  - Walk to berry bush, harvest for coins (1 coin per berry, ~4 berries per bush)
+  - Berry bushes only spawn in winter (Agent 3 will handle spawning)
+- Import Season from types.ts, check state.season in updateFarmerDay
+
+TASK 6: SEASONAL ANIMALS IN animals.ts
+- Spring/Summer: normal animal spawning
+- Autumn: reduced spawn rate (1.5x respawn interval)
+- Winter: no rabbits or deer spawn at all
+  - Instead, spawn 1 boar (worth 30 coins, high HP=5, slow, aggressive)
+  - Boar: charges at nearby entities, drops 30 coins on death
+  - Add AnimalType.Boar to animal types
+  - MAX_BOARS = 1 per winter season
+
+TASK 7: UPDATE ai.ts FOR NEW UNIT TYPES
+- Add dispatch for UnitRole.Pikeman -> updatePikeman
+- Add dispatch for UnitRole.Squire -> updateSquire (use knight update with weaker stats)
+- Import the new update functions
+
+TASK 8: UPDATE economy.ts
+- Add MAX_PIKEMEN = 6
+- Add pike vendor check: requires TownCenterTier >= 5
+- Add squire recruitment: requires TownCenterTier >= 6
+- Add getNearbyInteractable entries for banker ("Deposit coins") and merchant ("Pay merchant")
+- Update dropCoin to handle banker deposit (if near town center and banker exists)
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent2-phase7.txt
+++ b/kingdom/.agent2-phase7.txt
@@ -1,0 +1,113 @@
+Phase 7: Dog companion, crown mechanic, unit coin capacities, builder tree cutting, farmer farmhouse, dawn bonus.
+
+Read KINGDOM_TODO.md, types.ts, monarch.ts, builder.ts, farmer.ts, knight.ts, economy.ts, ai.ts first.
+
+You own: monarch.ts, villager.ts, builder.ts, archer.ts, farmer.ts, knight.ts, animals.ts, mount.ts, economy.ts, ai.ts
+
+TASK 1: DOG COMPANION
+Create entities/dog.ts (NEW FILE):
+- Dog is found on Island 2 under a fallen tree (position depends on map, use x=200 default)
+- 1 coin to free (coin returned immediately)
+- Dog follows monarch at all times (stays within 5 tiles)
+- Movement: matches monarch speed, slightly behind (x - 3 if going right, x + 3 if going left)
+- Warning system: when greed entity is within 30 tiles of dog:
+  - Dog faces toward threat direction
+  - "bark" flag set to true (renderer will show '!')
+  - Bark lasts 2 seconds, then resets
+- Dog can be kidnapped by greedlings:
+  - If greedling reaches dog: dog.captured = true, dogCaptorId = greedling entity
+  - Dog is carried to nearest portal
+  - Recovery: destroy the portal OR lose crown (dog returns next day)
+- State in GameState: hasDog: boolean (default false), dogCaptured: boolean (default false)
+- State in dog module: dogX, dogY, barkTimer, barkDirection, captorEntity
+- Export: createDog, updateDog, freeDog, captureDog, isDogBarking, getDogBarkDirection
+
+TASK 2: CROWN MECHANIC IN monarch.ts
+The crown can be knocked off:
+- When monarch has 0 coins AND takes a hit from any greed:
+  - state.crownDropped = true
+  - state.crownX = monarch position x
+  - crown stays on ground for 10 seconds
+- Crown recovery: if monarch walks over crownX (within 2 tiles) before timer expires
+  - state.crownDropped = false
+  - Message: "Crown recovered!"
+- Crown lost: if timer expires OR crown stealer grabs it
+  - state.gamePhase = GamePhase.GameOver
+  - Message: "The crown has been lost!"
+- Crown stealer interaction:
+  - Crown stealer that reaches monarch instantly drops crown
+  - Crown stealer then tries to carry crown to portal (very fast)
+  - If crown stealer reaches portal with crown: permanent game over
+- Add crownTimer: number to track countdown (10 second recovery window)
+- Update updateMonarch to handle crown drop/recovery logic
+- Export: dropCrown, recoverCrown, isMonarchVulnerable
+
+TASK 3: UNIT COIN CAPACITIES IN economy.ts
+Each unit type should have a max coin carrying capacity:
+- Add UNIT_COIN_CAPACITY map:
+  - Vagrant: 0
+  - Builder: 2
+  - Archer: 11
+  - Farmer: 14
+  - Knight: 11
+  - Squire: 5
+  - Pikeman: 0 (drops immediately)
+  - Monarch: 40 (current pouch)
+- When a unit picks up coins, cap at their capacity
+- Overflow coins drop to ground (create dropped coin at unit position)
+- Export: getUnitCoinCapacity(role): number
+
+TASK 4: BUILDER TREE CUTTING IN builder.ts
+Builders can cut trees for coins:
+- When no higher-priority tasks (no build/repair work):
+  - Find nearest tree within builder's side of kingdom
+  - Walk to tree, "chop" for 3 seconds
+  - Tree removed, drops 1 coin at position
+  - Cleared land can now have walls/structures placed
+- Trees are in the terrain data (check state.tiles for tree tiles)
+- Only cut trees outside current wall perimeter (expand kingdom)
+- Add TreeCuttingTask to builder task types
+- Priority: repair damaged walls > build queued > cut trees > idle
+- Limit: builders only cut trees during daytime
+- Export: findNearestTree(state, builderX), cutTree(state, treeX)
+
+TASK 5: FARMER FARMHOUSE BEHAVIOR IN farmer.ts
+Farmers with access to a farmhouse (upgraded farm) stay there at night:
+- Check if the farm entity has farmhouse flag (StructureType.Farmhouse or farm level >= 2)
+- At night (dusk/night phase):
+  - If farm has farmhouse: farmer stays at farm position (safe, no travel)
+  - If farm has NO farmhouse: farmer walks to town center (current behavior)
+- Farmhouse provides shelter: farmer doesn't lose coins to greed while inside
+- Add isFarmerSheltered(state, farmerEntity): boolean check
+- Export: updateFarmerNight with shelter logic
+
+TASK 6: DAWN BONUS IN economy.ts
+Every dawn, the kingdom gets a small coin bonus:
+- At dawn transition (when timePhase changes to Day):
+  - Drop 2 coins near town center (at CAMP_CENTER_X + random(-3, 3))
+  - Message: "Dawn breaks. +2 coins"
+- This is the Kingdom "tax chest" mechanic simplified
+- Scale with town center tier: tier 1-2: 2 coins, tier 3-4: 3 coins, tier 5-7: 4 coins
+- Export: applyDawnBonus(state)
+- Call from index.ts game loop at dawn
+
+TASK 7: IMPROVED ARCHER BEHAVIOR IN archer.ts
+- Tower archers vs ground archers:
+  - If archer is assigned to a tower: stays at tower position, doesn't hunt
+  - Tower archers get range bonus: +5 tiles range per tower tier
+  - Tower archers have 100% accuracy (currently ~33% for ground)
+  - Ground archers: continue current hunt/defend behavior
+- Add isInTower flag to archer state (set when assigned to tower)
+- Archer distribution: try to keep even left/right split
+  - When recruiting, assign to side with fewer archers
+- Export: assignArcherToTower(state, archerId, towerId), isArcherInTower(archerId)
+
+TASK 8: UPDATE ai.ts FOR DOG AND CROWN
+- Add dog update call in the main AI update loop
+- Add crown recovery check in monarch update section
+- When crownDropped: all knights rush to defend crown position
+  - Override knight behavior to move toward crownX
+- When dogBarking: archers on that side get +2 range (alertness bonus)
+- Import and wire up updateDog from dog.ts
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent2-phase8.txt
+++ b/kingdom/.agent2-phase8.txt
@@ -1,0 +1,147 @@
+Phase 8: Hermit system, multiple mounts, statue blessings, proper knight portal assault.
+
+Read KINGDOM_TODO.md, types.ts, knight.ts, mount.ts, archer.ts, economy.ts, ai.ts first.
+
+You own: monarch.ts, villager.ts, builder.ts, archer.ts, farmer.ts, knight.ts, animals.ts, mount.ts, economy.ts, ai.ts
+
+TASK 1: HERMIT SYSTEM
+Create entities/hermit.ts (NEW FILE):
+- 7 hermit types, each on specific islands:
+  - Ballista Hermit (Island 1, 3 gems to coax, 1 coin to mount)
+    - Unlocks: convert towers to ballista towers
+  - Stable Hermit (Island 2, 1 gem, 1 coin)
+    - Unlocks: farmhouse upgrade, mount summoning horn
+  - Bakery Hermit (Island 3, 4 gems, 1 coin)
+    - Unlocks: convert towers to bakeries (produce bread for vagrant recruitment)
+  - Knight Hermit (Island 4, 2 gems, 1 coin)
+    - Unlocks: convert towers to squire towers (produce shields)
+  - Horn Hermit (Island 5, 3 gems, 1 coin)
+    - Unlocks: horn walls (reinforcement call each night)
+  - Fire Tower Hermit (varies, 2 gems, 1 coin)
+    - Unlocks: convert towers to fire towers (AoE burn)
+  - Berserker Hermit (varies, 2 gems, 1 coin)
+    - Unlocks: berserker towers (produce potions for knights)
+
+Hermit mechanics:
+- Each hermit lives in a cottage in the forest (fixed position per island)
+- Monarch visits cottage, pays gem cost to "coax" hermit out
+- Hermit rides on monarch's mount (only 1 hermit at a time)
+- Drop hermit at target tower/structure to convert it
+- Hermit then returns to cottage (walks back slowly)
+- If greed reaches hermit: hermit kidnapped, must destroy that portal to rescue
+- State per hermit: { type, islandIndex, x, coaxed, riding, kidnapped, rescuable }
+- Export: createHermit, updateHermit, coaxHermit, dropHermit, getAvailableHermits
+
+TASK 2: MULTIPLE MOUNT TYPES IN mount.ts
+Expand from single horse to 7 mount types:
+- Each mount found at a stable (or wild location) on specific islands
+- Gem cost to unlock, coin cost to ride:
+
+  | Mount | Island | Gems | Coins | Speed | Stamina | Ability |
+  |-------|--------|------|-------|-------|---------|---------|
+  | Horse | 1 | 0 | 3 | 1.5x | 100 | None (baseline) |
+  | Stag | 2 | 1 | 3 | 1.3x | 80 | Attracts deer within 20 tiles |
+  | Griffin | 1 | 2 | 8 | 1.8x | 60 | Wing flap knockback (5 tiles AoE) |
+  | Warhorse | 3 | 2 | 8 | 1.5x | 120 | Charge: 10s invincibility to nearby allies |
+  | Bear | 4 | 3 | 11 | 1.0x | 150 | Pounce: instakill 1 greed, 8s cooldown |
+  | Lizard | 4 | 3 | 10 | 1.3x | 70 | Fire breath: 3-tile cone, 3 DPS, 6s cooldown |
+  | Unicorn | 5 | 4 | 12 | 1.4x | 90 | Grass eating: generates 3 coins, 15s cooldown |
+
+- Mount stable: fixed position per island where mounts are housed
+- 3 coins to switch between unlocked mounts at stable
+- Mount loss: when monarch takes hit, mount bucks and returns to stable
+  - Monarch on foot until reaching stable again
+- Mount grazing: when idle (monarch not moving), mount slowly regenerates stamina
+- Ability activation: use 'e' key while riding to trigger mount ability
+- State: mountsUnlocked: Set<MountType>, currentMount: MountType, mountAbilityCooldown: number
+- Export: switchMount, activateMountAbility, updateMountAbility, getMountStats
+
+TASK 3: STATUE BLESSING SYSTEM
+Create entities/statue.ts (NEW FILE):
+- 4 statues on specific islands:
+  - Archer Statue (Island 1): 4 gems unlock, 10 coins activate
+    - Blessing: all archers get perfect accuracy for 1 full day/night cycle
+  - Farmer Statue (Island 2): 1 gem unlock, 7 coins activate
+    - Blessing: +2 farmers per farm, farms produce 50% more for 2 days
+  - Builder Statue (Island 3): 3 gems unlock, 9 coins activate
+    - Blessing: all walls get +50% HP for 2 days
+  - Knight Statue (Island 5): 2 gems unlock, 9 coins activate
+    - Blessing: all knights get jump-slash (2x damage) for 1 day
+
+- Statue mechanics:
+  - First, unlock with gems (one-time)
+  - Then, activate with coins (repeatable, blessing lasts set duration)
+  - Blessing timer counts down, when expired statue needs reactivation
+  - Only one blessing active at a time (activating new one replaces old)
+- State: statues: { type, islandIndex, x, unlocked, blessingActive, blessingTimer }[]
+- Export: unlockStatue, activateStatue, updateStatueBlessings, isBlessed, getBlessingType
+
+TASK 4: KNIGHT PORTAL ASSAULT MECHANIC IN knight.ts
+Proper portal assault sequence:
+- Monarch drops coin at outermost wall banner -> triggers assault
+- Knight + 4-archer squad dispatched:
+  - Knight leads, archers follow in formation behind
+  - Formation: knight in front, archers spaced 2 tiles behind in a line
+  - Knight absorbs hits for archers (shield mechanic)
+  - Archers split fire: 50% at approaching greed, 50% at portal
+- Knight charges at portal:
+  - Deals 2 damage per second to portal
+  - Shield absorbs 3 hits before breaking
+  - If shield breaks: knight retreats (and squad retreats)
+- Squad retreat conditions:
+  - Knight shield broken
+  - Knight HP reaches 1
+  - All archers killed
+  - Manual recall (future: drop coin at wall again to recall)
+- If portal destroyed: squad returns to kingdom, celebration message
+- Add assaultSquad: { knightId, archerIds, targetPortal, active } to state
+- Export: dispatchAssault, updateAssault, recallSquad
+
+TASK 5: IMPROVED ANIMAL BEHAVIOR IN animals.ts
+- Deer: attracted to stag mount (within 20 tiles, don't flee)
+  - Normal deer flee from monarch
+  - With stag mount: deer slowly approach, easier to hunt
+- Rabbits: worth 1 coin, quick, flee from everything
+  - Spawn from rabbit dens (fixed positions in forest)
+  - Den spawns 1 rabbit every 45 seconds, max 2 alive per den
+  - Den destroyed in winter (no rabbits)
+- Boar (winter only, from Phase 6):
+  - Verify boar implementation works with new seasonal system
+  - Boar charges at monarch if within 10 tiles
+  - 5 HP, drops 30 coins on death
+  - Only 1 boar per winter season
+- Add rabbit den tracking: rabbitDens: { x, rabbitsAlive }[]
+- Export: updateDenSpawning
+
+TASK 6: BREAD RECRUITMENT IN economy.ts
+After bakery tower is built (via Bakery Hermit):
+- Bakery produces 7 bread loaves per day
+- Bread can recruit vagrants (like coins, but doesn't cost money)
+  - Vagrant + bread = recruited unit (random role based on available tools)
+- Bread dropped near vagrant: vagrant picks it up and becomes loyal
+- Bread spoils after 2 days if not used (removed from world)
+- State: breadCount: number at bakery position
+- Export: produceBread, useBreadForRecruitment
+
+TASK 7: UPDATE ai.ts FOR NEW SYSTEMS
+- Add hermit update dispatch
+- Add statue blessing effect application:
+  - If archer blessed: set accuracy to 100% for all archers
+  - If farmer blessed: double farm output
+  - If builder blessed: multiply wall maxHP by 1.5
+  - If knight blessed: double knight damage
+- Add mount ability cooldown tracking
+- Import all new entity update functions
+- Wire up portal assault squad updates
+
+TASK 8: UPDATE economy.ts FOR HERMITS AND STATUES
+- Add gem costs for hermit coaxing
+- Add coin costs for statue activation
+- Add mount switching cost (3 coins at stable)
+- Add getNearbyInteractable entries:
+  - Near hermit cottage: "Coax hermit (N gems)"
+  - Near statue: "Unlock (N gems)" or "Bless (N coins)"
+  - Near stable: "Switch mount (3 coins)"
+  - Near forge: "Forge sword (12 coins)"
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent2-phase9.txt
+++ b/kingdom/.agent2-phase9.txt
@@ -1,0 +1,127 @@
+Phase 9: Crusher greed type, proper unit behavior polish, heir system, co-op prep.
+
+Read KINGDOM_TODO.md, types.ts, knight.ts, archer.ts, builder.ts, farmer.ts, ai.ts, economy.ts, mount.ts first.
+
+You own: monarch.ts, villager.ts, builder.ts, archer.ts, farmer.ts, knight.ts, animals.ts, mount.ts, economy.ts, ai.ts
+
+TASK 1: HEIR SUCCESSION IN monarch.ts
+When the crown is permanently lost (game over):
+- Instead of immediate game over, implement heir system:
+  - If this is first crown loss: "A new heir approaches..."
+  - New monarch spawns at dock on the SAME island
+  - Heir starts with: 8 coins, no mount (walks)
+  - Previous kingdom state is preserved but decayed:
+    - Apply 100 days of decay to ALL unlocked islands
+    - Banker coins preserved (inheritance)
+    - Gems preserved
+    - Unlocks (mounts, hermits, statues) preserved
+    - But all subjects lose their tools (revert to vagrants)
+  - Track totalHeirs: number in GameState
+  - Max heirs: unlimited (but each succession causes more decay)
+- Export: triggerHeirSuccession(state), spawnHeir(state)
+
+TASK 2: PROPER ARCHER DISTRIBUTION IN archer.ts
+- When new archer is recruited, assign to side with fewer archers
+  - Count archers on left (x < CAMP_CENTER_X) vs right
+  - New archer walks to side with fewer
+- Tower priority: fill tower slots before ground positions
+  - Check all towers for empty slots
+  - Assign nearest available archer to tower
+- Night repositioning:
+  - Unassigned archers walk to outermost wall on their side
+  - Space evenly along wall (not all stacked at same position)
+  - If wall has tower: prioritize tower slots
+- Export: getArcherDistribution(state): { left: number, right: number }
+
+TASK 3: PROPER BUILDER PRIORITIES IN builder.ts
+Full builder task priority list (descending):
+1. Repair town center (if damaged)
+2. Repair damaged walls (lowest HP first)
+3. Build queued structures (walls, towers)
+4. Upgrade town center (if coin dropped at center)
+5. Upgrade towers (if coin dropped at tower)
+6. Upgrade farms (if coin dropped at farm)
+7. Restore boat hull pieces (if boat restoration active)
+8. Operate catapult (if loaded and enemies in range)
+9. Push bomb (if bomb active, needs 3 builders + knight escort)
+10. Cut trees (expand territory)
+11. Idle: walk to nearest outer wall and wait
+
+- Max 2 builders per construction task (prevent overcrowding)
+- Builders work day and night (no self-preservation)
+- Builder pathfinding: straight line walk to task position
+- Export: getBuilderPriority(taskType): number, findBestBuilderTask(state, builderX): Task
+
+TASK 4: IMPROVED KNIGHT AI IN knight.ts
+- Defensive mode (night, no assault active):
+  - Knights position at outermost walls
+  - Shield wall formation: knight faces outward, blocks damage for archers behind
+  - Shield absorbs hits: 3 HP shield, regenerates 1 HP per day at dawn
+  - Knight + 4 archers form "company" - move together
+- Offensive mode (portal assault dispatched):
+  - Knight leads company toward target portal
+  - Knight charges ahead, archers provide covering fire
+  - Knight deals melee damage to portal
+  - On retreat: knight falls back behind archers, archers cover retreat
+- Crown defense mode (crown dropped):
+  - All knights rush to crown position regardless of current task
+  - Form defensive circle around crown
+  - Attack any greed within 5 tiles of crown
+- Export: getKnightMode(state, knightId): 'defensive' | 'offensive' | 'crownDefense'
+
+TASK 5: VAGRANT CAMP IMPROVEMENTS IN villager.ts
+- Vagrant camps at fixed forest positions (3-5 per island)
+- Each camp holds 2-3 vagrants
+- Vagrant spawning: 1 new vagrant per camp every 2 minutes
+  - Max vagrants per camp: 3
+  - Total max vagrants on island: 15
+- Vagrants freeze and crouch when greed approaches:
+  - If greed within 10 tiles: vagrant crouches (stops moving)
+  - Cannot be recruited while crouching
+  - After greed passes: resume wandering after 3 seconds
+- Vagrant wandering: random walk within 10 tiles of camp
+- When recruited: vagrant walks to nearest tool stand
+- Export: getVagrantCamps(state), updateVagrantSpawning(state, dt)
+
+TASK 6: TOOL THEFT MECHANIC IN economy.ts
+When a greedling kills a unit:
+- Unit drops their tool (bow/hammer/scythe/pike/shield/sword)
+- Greedling picks up the tool and carries it toward portal
+- If greedling reaches portal with tool: tool destroyed permanently
+- If greedling killed while carrying tool: tool drops to ground
+  - Dropped tool stays for 60 seconds
+  - Any vagrant can pick up a dropped tool to become that unit type
+  - After 60 seconds: tool despawns
+- Track droppedTools: { x, toolType, timer }[]
+- Tool types map to unit roles: bow->archer, hammer->builder, etc.
+- Export: dropTool(x, toolType), pickUpTool(state, vagrantId, toolIndex)
+
+TASK 7: MOUNT FEAR MECHANIC IN mount.ts
+- When monarch on mount is near a breeder (within 8 tiles):
+  - Mount panics: 2 seconds of uncontrolled movement
+  - Mount moves away from breeder at 2x speed
+  - Monarch cannot control direction during panic
+  - After panic: 3 second cooldown before normal control resumes
+- Bear mount is immune to fear (too brave)
+- Warhorse has reduced fear (1 second instead of 2)
+- Griffin can fly over breeder (no fear trigger)
+- Add mountPanicTimer: number to mount state
+- Export: triggerMountPanic(state, breederX), isMountPanicking(state)
+
+TASK 8: FINAL AI INTEGRATION IN ai.ts
+Wire up ALL systems:
+- Heir succession check (on crown loss)
+- Archer distribution balancing
+- Builder priority system
+- Knight mode switching (defensive/offensive/crown defense)
+- Vagrant camp spawning
+- Tool theft tracking
+- Mount fear triggers
+- All blessing effects from statues
+- Weather effects on unit behavior (rain: slightly slower movement)
+- Seasonal checks for all unit types
+- Update all entity modules in correct order:
+  1. monarch, 2. mount, 3. dog, 4. archers, 5. builders, 6. farmers,
+  7. knights/squires, 8. pikemen, 9. hermits, 10. vagrants, 11. animals
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent2-prompt.txt
+++ b/kingdom/.agent2-prompt.txt
@@ -1,0 +1,36 @@
+You are Agent 2: Entities + Economy + AI. You are building a Kingdom-style side-scrolling TUI strategy game using blECSd 0.2.0. The project is at /home/kadajett/Dev/gameDev2026/blECSd-Examples/kingdom. Read types.ts first for all shared types/constants. Also look at the dvd-bounce and roguelike examples in sibling directories for blECSd API patterns.
+
+YOUR FILES ONLY (do NOT create or touch any other files):
+- entities/monarch.ts
+- entities/villager.ts
+- entities/builder.ts
+- entities/archer.ts
+- entities/farmer.ts
+- game/economy.ts
+- systems/ai.ts
+- systems/movement.ts
+
+BLECSD API REFERENCE:
+- import { createWorld, addEntity, addComponent, removeEntity, Position, Velocity, setPosition, setVelocity, getPosition, getVelocity } from 'blecsd'
+- Direct array access: Position.x[eid], Position.y[eid], Velocity.x[eid], Velocity.y[eid]
+- Entity is a number type, World from createWorld()
+
+BUILD EACH FILE:
+
+1) entities/monarch.ts - Export createMonarch(state: GameState): creates entity with Position at CAMP_CENTER_X, GROUND_Y-1. Returns UnitData with role=Monarch, hp=1. Export updateMonarch(state,dt): read inputLeft/inputRight/inputSprint, set velocity to MONARCH_SPEED or MONARCH_SPRINT. Clamp position to world bounds. Handle coin drop when inputDrop is true with COIN_DROP_COOLDOWN.
+
+2) game/economy.ts - Export dropCoin(state): check what's nearby monarch. If vagrant within 2 tiles and coins >= RECRUIT_COST, recruit it. If bow stand within 2 tiles and vagrant nearby, make archer (BOW_COST). If hammer stand, make builder (HAMMER_COST). If wall blueprint, upgrade wall (WALL_COST_*). If farm plot, build farm (FARM_BUILD_COST). Export collectCoins(state,amount). Export canAfford(state,cost): boolean.
+
+3) entities/villager.ts - Export spawnVagrant(state,x): create entity, add to state.units with role=Vagrant, aiState=Idle. Vagrants wander randomly within 10 tiles of spawn. Export updateVagrant(state,unit,dt): random walk behavior, stay within camp area. Export recruitVagrant(state,unit,newRole): change role, set appropriate stats.
+
+4) entities/builder.ts - Export updateBuilder(state,unit,dt): During Day - find nearest construction site or damaged structure, move toward it, work on it (decrement build timer). During Dusk - set aiState=Retreating, move behind nearest wall toward camp center. During Night - hide, aiState=Idle. Priority: closest unfinished structure > closest damaged structure > idle.
+
+5) entities/archer.ts - Export updateArcher(state,unit,dt): During Day - patrol outskirts, hunt (move toward animals area, generate coins on successful hunt at random intervals). During Dusk - return to nearest wall position, aiState=Retreating. During Night - defend walls, aiState=Defending, auto-target nearest Greed within ARROW_RANGE, shoot with ARROW_COOLDOWN. Export createArrow(state,fromX,fromY,direction): add projectile to state.projectiles.
+
+6) entities/farmer.ts - Export updateFarmer(state,unit,dt): move to assigned farm structure. During Day, work: every FARM_INCOME_INTERVAL seconds, generate FARM_REWARD_BASE coins. During Dusk/Night, retreat behind walls like builders.
+
+7) systems/ai.ts - Export updateAI(state,dt): iterate all state.units. Based on unit.role, call the appropriate update function (updateMonarch, updateVagrant, updateBuilder, updateArcher, updateFarmer). Handle global state transitions: when timeOfDay changes to Dusk, set all non-monarch units to Retreating.
+
+8) systems/movement.ts - Export updateMovement(state,dt): iterate all entities (units + greeds + projectiles). Apply velocity * dt to position. Clamp to world bounds [0, MAP_WIDTH]. Remove projectiles that go off-screen.
+
+Each file exports functions taking (state: GameState, dt: number) or similar. All entity data stored in state.units as UnitData[]. Make sure everything typechecks against types.ts. Use Bundler module resolution (no .ts extensions on imports). Write all files now.

--- a/kingdom/.agent3-phase2.txt
+++ b/kingdom/.agent3-phase2.txt
@@ -1,0 +1,18 @@
+Phase 2: Improve combat, structures, and spawning. The game runs but needs better gameplay mechanics. Read the current files first (all files in structures/, entities/greed.ts, systems/combat.ts, systems/construction.ts, systems/spawn.ts).
+
+Tasks:
+1. Fix systems/spawn.ts: Currently spawns all greeds instantly. Instead, spawn them over the night with delays. Track a spawnQueue per portal: calculate total wave size at night start, then pop one greed every 2 seconds. Add variety - 70% basic, 20% masked, 10% special (based on island).
+
+2. Improve entities/greed.ts updateGreed: Greeds should group up and attack the nearest wall together. When a wall is destroyed, they should pause briefly (0.5s) then continue. Add knockback when hit by arrows (push back 1 tile). CrownStealers should pathfind around walls instead of attacking them.
+
+3. Improve structures/wall.ts: Add visual damage states. When wall hp < 50%, it shows CHAR_WALL_DAMAGED. Add a repair mechanic: builders near damaged walls should slowly restore hp (1 hp per 3 seconds). Export getWallHealth(state, x) returning a 0-1 ratio.
+
+4. Add structures/ship.ts (new file): The ship is at x=0 (left edge). It starts damaged. Costs SHIP_REPAIR_COST coins to repair. When fully repaired, pressing space near it triggers island transition (increment islandIndex, regenerate map with higher difficulty). Export createShip, repairShip, isShipReady.
+
+5. Improve systems/combat.ts: Add arrow visual trail - projectiles should have a lifetime (disappear after 0.5s even if no hit). Add critical hits (10% chance for 2x damage). When a greed dies, drop 1 coin at their position that the monarch can pick up by walking over it. Track dropped coins as a new array in GameState or use a simple position list.
+
+6. Improve systems/construction.ts: Builders should choose the closest task. Priority: repair damaged walls > build new structures > upgrade existing. Add build time based on structure type (walls: 5s, farms: 8s, upgrades: 10s).
+
+7. Add a retaliation wave system: When a portal is destroyed (via destroyPortal), immediately spawn a massive wave (3x normal size) from the remaining portals. Track this in spawn.ts with a retaliationPending flag.
+
+Write all changes now. Make sure everything typechecks.

--- a/kingdom/.agent3-phase3.txt
+++ b/kingdom/.agent3-phase3.txt
@@ -1,0 +1,18 @@
+Phase 3: Combat depth and difficulty scaling. Read all current files in structures/, entities/greed.ts, systems/combat.ts, systems/spawn.ts, systems/construction.ts first.
+
+Tasks:
+1. Improve wave composition in systems/spawn.ts: Night 1-3: only basic greed. Night 4-5: introduce masked (30% chance). Night 6+: introduce floaters (15%). Night 8+: crown stealers (5%). Blood moons double all percentages for special types. Add a wave preview - before night, show "Wave X approaching" message with count.
+
+2. Add breeder greed behavior in entities/greed.ts: Breeders are slow but spawn 2 mini-greeds when they take damage. Mini-greeds have 1hp and basic speed. Breeders appear starting night 7. Add greed retreat - greeds carrying 3+ stolen coins should try to flee back to their portal.
+
+3. Improve structures/wall.ts: Add tower upgrade path. After iron wall, spending 15 coins creates a tower (StructureType.Tower). Towers give archers +5 range and allow 2 archers to station there. Export createTower, getTowerAt. Add StructureType.Tower to types.ts if needed.
+
+4. Improve structures/farm.ts: Farms should have a visual growth cycle. Newly built farms produce nothing for 10 seconds (growing). Windmill farms attract more farmers. Add a max of 3 farms per side.
+
+5. Add catapult/ballista in a new file structures/siege.ts: Late-game structure (island 3+). Costs 12 coins. Does 3 damage to all greeds in a 3-tile radius. Fires every 5 seconds during night. Auto-targets the largest group of greeds. Export createBallista, updateBallista.
+
+6. Improve systems/combat.ts: Add friendly fire prevention (arrows shouldn't hit friendly units). Add armor penetration - masked greeds take 50% less damage from basic arrows, but full damage from tower archers. Add combo system - 3 arrows hitting the same greed within 1 second does bonus damage.
+
+7. Add difficulty progression: Each island increases portal count by 1, greed base hp by 0.5, and wave size multiplier by 0.5. Island 5 is the final island. When all portals on island 5 are destroyed, set GamePhase.Victory.
+
+Write all changes now. Make sure everything typechecks.

--- a/kingdom/.agent3-phase4.txt
+++ b/kingdom/.agent3-phase4.txt
@@ -1,0 +1,44 @@
+Phase 4: Auto-protection, enemy scaling for massive world, and structure improvements.
+
+Read types.ts, structures/wall.ts, structures/farm.ts, structures/portal.ts, structures/shrine.ts, structures/ship.ts, systems/combat.ts, systems/spawn.ts, systems/construction.ts, entities/greed.ts first.
+
+CRITICAL CHANGES:
+
+1. Auto-protection system in systems/construction.ts:
+   - Add a function planDefenses(state): analyzes the map and creates wall blueprints automatically
+   - When a settlement is first visited (monarch enters within 10 tiles), auto-place wall blueprint positions 15 tiles left and right of the settlement campfire
+   - Builders assigned to a settlement should auto-queue: walls first, then farms
+   - Track blueprint positions in a module-level Set. Blueprints are "virtual structures" with buildProgress 0.
+   - Builders pick the nearest blueprint and start building. Once complete, it becomes a real wall in state.structures.
+   - Export getBlueprints(), addBlueprint(x), removeBlueprint(x)
+
+2. Scale enemies for the massive 1200-wide world:
+   - Update systems/spawn.ts: portals now exist between EACH settlement (not just at forest edges)
+   - Each portal group spawns independently - so the player faces threats from multiple directions
+   - Greed from different portals should target the nearest settlement, not always the center
+   - Add a new greed behavior: roaming bands. During day, small groups of 2-3 greed roam between portals. They're weaker but force the player to patrol.
+
+3. Improve structures/wall.ts:
+   - Add gate structure (StructureType.Gate if not in types.ts, use a numeric value). Gates let friendly units pass but block greed.
+   - Auto-gate: when a wall line is built, automatically place a gate every 10 tiles so builders/archers can move through
+   - Wall chains: connected walls (adjacent x positions) get a +1 HP bonus each. A line of 5 walls each gets +5 bonus HP.
+
+4. Improve structures/portal.ts for the massive world:
+   - Portals should be placed at: x=50, x=275, x=475, x=725, x=925, x=1150 (between settlements)
+   - Each portal has its own difficulty level that scales independently
+   - Destroying a portal permanently clears the area, allowing settlement expansion
+
+5. Add resource nodes in a new file structures/resources.ts:
+   - Gold veins: found in mountain biomes, miners (builders reassigned) extract 1 coin every 10 seconds
+   - Berry bushes: found in forest, farmers can harvest for bonus coins
+   - Export createResource(state, x, type), harvestResource(state, x), getResourceAt(state, x)
+   - Resources deplete after 20 harvests and respawn after 60 seconds
+
+6. Update systems/combat.ts for the wider world:
+   - Combat should only process entities within 50 tiles of the camera (performance optimization)
+   - Archers at different settlements should defend independently
+   - Add settlement defense rating: count walls + archers near each settlement to determine defense strength
+
+7. Update entities/greed.ts: Greed should target the WEAKEST settlement (lowest defense rating) not always the center. This forces the player to balance defense across the map.
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent3-phase5.txt
+++ b/kingdom/.agent3-phase5.txt
@@ -1,0 +1,101 @@
+Phase 5: Fix movement system, portal/settlement positions, and construction system.
+
+Read movement.ts, construction.ts, portal.ts, spawn.ts, combat.ts, greed.ts, wall.ts first.
+Also read world/map.ts to see SETTLEMENT_CENTERS and PORTAL_POSITIONS.
+
+The game has CRITICAL bugs:
+
+BUG 1: DOUBLE MOVEMENT IN movement.ts
+Entity-specific updates (monarch.ts, builder.ts, archer.ts, etc.) set velocity via setVelocity.
+Agent 2 is removing their direct setPosition calls so only velocity is set.
+Then movement.ts applies velocity to position. This is correct.
+
+BUT: Currently movement.ts also applies velocity to monarch (lines 28-37) AND units (lines 17-27) AND greeds (lines 39-49).
+Since Agent 2 is removing direct setPosition from entity updates, movement.ts becomes the SOLE mover.
+This is the correct fix. HOWEVER, greed movement is special: greed.ts uses Position.x[greed.eid] directly
+(line 236, 294) instead of setVelocity. So greeds bypass the velocity system entirely.
+
+FIX for movement.ts:
+- Keep the unit position-from-velocity code (lines 17-27) - this is now the only movement
+- Keep the monarch position-from-velocity code (lines 28-37) - this is now the only movement
+- For greeds (lines 39-49): Greeds don't use velocity, they modify Position directly in greed.ts.
+  REMOVE the greed velocity loop from movement.ts (lines 39-49). Greeds handle their own movement.
+- Keep projectile movement (lines 52-59) and collision avoidance (line 66)
+
+BUG 2: PORTAL POSITIONS MISMATCH
+map.ts PORTAL_POSITIONS = [30, 220, 540, 880, 1170] (5 portals)
+portal.ts PORTAL_POSITIONS_WORLD = [50, 275, 475, 725, 925, 1150] (6 portals, DIFFERENT positions)
+
+The ACTUAL portals are placed by map.ts into state.structures and state.portalPositions.
+portal.ts's PORTAL_POSITIONS_WORLD is never used for placement but IS used by spawn.ts.
+
+FIX in portal.ts:
+- Change PORTAL_POSITIONS_WORLD to match map.ts: [30, 220, 540, 880, 1170]
+  Or better: import PORTAL_POSITIONS from map.ts (but it's not exported).
+  Simplest: just update the constant to [30, 220, 540, 880, 1170]
+
+BUG 3: SETTLEMENT POSITIONS MISMATCH
+map.ts SETTLEMENT_CENTERS = [150, 400, 600, 800, 1050]
+portal.ts SETTLEMENT_POSITIONS = [200, 375, 600, 825, 1050]
+
+These MUST match because:
+- construction.ts uses getNearestSettlement (from portal.ts) for auto-gate placement
+- getWeakestSettlement uses SETTLEMENT_POSITIONS for defense rating
+- getSettlementDefenseRating uses SETTLEMENT_POSITIONS
+
+FIX in portal.ts:
+- Change SETTLEMENT_POSITIONS to match map.ts: [150, 400, 600, 800, 1050]
+  Or better: import SETTLEMENT_CENTERS from '../world/map' and re-export as SETTLEMENT_POSITIONS.
+  map.ts already exports SETTLEMENT_CENTERS. So:
+  import { SETTLEMENT_CENTERS } from '../world/map';
+  export const SETTLEMENT_POSITIONS = SETTLEMENT_CENTERS;
+  Delete the old hardcoded SETTLEMENT_POSITIONS array.
+
+BUG 4: CONSTRUCTION SYSTEM NEEDS TO BE THE SOLE BUILDER
+Agent 2 is removing direct HP modification from builder.ts. The construction system (construction.ts)
+needs to be the SOLE system that handles building/repairing.
+
+FIX in construction.ts:
+- The system already handles builders in Working state
+- BUT it only processes builders already in Working state. After Agent 2's fix, builder.ts will set
+  builders to Working when close to a target. construction.ts then needs to do the actual HP work.
+- Current issue: findBestTask checks both blueprints Set AND state.structures. But walls placed by
+  placeWallBlueprint go into state.structures with hp:0, NOT into the blueprints Set. So they're
+  found as "BuildNew" priority, not "BuildBlueprint".
+
+  FIX: In findBestTask, for structures with hp===0 and maxHp > 0, treat them as blueprints:
+  ```
+  if (structure.hp === 0 && structure.maxHp > 0) {
+    tasks.push({ ..., priority: TaskPriority.BuildBlueprint, isBlueprint: false, ... });
+  }
+  ```
+  This ensures walls placed by placeWallBlueprint get built promptly.
+
+- When a "BuildNew" or hp:0 structure finishes building (buildProgress reaches 100), set structure.hp = structure.maxHp.
+  Currently, for non-blueprint tasks, it just deletes buildProgress but doesn't set HP.
+  ADD: `if (task.structure) { task.structure.hp = task.structure.maxHp; }` when next >= 100 for non-blueprint tasks.
+
+- For the repair path (TaskPriority.RepairWall): this already modifies hp directly, which is correct.
+
+BUG 5: GREED DON'T LOOK SCARY ENOUGH AND WALLS NEED BETTER BLOCKING
+The greed system works but some edge cases:
+
+- In greed.ts, Position.x is modified directly (line 236, 294) bypassing setPosition. This is fine since
+  movement.ts won't touch greeds (per fix above), but it means greed y position is never updated.
+  Make sure greeds stay at GROUND_Y - 1.
+
+- findNearestDefenseInPath (line 147) scans from greed toward target checking state.structures.get(checkX).
+  This only finds structures at exact integer positions. Make sure Math.round is used consistently.
+  The current code uses Math.round(greedX) and Math.round(targetX) - looks correct.
+
+BUG 6: COMBAT SYSTEM NEEDS TO TRACK ARCHER KILLS FOR REAL
+Currently archer.ts optimistically tracks kills when arrows are fired (for greed).
+Agent 2 is removing that. Combat.ts should track real kills.
+
+FIX in combat.ts:
+- In cleanupDeadGreeds, when a greed dies, check if any projectile recently hit it
+  (or simpler: just don't track greed kills for archers since the leveling system is for animal hunting).
+  The current system is fine as-is since recordKill is only meaningful for archer leveling (range/cooldown bonuses).
+  No change needed here - Agent 2's fix to remove optimistic tracking is sufficient.
+
+Write all changes. Make sure everything typechecks.

--- a/kingdom/.agent3-phase6.txt
+++ b/kingdom/.agent3-phase6.txt
@@ -1,0 +1,122 @@
+Phase 6: Town Center system, proper 5-tier walls, gem currency, seasonal spawning, catapult.
+
+Read KINGDOM_TODO.md, .research-agent3-world.md, types.ts, wall.ts, portal.ts, spawn.ts, construction.ts first.
+
+You own: combat.ts, wall.ts, portal.ts, resources.ts, shrine.ts, ship.ts, siege.ts, spawn.ts, construction.ts, movement.ts, greed.ts
+
+TASK 1: TOWN CENTER UPGRADE SYSTEM
+Create structures/townCenter.ts (NEW FILE):
+- Town center is at CAMP_CENTER_X (600)
+- TownCenterTier enum will be in types.ts (Agent 1 adds it)
+- Export functions:
+  - getTownCenterTier(state): returns current tier
+  - canUpgradeTownCenter(state): checks coins >= cost AND no cooldown active
+  - upgradeTownCenter(state): deducts coins, increments tier, starts cooldown
+  - updateTownCenter(state, dt): manages upgrade cooldown timer
+  - getTownCenterUnlocks(tier): returns what's unlocked at each tier
+    - Tier 1 (Campfire): bow + hammer stands
+    - Tier 2 (Camp): second tool stand set
+    - Tier 3 (Village): scythe vendor (farmers), inner spike walls
+    - Tier 4 (Town Hall): banker, siege workshop
+    - Tier 5 (Stone Fort): stone walls, pike vendor, catapult station
+    - Tier 6 (Castle): shields (squires), gem keeper
+    - Tier 7 (Iron Keep): bomb, forge, iron walls
+- Cooldown: 30 seconds between upgrades (scales: tier * 10 seconds)
+- Add townCenterTier, townCenterCooldown to GameState in types.ts if Agent 1 hasn't
+- Town center HP: [0, 10, 20, 30, 50, 80, 120, 200] per tier
+- If town center HP reaches 0 from greed attack: game over
+
+TASK 2: PROPER 5-TIER WALL SYSTEM
+Modify wall.ts:
+- Currently has 3 wall types (WallWood, WallStone, WallIron). Expand to 5:
+  - Add StructureType.Spikes (or reuse existing, value = next available)
+  - Add StructureType.TallStone (value = next available)
+  - Update types.ts with new StructureType values
+- Wall tiers with proper stats:
+  | Tier | Type | Cost | HP | Requires |
+  |------|------|------|----|----------|
+  | 1 | Spikes | 1 | 25 | Nothing |
+  | 2 | WallWood | 3 | 50 | Nothing |
+  | 3 | WallStone | 6 | 200 | TownCenterTier >= 5 |
+  | 4 | TallStone | 9 | 300 | TownCenterTier >= 5 |
+  | 5 | WallIron | 12 | 400 | TownCenterTier >= 7 |
+- Upgrade path: each wall can be upgraded to next tier by dropping coins
+- upgradeWall(state, x): checks tier and requirements, upgrades in place
+- Add getWallTier(type): returns 1-5
+- Add getNextWallTier(type): returns next StructureType or null
+- Add getWallUpgradeCost(currentType): returns coin cost for next tier
+- Update isDefensiveStructure to include Spikes
+- Keep chain bonuses, auto-gates, tower conversion
+
+TASK 3: GEM CURRENCY SYSTEM
+Create systems/gems.ts (NEW FILE):
+- Add to GameState: gems: number (starts at 0), gemCapacity: number (default 10)
+- Gems are a secondary currency that persists across islands
+- Functions:
+  - addGems(state, amount): adds gems up to capacity
+  - spendGems(state, amount): returns true if enough, deducts
+  - getGems(state): returns current gem count
+- Gem sources:
+  - Portal destruction: dropGemsOnPortalDestruction(state, portalX)
+    - Small portal: 1-2 gems (random)
+    - Add gem drop to portal destruction in portal.ts
+  - Gem chests: found in ruins terrain (island 2+)
+    - Add GEM_CHEST positions to map generation (Agent 1's domain, but add the interface)
+- Gem uses (for now, just the storage system; hermits/mounts/statues use them later):
+  - Export canAffordGems(state, cost): boolean
+
+TASK 4: CATAPULT WEAPON
+Create structures/catapult.ts (NEW FILE):
+- Requires TownCenterTier >= 5 (Stone Fort) AND siege workshop
+- Cost: 6 coins to build
+- One catapult per side maximum
+- Placement: near outermost wall (within 5 tiles)
+- Mechanics:
+  - 1-2 builders operate it (auto-assigned when idle)
+  - Fires autonomously when loaded and greed in range
+  - Range: 15 tiles from catapult position
+  - Damage: 15 per shot, 3-tile AoE radius
+  - Reload time: 8 seconds (4 seconds with 2 builders)
+  - Can one-shot floaters
+- Fire barrels (future upgrade at Iron Keep): 5 coins each, continuous burn
+- Breeders can pick up and throw back boulders (future)
+- State tracking:
+  - catapults: Map<'left'|'right', CatapultData>
+  - CatapultData: { x, loaded, reloadTimer, builders: Entity[] }
+- Export: createCatapult, updateCatapults, assignBuilderToCatapult
+
+TASK 5: SEASONAL WAVE SPAWNING IN spawn.ts
+Modify spawn.ts for seasonal effects:
+- Import Season from types.ts
+- Winter: longer nights mean more time for greed to attack
+  - Multiply wave size by 1.3 in winter
+  - Shorter day = less prep time
+- Spring: normal waves
+- Summer: slightly smaller waves (0.9x multiplier, longer days for recovery)
+- Autumn: slightly larger waves (1.1x multiplier, warning of winter)
+- Blood moon timing: adjust to be ~2 days before season change
+  - Calculate next season change day, trigger blood moon 2 days before
+  - Keep the every-7-days as fallback
+
+TASK 6: BERRY BUSHES IN WINTER (resources.ts)
+Modify resources.ts:
+- In winter (Season.Winter), dynamically spawn berry bushes in forest zones
+- Berry bushes: harvestable by farmers, yield 1 coin per berry, 4 berries per bush
+- Spawn ~8-12 berry bushes across the map when winter starts
+- Remove them when winter ends
+- Export: spawnWinterBerries(state), clearWinterBerries(state)
+- Call these from the seasonal transition logic
+
+TASK 7: UPDATE construction.ts FOR TOWN CENTER
+- When monarch drops coin at town center position (CAMP_CENTER_X +/- 2):
+  - If canUpgradeTownCenter: trigger upgrade instead of wall build
+  - Show message: "Town Center upgraded to [TierName]!"
+- Add town center to findBestTask priorities (repair town center > repair walls)
+
+TASK 8: UPDATE portal.ts FOR GEM DROPS
+- When a portal is destroyed (in portal.ts or wherever destruction happens):
+  - Call dropGemsOnPortalDestruction from gems.ts
+  - Show message: "Portal destroyed! +N gems"
+- Gems are added directly to state.gems (no physical pickup needed for now)
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent3-phase7.txt
+++ b/kingdom/.agent3-phase7.txt
@@ -1,0 +1,172 @@
+Phase 7: Greed overhaul, bomb structure, lighthouse, forge, decay system, tower upgrades in wall.ts.
+
+Read KINGDOM_TODO.md, types.ts, greed.ts, combat.ts, wall.ts, portal.ts, construction.ts, spawn.ts first.
+
+You own: combat.ts, wall.ts, portal.ts, resources.ts, shrine.ts, ship.ts, siege.ts, spawn.ts, construction.ts, movement.ts, greed.ts
+
+TASK 1: GREED TYPE OVERHAUL IN greed.ts AND spawn.ts
+Upgrade all greed types to match Kingdom Two Crowns:
+
+Greedling (basic):
+- 1 HP (keep current)
+- Flee at sunrise: when timePhase === Day, all greedlings move toward nearest portal
+  - Speed: 0.8x normal speed when fleeing
+  - If they reach a portal, they vanish (remove entity)
+  - If sunrise catch: greedlings in open despawn with a puff (after 5 seconds of daylight)
+- Tool theft: when greedling kills a unit, that unit's tool drops
+  - Greedling picks up tool and carries it to portal (tool destroyed on portal entry)
+
+Masked Greedling:
+- 3 HP (was 2, increase to 3)
+- Front mask: first hit from the FRONT does 0 damage (mask absorbs)
+  - Track maskBroken: boolean per masked greedling
+  - Hits from behind bypass mask
+  - Tower archers bypass mask
+- More wall damage: 2x damage vs walls compared to basic greedling
+
+Floater:
+- 12 HP (was much less)
+- Does NOT steal coins. Does NOT interact with walls.
+- Abducts villagers: targets nearest non-monarch unit
+  - Grab animation: floater moves to unit, picks up (3 second grab time)
+  - Carries unit toward portal at half speed
+  - If floater killed while carrying: unit dropped at current position (alive)
+  - Abducted unit is removed if floater reaches portal
+- Roofed towers (towerTier >= 5): archers in roofed towers cannot be abducted
+- First appears: Blood Moon 3 (around day 15+)
+- Does NOT flee at sunrise (fights until dead)
+- Countered by: catapults (one-shot), heavy archer fire, pikemen
+- Add floaterTarget: Entity | null, isCarrying: boolean to floater state
+
+Breeder:
+- 70 HP (was 3, massive increase)
+- Punch attack: every 4 seconds, knocks down all units within 2 tiles
+  - Knocked units stunned for 1.5 seconds (can't attack/move)
+  - Units hit by punch drop their coins
+- Continuous spawning: spawns 2 greedlings every 6 seconds while alive
+  - Spawned greedlings are basic type
+  - Max 20 greedlings per breeder at a time
+- Does NOT flee at sunrise
+- First appears: around day 20+
+- Countered by: concentrated fire, catapults, bombs
+- Add breederSpawnTimer: number, breederPunchTimer: number
+
+Crown Stealer:
+- 8 HP (was 2)
+- Speed: 2.5x normal greed speed (faster than any mount)
+- Bypasses walls entirely (pathfinds around or over)
+- Bypasses coins, gems - ignores everything except monarch
+- On contact with monarch: instantly knocks crown off
+- Then picks up crown and runs to portal at 3x speed
+- If killed before reaching portal: crown drops, recoverable
+- First appears: day 30+ on blood moons, day 50+ on regular nights
+- Add hasCrown: boolean to crown stealer state
+
+TASK 2: BOMB STRUCTURE
+Create structures/bomb.ts (NEW FILE):
+- Requires Iron Keep (TownCenterTier >= 7) AND 18 coins
+- Build process: 3 builders required, takes 15 seconds to construct
+- Bomb is placed near town center
+- Bomb push sequence:
+  - 3 builders push bomb toward nearest active portal
+  - Movement speed: 0.3x normal (very slow)
+  - Knight escort required: at least 1 knight must accompany
+  - Without knight escort, builders stop pushing
+- Cave entry: 5 coins to enter cave portal
+- Cave interior:
+  - For now, simplified: bomb reaches portal, 5 coins to ignite
+  - 20 second escape timer starts
+  - After timer: portal destroyed permanently, all greed from that portal die
+  - Builders must escape (reach kingdom border before timer)
+  - Builders caught in blast are lost
+- State: bombBuilt, bombX, bombPushers: Entity[], bombEscapeTimer
+- Export: createBomb, updateBomb, startBombPush, igniteBomb, isBombActive
+
+TASK 3: LIGHTHOUSE STRUCTURE
+Create structures/lighthouse.ts (NEW FILE):
+- Found at island edge (x = 10 or x = MAP_WIDTH - 10)
+- 3 upgrade tiers:
+  - Wooden (6 coins): 10 days decay protection
+  - Stone (12 coins): 20 days decay protection
+  - Iron (18 coins): 30 days decay protection
+- Lighthouse state per island:
+  - lighthouseTier: 0-3 (0 = ruins/unbuilt)
+  - lighthouseX: number (position)
+- Functions:
+  - buildLighthouse(state, tier): upgrade to tier, deduct coins
+  - getLighthouseDecayProtection(state): returns days of protection
+  - canUpgradeLighthouse(state): checks coins and current tier
+- When monarch returns to an island:
+  - Without lighthouse: boat crashes, lose some coins
+  - With lighthouse: safe landing
+- Export: createLighthouse, upgradeLighthouse, getLighthouseDecayProtection, updateLighthouse
+
+TASK 4: FORGE STRUCTURE
+Create structures/forge.ts (NEW FILE):
+- Found on islands 3+ as ruins (forge ruin at fixed position, e.g., x = 400)
+- 8 coins to repair from ruins
+- Produces iron swords: 12 coins per sword
+  - Sword appears at forge position
+  - Squire walks to forge, picks up sword -> becomes Knight
+  - One sword produced at a time, 30-second production time
+- Requires TownCenterTier >= 7 (Iron Keep)
+- State: forgeBuilt: boolean, forgeX: number, forgeSwordReady: boolean, forgeSwordTimer: number
+- Export: buildForge, updateForge, isSwordReady, collectSword
+
+TASK 5: DECAY SYSTEM
+Create systems/decay.ts (NEW FILE):
+- Decay begins when monarch leaves an island (sails away)
+- Walls decay from outermost to innermost
+- Decay rates per wall tier:
+  - Spikes: 2 days
+  - Wood: 4 days
+  - Stone: 8 days
+  - TallStone: 12 days
+  - Iron: 20 days
+- Lighthouse adds protection days (additive)
+- When a wall decays: remove it, any units behind lose their tools (revert to vagrant)
+- Track per-island: lastVisitDay (set when monarch departs)
+- When monarch returns to island: apply accumulated decay
+  - daysAway = currentDay - lastVisitDay
+  - Remove walls that exceed their decay threshold
+- Completed islands (all portals destroyed) do NOT decay
+- Banker coins persist through decay
+- Gems never decay
+- Export: applyDecay(islandState, daysAway, lighthouseProtection), getDecayRate(wallType)
+
+TASK 6: TOWER UPGRADES IN wall.ts AND construction.ts
+- Towers are built on maxed-out walls (current behavior, keep it)
+- Add tower upgrade path in construction.ts:
+  - When monarch drops coin on existing tower: upgrade to next tier
+  - Cost from TOWER_COSTS array (defined by Agent 1 in types.ts)
+  - Requirements:
+    - Tier 3 (Stone Tower): TownCenterTier >= 5
+    - Tier 5 (Roofed): TownCenterTier >= 7
+  - Builder walks to tower and upgrades it (5 second build time)
+- Add upgradeTower(state, towerX) to construction.ts
+- Update findBestTask to include tower upgrades
+
+TASK 7: PORTAL ASSAULT IMPROVEMENTS IN portal.ts
+- When monarch drops coin at outermost wall banner:
+  - Dispatch nearest knight + their archer squad toward nearest portal
+  - Knight marches forward, archers follow behind
+  - Archers split fire between approaching greed and portal
+  - Portal takes damage: knight deals 2 DPS to portal, archers 1 DPS each
+  - Portal defense waves: portal spawns small groups (3-5 greed) every 10 seconds during assault
+  - Portal damage is permanent (does not regenerate between assaults)
+  - When portal HP reaches 0: portal destroyed, gem drop, retaliation wave
+- Add portalAssaultActive: boolean, assaultTargetPortal: number to state
+- Export: startPortalAssault(state, side), updatePortalAssault(state, dt)
+
+TASK 8: GREED SUNRISE FLEE IN movement.ts AND spawn.ts
+- At dawn (timePhase changes to Day):
+  - All greedlings and masked greedlings switch to flee mode
+  - Target: nearest portal position
+  - Speed: normal speed (they're in a hurry)
+  - On reaching portal: entity removed
+  - If no portal exists nearby (all destroyed): greedling despawns after 10 seconds
+- Breeders, floaters, crown stealers do NOT flee
+- Update movement.ts greed movement to check for flee state
+- In spawn.ts: stop spawning new greed during day phase
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent3-phase8.txt
+++ b/kingdom/.agent3-phase8.txt
@@ -1,0 +1,154 @@
+Phase 8: Tower conversions, farm upgrades, proper boat mechanics, cave portal, counter-attack support.
+
+Read KINGDOM_TODO.md, types.ts, wall.ts, construction.ts, ship.ts, portal.ts, siege.ts, spawn.ts first.
+
+You own: combat.ts, wall.ts, portal.ts, resources.ts, shrine.ts, ship.ts, siege.ts, spawn.ts, construction.ts, movement.ts, greed.ts
+
+TASK 1: SPECIAL TOWER CONVERSIONS IN wall.ts
+After hermit system is implemented (Agent 2), towers can be converted:
+- Add StructureType values for special towers:
+  - BallistaTower: 1 builder operates, fires piercing bolts (hits all greed in a line)
+    - Range: 20 tiles, Damage: 5, Reload: 4 seconds
+    - Cost: 6 coins to convert from existing tower (tier 3+)
+  - FireTower: 1 builder + 1 archer, fires burning projectiles
+    - Range: 15 tiles, Damage: 2/sec burn for 3 seconds, AoE 3 tiles
+    - Cost: 8 coins to convert
+  - BakeryTower: produces 7 bread loaves per day (dawn delivery)
+    - No combat capability, purely economic
+    - Cost: 6 coins to convert
+  - KnightTower: produces 1 shield per day (for squire recruitment)
+    - No combat capability
+    - Cost: 6 coins to convert
+  - BerserkerTower: produces 1 potion per day
+    - Potion: knight picks up for temporary 2x damage, 2x speed for 30 seconds
+    - Cost: 6 coins to convert
+- Tower conversion: hermit dropped at tower triggers conversion
+- Converted towers cannot be further upgraded (locked at conversion tier)
+- Export: convertTower(state, towerX, conversionType), getConvertedTowerOutput
+
+TASK 2: FARM UPGRADES IN construction.ts AND resources.ts
+Proper farm tier system:
+- Tier 1: Water Well / Basic Farm
+  - 5 coins to build at eligible stream position
+  - Up to 4 crop plots, 1 farmer assigned
+  - Harvest: 6 coins per plot (24 coins total per cycle)
+- Tier 2: Farmhouse (Mill House)
+  - 8 coins to upgrade from Tier 1
+  - Up to 6 crop plots, 2 farmers assignable
+  - Provides nighttime shelter for farmers (they stay at farm)
+  - Harvest: 6 coins per plot (36 coins total per cycle)
+- Tier 3: Blessed Farm (via Farmer Statue)
+  - +2 additional plots (8 total), +50% yield
+  - Only while Farmer Statue blessing is active
+- Max 3 farms per side (6 total)
+- Farm placement: only near water/stream tiles
+- Farm destruction by greed: reverts to wild land, farmer loses scythe
+- Add farmTier field to farm StructureData
+- Export: upgradeFarm(state, farmX), getFarmCapacity(tier), getFarmYield(tier, blessed)
+
+TASK 3: PROPER BOAT MECHANICS IN ship.ts
+Expand boat from simple transition to full mechanic:
+- Boat wreck found at island edge (x = 5 or x = MAP_WIDTH - 5)
+- Restoration process:
+  - 10 coins to begin restoration (initial repair)
+  - 59 hull pieces needed, 2 coins each (118 coins total)
+    - Island 1: all pieces free (tutorial), Island 2: 40 free
+  - Track hullPieces: number (0-59)
+  - Builders hammer pieces into place (1 builder per piece, 5 seconds each)
+  - Uninstalled hull pieces can be stolen by greedlings during night
+- Launch: 2 coins to launch boat into water
+- Dock sequence:
+  - Builders push vessel toward dock (0.5x speed, 2+ builders)
+  - Dock bell: 2 coins to summon 3 vagrants and 3 archers as crew
+- Departure: 10 coins to depart
+  - Dog and hermits auto-board
+  - Knight squads can be assigned as escort
+- Return trip: arriving at destination island
+  - If lighthouse exists: safe landing
+  - If no lighthouse: crash landing, lose 20% of coins
+- State: boatState: 'wreck' | 'restoring' | 'ready' | 'launched' | 'docked' | 'departed'
+- State: hullPieces, boatX, boatBuilders: Entity[], boardedEntities: Entity[]
+- Export: startBoatRestoration, addHullPiece, launchBoat, dockBoat, departBoat, boardEntity
+
+TASK 4: CAVE PORTAL SYSTEM IN portal.ts
+Add cave portal as special portal type:
+- Cave portal appears on islands 3+ (one per island)
+- Cave is the "Greed Nest" - source of all greed on the island
+- Cannot be destroyed by normal combat
+- Only destroyed by bomb (see bomb.ts from Phase 7)
+- Cave portal mechanics:
+  - Spawns greed at 2x rate of cliff portals
+  - During blood moon: spawns at 3x rate
+  - When all cliff portals destroyed: cave becomes sole spawner
+  - Cave has "hives" inside equal to island number (Island 3: 3 hives, Island 5: 5 hives)
+- Cave portal HP: 200 * islandIndex (Island 3: 600, Island 5: 1000)
+- When cave destroyed by bomb: ALL greed on island die immediately
+  - Island marked as "cleared" (no more greed spawn ever)
+  - Gem reward: 4-8 gems
+- Add PortalType enum: Cliff, Dock, Cave
+- Add portalType to portal data
+- Export: createCavePortal, isCavePortal, getCaveHiveCount
+
+TASK 5: PORTAL-TO-TELEPORTER CONVERSION IN portal.ts
+When a portal is destroyed:
+- Portal becomes a teleporter after 3 days
+- Teleporter connects to other teleporters on the same island
+- Monarch can use teleporter to fast-travel between destroyed portal locations
+- Cost: 2 coins per teleport
+- Add isTeleporter: boolean to portal data
+- Add teleporterReady: boolean (3-day timer after destruction)
+- When monarch stands on teleporter and presses 'e':
+  - Show list of other teleporter positions
+  - Monarch instantly moves to selected position
+- Export: convertToTeleporter, useTeleporter, getAvailableTeleporters
+
+TASK 6: IMPROVED COMBAT IN combat.ts
+- Piercing damage type for ballista (hits all enemies in a line):
+  - When ballista fires: check all greed at same y within range
+  - Deal damage to each one hit
+- Burn damage type for fire tower:
+  - On hit: apply burn status to greed (2 DPS for 3 seconds)
+  - Track burnTimer per greed entity
+- Pike thrust AoE for pikemen:
+  - Hits all greed within 1.5 tiles of pikeman
+  - Deals 3 damage per thrust
+  - 2 second cooldown between thrusts
+- Catapult AoE: verify Phase 7 catapult damage applies to all greed in radius
+- Mounted combat: monarch on bear can instakill 1 greed (8s cooldown)
+- Add DamageType enum: Normal, Piercing, Burn, AoE
+- Export: applyBurn, applyPiercing, applyAoE
+
+TASK 7: WAVE SCALING IMPROVEMENTS IN spawn.ts
+Proper wave difficulty formula:
+- Base wave size: floor(dayCount / 3) + 2
+- Island multiplier: [1.0, 1.25, 1.5, 1.75, 2.0]
+- Season multiplier: Spring 1.0, Summer 0.9, Autumn 1.1, Winter 1.3
+- Blood moon: 3x multiplier on top
+- Wave composition by day count:
+  - Day 1-5: greedlings only
+  - Day 6-10: greedlings + 1-2 masked
+  - Day 11-15: mixed + first floater
+  - Day 16-20: breeders start appearing
+  - Day 21-30: crown stealers on blood moons
+  - Day 30+: all types, increasing ratios of tough enemies
+- Spawn from multiple portals simultaneously (each contributes fraction of wave)
+- Waves timed to reach kingdom by midnight (spawn earlier for further portals)
+
+TASK 8: CONSTRUCTION PRIORITIES UPDATE
+Update construction.ts for new structures:
+- Add tower conversion to construction tasks
+- Add farm upgrade to construction tasks
+- Add boat restoration to construction tasks (hull pieces)
+- Priority order:
+  1. Repair town center (critical)
+  2. Repair damaged walls (structural)
+  3. Build queued walls/towers (expansion)
+  4. Upgrade town center (progression)
+  5. Upgrade towers (improvement)
+  6. Upgrade farms (economic)
+  7. Boat restoration (when active)
+  8. Cut trees (idle work)
+- Builder assignment: max 2 builders per task (prevent overcrowding)
+- Export: getConstructionPriority(taskType): number
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent3-phase9.txt
+++ b/kingdom/.agent3-phase9.txt
@@ -1,0 +1,174 @@
+Phase 9: Challenge islands, final wave tuning, siege improvements, comprehensive combat balance.
+
+Read KINGDOM_TODO.md, types.ts, spawn.ts, combat.ts, siege.ts, wall.ts, portal.ts, greed.ts first.
+
+You own: combat.ts, wall.ts, portal.ts, resources.ts, shrine.ts, ship.ts, siege.ts, spawn.ts, construction.ts, movement.ts, greed.ts
+
+TASK 1: CHALLENGE ISLANDS IN portal.ts AND spawn.ts
+Add 3 challenge islands (post-main-campaign):
+- Challenge islands unlocked after destroying all portals on Island 5
+
+Skull Island (Island 6):
+- Endless survival mode - no portals to destroy
+- Greed spawn from both edges of map, increasing every night
+- Hourglass statue: 10 coins to activate, freezes greed for 30 seconds
+- Score tracked: nights survived
+- Map: small (400 tiles), minimal resources
+- Victory: survive 30 nights = gold medal, 50 = diamond
+
+Dire Island (Island 7):
+- Same as Island 5 but 3x difficulty multiplier on all waves
+- All greed types from night 1
+- Limited vagrant camps (2 only)
+- No merchant, no banker
+- Victory: destroy all portals
+
+Plague Island (Island 8):
+- New enemy type: Plague Crawler
+  - Climbs over walls (doesn't need to fly)
+  - 4 HP, moderate speed
+  - On death: poisons adjacent units (1 DPS for 5 seconds)
+  - Add GreedType.PlagueCrawler
+- Poisoned units: track poisonTimer, take damage over time
+- Only cure: reach town center (removes poison)
+- Victory: destroy all portals + survive 10 nights after
+
+Export: isChallenge Island(index), getChallengeRules(index), getChallengeDifficulty(index)
+
+TASK 2: FINAL WAVE FORMULA IN spawn.ts
+Definitive wave scaling:
+- baseWaveSize = Math.floor(dayCount / 3) + 3
+- islandMultiplier = [1.0, 1.25, 1.5, 1.75, 2.0, 3.0, 5.0, 2.5] (8 islands)
+- seasonMultiplier = { Spring: 1.0, Summer: 0.85, Autumn: 1.15, Winter: 1.35 }
+- bloodMoonMultiplier = state.isBloodMoon ? 3.0 : 1.0
+- finalWaveSize = Math.floor(baseWaveSize * islandMultiplier * seasonMultiplier * bloodMoonMultiplier)
+
+Wave composition calculation:
+- greedlingRatio = max(0.3, 1.0 - dayCount * 0.01)
+- maskedRatio = min(0.3, dayCount * 0.005)
+- floaterRatio = dayCount > 15 ? min(0.15, (dayCount - 15) * 0.003) : 0
+- breederRatio = dayCount > 20 ? min(0.1, (dayCount - 20) * 0.002) : 0
+- crownStealerRatio = dayCount > 30 ? min(0.05, (dayCount - 30) * 0.001) : 0
+- Normalize ratios to sum to 1.0
+- Multiply each ratio by finalWaveSize for count per type
+
+Multi-portal spawning:
+- Total wave split across active portals proportionally
+- Closer portals get slightly more (weighted by inverse distance to town center)
+- Spawn timing: staggered so furthest portal spawns first (waves arrive together)
+
+TASK 3: SIEGE WEAPON IMPROVEMENTS IN siege.ts
+Finalize all siege weapons:
+
+Ballista (existing, improve):
+- Piercing damage: projectile hits ALL greed in its path (line)
+- Range: 25 tiles
+- Damage: 5 per hit
+- Reload: 3 seconds (2 with 2 builders)
+- 1-2 builders operate
+
+Catapult (from Phase 6, verify/improve):
+- AoE damage: 15 damage in 3-tile radius
+- Range: 20 tiles
+- Reload: 8 seconds (4 with 2 builders)
+- Can target: greedlings (group), floaters (one-shot), breeders (priority target)
+- Auto-target: prioritize breeders > floaters > largest group of greedlings
+- 1-2 builders operate
+
+Fire Barrel (catapult upgrade):
+- Requires Iron Keep tier
+- 5 coins per barrel
+- Replaces stone ammo with fire: adds 3-second burn to AoE
+- Continuous burn on ground (3x3 tiles) for 5 seconds after impact
+- Greed walking through fire patch take 2 DPS
+
+Export: updateSiegeWeapons(state, dt), getTargetPriority(greedEntities), fireBallista, fireCatapult
+
+TASK 4: WALL DAMAGE MECHANICS IN combat.ts AND wall.ts
+Differentiated wall damage per greed type:
+- Greedling: 1 damage per attack (1 attack/second)
+- Masked Greedling: 2 damage per attack (1 attack/second)
+- Breeder: 5 damage per punch (1 punch/4 seconds)
+- Crown Stealer: 0 damage (bypasses walls)
+- Floater: 0 damage (flies over)
+- Crusher: 10 damage per charge (1 charge/6 seconds, stuns self for 2 seconds after)
+
+Wall weakening:
+- At 50% HP: wall appearance changes (visual crack indicator)
+- At 25% HP: wall makes creaking sound (terminal bell)
+- At 0 HP: wall destroyed, greed pour through gap
+  - Units behind wall lose tools (revert to vagrant)
+  - Gap remains until new wall built
+
+Gate mechanics update:
+- Gates have 50% of wall HP at same tier
+- Gates can be locked at night (no friendlies pass either)
+- Locked gates take 50% less damage
+- Auto-lock at dusk, auto-unlock at dawn
+
+TASK 5: GREED PATHFINDING IMPROVEMENT IN movement.ts
+Better greed pathing:
+- Greedlings: walk toward town center, stop at first wall
+  - Stack at wall, attack it
+  - If wall destroyed: rush through gap toward next wall
+  - If no walls: rush toward town center
+- Masked: same as greedling but slightly faster
+- Floaters: fly in straight line toward nearest unit (not wall)
+  - If no unit in range: drift toward town center
+  - Height: 2 rows above ground (visual only, still in same combat layer)
+- Breeders: slow march toward outermost wall
+  - Stop and punch when in range
+  - Spawn greedlings while waiting
+  - If wall destroyed: advance to next wall
+- Crown Stealer: pathfind AROUND walls
+  - Check for gaps in wall line
+  - If no gaps: climb over (takes 2 seconds, vulnerable during climb)
+  - Beeline for monarch once past walls
+
+TASK 6: SHRINE IMPROVEMENTS IN shrine.ts
+Expand shrine system:
+- Currently basic shrine exists. Add multiple shrine types:
+  - Speed Shrine: +30% movement speed for 1 day (5 coins + 2 per previous use)
+  - Damage Shrine: +50% arrow damage for 1 day (5 coins + 2 per previous use)
+  - Shield Shrine: +30% wall HP for 2 days (8 coins + 3 per previous use)
+  - Spawn Shrine: spawn 3 archers immediately (10 coins, one-time per day)
+- Shrine locations: 2-3 per island, random from pool
+- Shrine cooldown: 1 day between uses
+- Shrine visual: different colors per type (blue/red/gray/green)
+- Export: getShrineType(x), activateShrine(state, shrineX), getShrineEffect(type)
+
+TASK 7: RESOURCE IMPROVEMENTS IN resources.ts
+- Gold vein depletion: each gold vein has finite coins (50 per vein)
+  - Track goldVeinRemaining: number per vein
+  - When depleted: vein becomes inert (dim visual)
+  - 3-5 gold veins per island
+- Berry bush improvements (winter):
+  - 4 berries per bush, 1 coin per berry
+  - Regrow after 2 days (if still winter)
+  - 8-12 bushes per island during winter
+- Tree resources:
+  - Trees drop 1 coin when cut by builder
+  - Trees block wall placement (must be cut first)
+  - Trees regrow slowly (1 per day in spring/summer)
+  - No regrowth in autumn/winter
+- Stream/water: fish can be caught by pikemen
+  - 1 coin per fish, 8-second fishing time
+  - Fish only in non-frozen streams (not winter)
+
+TASK 8: FINAL COMBAT BALANCE PASS
+Review and adjust all combat numbers:
+- Archer damage: 1 (ground), 2 (tower, bypasses mask)
+- Archer range: 10 (ground), 15 (tower tier 1), +5 per tower tier
+- Archer fire rate: 1.5 seconds (ground), 1.0 seconds (tower)
+- Archer accuracy: 33% (ground), 100% (tower), 100% (blessed)
+- Pike damage: 3 per thrust, 1.5 tile AoE
+- Pike fire rate: 2 seconds
+- Knight damage: 2 melee
+- Knight shield HP: 3 (regenerate 1/day)
+- Catapult: 15 damage, 3-tile AoE, 8s reload
+- Ballista: 5 damage, piercing, 3s reload
+- All greed HP as specified in Task 1 of Phase 7
+
+Verify all damage/HP values are consistent and balanced.
+
+Make sure everything typechecks when done.

--- a/kingdom/.agent3-prompt.txt
+++ b/kingdom/.agent3-prompt.txt
@@ -1,0 +1,36 @@
+You are Agent 3: Combat + Structures + Spawning. You are building a Kingdom-style side-scrolling TUI strategy game using blECSd 0.2.0. The project is at /home/kadajett/Dev/gameDev2026/blECSd-Examples/kingdom. Read types.ts first for all shared types/constants. Also look at the dvd-bounce and roguelike examples in sibling directories for blECSd API patterns.
+
+YOUR FILES ONLY (do NOT create or touch any other files):
+- entities/greed.ts
+- structures/wall.ts
+- structures/farm.ts
+- structures/portal.ts
+- structures/shrine.ts
+- systems/combat.ts
+- systems/construction.ts
+- systems/spawn.ts
+
+BLECSD API REFERENCE:
+- import { createWorld, addEntity, addComponent, removeEntity, Position, Velocity, setPosition, setVelocity, getPosition } from 'blecsd'
+- Direct array access: Position.x[eid], Velocity.x[eid]
+- Entity is a number type
+
+BUILD EACH FILE:
+
+1) entities/greed.ts - Export spawnGreed(state,x,type): create GreedData entity at given x, GROUND_Y-1. Types with stats: Basic(hp=1,speed=GREED_SPEED_BASE), Masked(hp=2,speed=GREED_SPEED_BASE), Floater(hp=1,speed=GREED_SPEED_FAST,flies over walls), Breeder(hp=3,speed=2,spawns mini greeds), CrownStealer(hp=2,speed=GREED_SPEED_FAST,targets monarch). Export updateGreed(state,greed,dt): move toward CAMP_CENTER_X. If wall in path, attack it. If no wall, continue to camp. If touches monarch with 0 coins, game over. Greeds steal coins on breach.
+
+2) structures/wall.ts - Export createWall(state,x,tier): add StructureData with hp based on tier (WALL_HP_WOOD/STONE/IRON). Export upgradeWall(state,x): wood->stone->iron, increase hp/maxHp. Export damageWall(state,x,dmg): reduce hp. If hp<=0, destroy wall (remove from state.structures). Export getOutermostWalls(state): return leftmost and rightmost wall x positions. Export getWallAt(state,x): find wall at position.
+
+3) structures/farm.ts - Export createFarm(state,x): add StructureData type=Farm at cleared land position. Export upgradeFarm(state,x): Farm->FarmIrrigated->FarmWindmill. Export getFarmOutput(farm): return coin yield based on tier (FARM_REWARD_BASE * level). Export getAvailableFarm(state): find farm needing workers.
+
+4) structures/portal.ts - Export createPortal(state,x): add StructureData type=Portal with PORTAL_HP. Export damagePortal(state,x,dmg): reduce hp. Export destroyPortal(state,x): remove portal, trigger retaliation wave flag. Export isPortalActive(state,x): check if portal exists and hp>0. Export getActivePortals(state): return all active portal positions.
+
+5) structures/shrine.ts - Export createShrine(state,x): add StructureData type=Shrine. Export activateShrine(state,x): costs SHRINE_COST coins, apply temporary buff. Track buff duration. Export ShrineBuffType enum (ArcherDamage, BuilderSpeed, WallDurability). Export getActiveBuff(state): return current buff or null.
+
+6) systems/combat.ts - Export updateCombat(state,dt): Process projectiles - move arrows, check collision with greeds (distance < 1 tile), apply ARROW_DAMAGE, remove arrow on hit. Process greed attacks - greeds adjacent to walls deal 1 damage per second. Handle greed-monarch collision: if monarch coins > 0, steal coins; if coins == 0, set phase to GameOver. Remove dead greeds (hp<=0) from state.greeds. Remove dead entities.
+
+7) systems/construction.ts - Export updateConstruction(state,dt): Find builders with aiState=Working. For each, reduce build timer on their target structure. When timer hits 0, mark structure as complete. Handle wall repairs similarly. Track build progress as percentage.
+
+8) systems/spawn.ts - Export updateSpawning(state,dt): Only spawn during Night. For each active portal, spawn wave. wave_size = 2 + state.dayCount * state.difficultyMultiplier. Blood moon every 7 days = 3x multiplier. Mix of greed types based on island: island 1 = basic only, island 2+ = add masked, island 3+ = add floaters, island 4+ = crown stealers. Spawn with random delay between greeds. Export isBloodMoon(dayCount): boolean.
+
+Each file exports functions taking (state: GameState, dt: number). Make sure everything typechecks against types.ts. Use Bundler module resolution (no .ts extensions on imports). Write all files now.

--- a/kingdom/.research-agent1-rendering.md
+++ b/kingdom/.research-agent1-rendering.md
@@ -1,0 +1,1341 @@
+# Kingdom: Two Crowns - Complete Visual & Rendering Reference
+
+This document is an exhaustive reference for all visual, UI, and rendering elements in Kingdom: Two Crowns, compiled from the Kingdom Wiki (kingdomthegame.fandom.com), Steam Community guides, developer interviews, and other sources. Intended for use as a reference when implementing accurate rendering in a terminal-based tribute game.
+
+---
+
+## Table of Contents
+
+1. [Art Style and Rendering Philosophy](#1-art-style-and-rendering-philosophy)
+2. [HUD and UI Elements](#2-hud-and-ui-elements)
+3. [Day/Night Cycle and Sky Transitions](#3-daynight-cycle-and-sky-transitions)
+4. [Seasons and Weather Effects](#4-seasons-and-weather-effects)
+5. [Blood Moon Events](#5-blood-moon-events)
+6. [Parallax Background and Camera](#6-parallax-background-and-camera)
+7. [Town Center / Castle Tiers](#7-town-center--castle-tiers)
+8. [Walls](#8-walls)
+9. [Towers](#9-towers)
+10. [Farms](#10-farms)
+11. [Special Structures](#11-special-structures)
+12. [Portals](#12-portals)
+13. [The Monarch](#13-the-monarch)
+14. [Mounts](#14-mounts)
+15. [Friendly NPCs and Subjects](#15-friendly-npcs-and-subjects)
+16. [The Greed (Enemies)](#16-the-greed-enemies)
+17. [Wildlife and Animals](#17-wildlife-and-animals)
+18. [Coins, Gems, and Economy Visuals](#18-coins-gems-and-economy-visuals)
+19. [Environmental Details](#19-environmental-details)
+20. [Special Effects](#20-special-effects)
+21. [Crown Visuals](#21-crown-visuals)
+22. [Title Screen and Menus](#22-title-screen-and-menus)
+23. [Game Over / Crown Loss Sequence](#23-game-over--crown-loss-sequence)
+24. [Island Map and Boat Travel](#24-island-map-and-boat-travel)
+25. [Statues](#25-statues)
+26. [Coat of Arms / Blazon System](#26-coat-of-arms--blazon-system)
+
+---
+
+## 1. Art Style and Rendering Philosophy
+
+### Overall Aesthetic
+- 2D side-scrolling perspective with modern pixel art
+- Described by creator Thomas van den Berg as having an "impressionist" quality, where the viewer fills in details with their imagination
+- Pixel sprites are composed of visible "little squares," each square formed by 3-8 pixels depending on zoom level
+- Shading uses big, chunky color clusters rather than individual pixel dithering
+- Background scenes combine forest hills and foreground trees into layered paintings
+- The art was inspired by retro graphics but without the hardware limitations of that era
+
+### Color Philosophy
+- Warm earth tones for daytime: greens, browns, golden yellows
+- Cool blues and purples for nighttime
+- Reds and crimsons for danger states (Blood Moon)
+- The game's signature palette (from color-hex.com/color-palette/103519):
+  - Deep Red: #9b1c31 (155, 28, 49)
+  - Royal Blue: #4169e1 (65, 105, 225)
+  - Gold: #ffd700 (255, 215, 0)
+  - Black: #000000 (0, 0, 0)
+  - White: #ffffff (255, 255, 255)
+
+### Technical Details
+- No fixed native resolution; the game scales to display resolution
+- Sprites scale in clusters rather than individual pixels
+- Two zoom levels available on most devices
+- Supports widescreen and ultrawide aspect ratios
+- Water features real-time reflections of the landscape above, described as "always-reflecting river"
+
+---
+
+## 2. HUD and UI Elements
+
+### Design Philosophy
+The game deliberately avoids numbers and explicit UI counters. The developer's stated goal was that players should not have "accurate counts of farms and banks and workers and greed." The result is an extremely minimalist HUD.
+
+### The Purse / Coin Pouch
+- **Position**: Displayed on/near the monarch character (not a fixed screen-corner element in the traditional sense)
+- **Empty state**: Small, flat, minimal pouch visible on the monarch
+- **Filling state**: The pouch visually grows as coins are added
+- **Full state**: Holds approximately 40 coins comfortably; the pouch appears visually stuffed
+- **Overflowing state**: Coins physically pile up on top of the pouch; coins picked up are "increasingly likely to slip off the overflowing pile" and bounce/fall off
+- **Coin colors inside**: Bronze, silver, and gold (purely cosmetic, all function identically)
+- **Gem display**: Gems appear inside the same pouch alongside coins; blue, green, and red gem colors (all function identically)
+- **Capacity**: Approximately 50 coins maximum (40 comfortable, 10 overflow)
+
+### Day Counter
+- Displayed in Roman numerals, not Arabic numbers
+- Appears briefly in the sky at the start of each new day (dawn)
+- Updates at midnight in Two Crowns
+- Also visible on the pause screen
+- On Blood Moon days, the day number displays with a reddish tint
+- After a Blood Moon, day counter appears with a blueish tint
+
+### Pause Screen Elements
+- Day counter
+- Island map showing structures and development across all visited islands
+- Coat of arms / blazon display
+- No explicit resource counters
+
+### What is NOT Shown
+- No coin counter number
+- No gem counter number
+- No stamina bar (stamina is indicated by mount behavior and particle effects)
+- No mini-map during gameplay
+- No health bars on structures (damage is shown through visual degradation)
+- No explicit wave/enemy counter
+
+---
+
+## 3. Day/Night Cycle and Sky Transitions
+
+### Cycle Duration
+A complete day-night cycle lasts approximately **4 real-life minutes**:
+- **Dawn to sunrise**: ~20 seconds
+- **Daytime**: ~2 minutes 45 seconds total
+- **Sunset to midnight**: Variable duration
+- **Nighttime**: ~1 minute 15 seconds
+
+### Dawn Phase (~20 seconds)
+- Sky transitions from deep dark blue/black to warm orange/pink at the horizon
+- The day number appears in Roman numerals in the sky
+- Horizon glows with warm golden light spreading upward
+- Stars fade out gradually
+- Long shadows stretch from right to left (sun rising on right)
+
+### Daytime Phase (~2:45)
+- Bright, warm sky with light blue tones
+- Sun visible as a bright golden disc tracking across the sky
+- Clouds may drift through the background layers
+- Full color saturation on all ground elements
+- Shadows are shortest at mid-day
+- Trees, grass, and structures are at full color vibrancy
+- Water reflections show bright sky colors
+
+### Dusk / Sunset Phase
+- Sky transitions from blue to deep orange, pink, and purple gradients
+- Sun descends toward the left horizon
+- Shadows lengthen dramatically from left to right
+- Orange and red hues wash over the landscape
+- The transition period serves as a warning: night is approaching
+- On Blood Moon days, the red dusk extends for a noticeably longer duration
+
+### Nighttime Phase (~1:15)
+- Deep blue/purple sky with occasional dark clouds
+- Moon rises (white/pale yellow disc)
+- Stars become visible as small bright dots
+- The ground is lit by cool blue moonlight
+- Structures with fire (town center, towers) emit warm orange glow pools
+- Greedlings' faces glow in the dark of night
+- Strong contrast between warm fire light and cool moonlight
+
+### Moon Phases
+- The moon appears as a standard crescent or full moon on normal nights
+- On Blood Moon nights, the moon acquires a distinct red hue
+- Moon position tracks across the sky similar to the sun
+
+---
+
+## 4. Seasons and Weather Effects
+
+Each season lasts **16 days**, completing a full cycle of 64 days. The cycle resets if the monarch loses their crown.
+
+### Spring (Days 1-16)
+- **Trees**: Full green foliage, vibrant leaf coverage
+- **Ground**: Lush green grass grows on plains; tall grass bushes spawn
+- **Wildlife**: Rabbits spawn from tall grass patches; deer appear in forests
+- **Sky**: Clear and bright, occasional rainfall
+- **Water**: Normal flowing river with reflections
+- **Overall tone**: Bright, lively, colorful
+
+### Summer (Days 17-32)
+- **Trees**: Maintained green foliage, peak vibrancy
+- **Ground**: Tall grasses generate frequently; maximum vegetation density
+- **Wildlife**: Most frequent wildlife spawns
+- **Sky**: Clear, no rain
+- **Water**: Normal appearance
+- **Overall tone**: Peak visual fertility, warmest color palette
+
+### Autumn (Days 33-48)
+- **Trees**: Leaves transition from green to red, orange, and brown
+- **Ground**: Cattails by the river turn red; grass begins to thin
+- **Wildlife**: Fewer animals spawning; gradual reduction
+- **Sky**: Slightly more muted palette
+- **Water**: Cattails along riverbanks turn reddish
+- **Overall tone**: Warning phase; the changing colors signal approaching winter
+- **Visual transition**: Serves as the primary visual indicator that winter is coming
+
+### Winter (Days 49-64)
+- **Trees**: All trees lose their leaves completely; bare branches visible
+- **Ground**: Snow falls and coats the ground; tall grass bushes freeze and disappear
+- **Wildlife**: Rabbits stop spawning; rabbit dens destroyed by frost; deer vanish
+- **River**: Water begins to freeze over; ice forms on the surface
+- **Sky**: Shorter days (sun rises later, sets earlier); more time spent in darkness
+- **Special**: Berry bushes appear as a winter-only food source
+- **Special**: Boar dens appear (single boar, winter exclusive)
+- **Overall tone**: Stark, barren, dangerous; limited color palette
+
+### Norse Lands Winter Specifics
+- Northern lights (aurora borealis) gradually become visible
+- Aurora appears nearly throughout entire nights during deep winter
+- Snow covers buildings as well as ground
+- Even shorter daylight hours than base game winter
+
+### Weather Effects
+
+#### Rain
+- Visible raindrops falling from sky
+- Darkened, cloudy sky during rain
+- Affects certain mount stamina recovery (mounts cannot recover stamina in rain)
+- Can occur during spring and autumn
+- Before Blood Moons, rain and stormy weather persist throughout the entire day
+
+#### Snow
+- White particles falling from sky during winter
+- Accumulates on ground, buildings, and trees
+- Ground color shifts from green/brown to white
+- Replaces rain in winter season
+
+#### Fog
+- Reduced visibility
+- Hazy atmospheric effect
+- Affects mount stamina recovery (sunlight-dependent mounts)
+
+#### Clouds
+- Drift across background layers
+- Darker/heavier clouds during storms
+- Pink/red clouds before Blood Moon events
+
+---
+
+## 5. Blood Moon Events
+
+### Pre-Event Warning Signs (Daytime)
+- **Morning**: The Roman numeral day counter displays in a reddish color
+- **Sunrise**: Sky is pinker and darker than usual from sunrise onward
+- **Daytime weather**: The entire day preceding a Blood Moon is usually stormy, rainy (snowy in winter), or heavily cloudy
+- **Dusk**: The red sunset extends for a noticeably longer time than normal; sky stays red far longer before transitioning to night
+
+### During the Blood Moon (Night)
+- **Sky**: Entire sky takes on a deep red/crimson hue
+- **Moon**: The moon itself acquires a blood-red color, distinctly different from the normal white/yellow moon
+- **Environment**: Red-tinted ambient lighting washes over the entire landscape
+- **Audio cue**: Sinister music begins playing exactly at sunset
+- **Timing**: Approximately 40 seconds after sunset music starts, it reaches midnight when the greed wave hits the Kingdom borders
+- **Dog behavior**: The dog howls instead of barking (unique Blood Moon indicator)
+
+### Visual Progression
+1. Pink-tinted morning sky
+2. Intensifying stormy weather throughout the day
+3. Extended red dusk phase (longer than normal sunset)
+4. Crimson night sky with red moon overhead
+5. Red ambient lighting on all ground elements
+6. Dawn returns to normal colors after the event
+
+---
+
+## 6. Parallax Background and Camera
+
+### Background Layer Structure
+The game uses multiple parallax scrolling layers creating depth:
+
+1. **Sky layer** (furthest back): Gradient sky colors, sun/moon, stars, clouds
+2. **Far mountain/hill layer**: Distant landforms, very slow parallax movement
+3. **Mid-background hills**: Rolling hills with forest silhouettes, moderate parallax
+4. **Near-background trees**: Tree canopies and forest detail, faster parallax
+5. **Gameplay layer**: Ground terrain, structures, characters, water (1:1 movement)
+6. **Foreground layer**: Occasional foreground elements (grass tips, tree branches) moving faster than camera
+
+### Camera Behavior
+- Camera follows the monarch horizontally as they walk/ride
+- The camera is centered on the monarch but with some lead space in the direction of movement
+- Camera may lock during certain events (cave explosion escape sequence)
+- Smooth, gentle camera motion; no sudden jumps during normal gameplay
+- The world scrolls left/right as a continuous side-scrolling landscape
+
+### Water Reflections
+- The river/water surface reflects the scene above it in real time
+- Reflections include sky colors, structures, trees, and characters
+- Slight ripple/wave distortion on reflected images
+- The river runs through the center-bottom of the gameplay area
+- Water color shifts with time of day (golden at sunset, cool blue at night, bright at midday)
+- In winter, ice forms on water surface, partially obscuring reflections
+
+---
+
+## 7. Town Center / Castle Tiers
+
+The central structure of the kingdom upgrades through 8 tiers (0-7). Each tier has a distinct visual appearance.
+
+### Tier 0: Unlit Campfire
+- **Appearance**: A simple stone fire pit with no flame, sitting on bare ground
+- **Cost**: Free (starting structure on each island)
+- **Visual features**: Just stones in a small circle, dark and cold
+- **Function**: Marks the center of the future kingdom
+
+### Tier 1: Lit Campfire
+- **Appearance**: The fire pit now has a burning flame
+- **Cost**: 3 coins (Two Crowns)
+- **Visual features**: Orange/yellow flickering fire with warm light cast on nearby ground
+- **Unlocks**: Hammer vendor (left of fire) and bow vendor (right of fire)
+- **Vendors appear as**: Small wooden posts/stands with the respective tool displayed
+
+### Tier 2: Camp with Tents
+- **Appearance**: Tents appear around the campfire, creating a small settlement
+- **Cost**: 6 coins
+- **Visual features**: Canvas/cloth tents flanking the fire, still relatively small
+- **Color**: Tents use the monarch's coat of arms colors
+
+### Tier 3: Wooden Village / Fortifications
+- **Appearance**: Wooden structures replace tents; wooden barriers/palisades erected
+- **Cost**: 9 coins
+- **Visual features**: Roughhewn wooden buildings, wooden log construction
+- **Bonus**: Free tier-1 spike walls built automatically on both sides
+- **Unlocks**: Scythe vendor (for creating farmers)
+
+### Tier 4: Town Hall / Church
+- **Appearance**: A church-like stone building rises at the center
+- **Cost**: 12 coins
+- **Visual features**: Taller stone building with possible steeple or peaked roof
+- **Unlocks**: The Banker NPC spawns automatically
+- **Notable**: This is where the kingdom starts looking like a proper settlement
+
+### Tier 5: Stone Fort / Fortifications
+- **Appearance**: Stone fortifications surrounding the town center
+- **Cost**: 15 coins
+- **Visual features**: Thick stone walls, masonry construction, medieval fort aesthetic
+- **Bonus**: Free tier-3 stone walls and tier-2 wooden watchtowers built on both sides
+- **Unlocks**: Stone-age technology for further wall/tower upgrades
+
+### Tier 6: Castle Keep
+- **Appearance**: A proper castle structure with towers and battlements
+- **Cost**: 18 coins
+- **Visual features**: Large castle building, crenellated walls, imposing stone construction
+- **Unlocks**: Shield purchases (shields hang on the castle facade as colored items)
+- **Shield display**: Shields visible hanging on the castle wall; when a squire takes one, a similarly colored banner replaces it
+- **Unlocks**: Gem bank
+
+### Tier 7: Iron Castle (Two Crowns exclusive)
+- **Appearance**: Iron-reinforced castle with metallic fortifications
+- **Cost**: 20 coins
+- **Visual features**: Dark metallic sheen on castle elements, iron plating visible
+- **Bonus**: Free iron walls on both sides; innermost towers upgraded to roofed triplet towers
+- **Unlocks**: Bomb banner for cliff portal destruction (banner visible on castle)
+- **Special**: The most visually imposing structure in the game
+
+---
+
+## 8. Walls
+
+Walls are built on stone piles found in the landscape. They progress through tiers with distinct visual appearances.
+
+### Tier 1: Spikes / Barricade
+- **Appearance**: Simple pointed wooden stakes driven into the ground
+- **Cost**: 1 coin to build, 1 coin to rebuild
+- **HP**: 25 base, 45 when blessed
+- **Visual**: Rough, sharpened wooden poles arranged outward
+- **Decay resistance**: 2 days
+
+### Tier 2: Palisade / Wood Wall
+- **Appearance**: A proper wooden fence/wall structure, log construction
+- **Cost**: 3 coins to build, 1 coin to rebuild
+- **HP**: 50 base, 90 blessed
+- **Visual**: Upright wooden logs lashed together, taller than spikes
+- **Decay resistance**: 4 days
+- **Requires**: Stone technology unlocked
+
+### Tier 3: Stone Wall
+- **Appearance**: Solid stone masonry construction
+- **Cost**: 6 coins to build, 2 coins to rebuild
+- **HP**: 200 base, 360 blessed
+- **Visual**: Cut stone blocks fitted together, substantial height increase
+- **Decay resistance**: 8 days
+
+### Tier 4: Tall Stone Wall
+- **Appearance**: Elevated stone fortification, taller and thicker
+- **Cost**: 9 coins to build, 4 coins to rebuild
+- **HP**: 300 base, 552 blessed
+- **Visual**: Taller stone wall with battlements, more imposing construction
+- **Decay resistance**: 12 days
+
+### Tier 5: Iron Wall (Two Crowns exclusive)
+- **Appearance**: Metal-reinforced fortification
+- **Cost**: 12 coins to build, 6 coins to rebuild
+- **HP**: 400 base, 736 blessed
+- **Visual**: Stone base with iron plating/reinforcement, metallic dark sheen
+- **Decay resistance**: 20 days
+- **Requires**: Iron technology unlocked
+
+### Norse Lands Wall Variants
+- Wood substitutes for stone/iron due to the setting's material scarcity
+- **Birch Wall** (replaces stone tier): Lighter wood, birch bark visible, notably weaker (half HP of stone counterpart)
+- **Pine Wall** (replaces iron tier): Darker wood, pine log construction, half HP of iron counterpart
+
+### Decay Visual States
+- Walls degrade visually over time when the monarch is away from the island
+- Fully decayed walls leave "stumps" on their spots, similar to structures demolished by the Greed
+- Progressive degradation shows cracks, missing sections, and weathering
+
+---
+
+## 9. Towers
+
+### Tier 1: Rock Platform / Raised Platform
+- **Appearance**: A low stone platform on a natural rock pile
+- **Cost**: 3 coins
+- **Capacity**: 1 archer
+- **Visual**: Simple flat stone surface barely above ground level
+- **Height**: Minimal elevation; archer has almost no height advantage
+
+### Tier 2: Wooden Watchtower
+- **Appearance**: A wooden tower structure with a small platform on top
+- **Cost**: 5 coins
+- **Capacity**: 1 archer
+- **Visual**: Wooden posts and crossbeams supporting an elevated platform
+- **Height**: Raises archer above ground level, increasing shooting range
+
+### Tier 3: Stone Tower / Defense Tower
+- **Appearance**: A stone-built tower with increased height
+- **Cost**: 7 coins
+- **Capacity**: 2 archers
+- **Visual**: Stone masonry tower, taller than watchtower, two visible positions
+- **Requires**: Stone technology
+
+### Tier 4: Triplet Tower / Castle Tower
+- **Appearance**: A tall tower with three archer positions at varying heights
+- **Cost**: 9 coins
+- **Capacity**: 3 archers
+- **Visual**: Multi-level stone tower; top-positioned archers can shoot over tall walls
+- **No roof**: Archers are exposed to floater attacks
+
+### Tier 5: Roofed Triplet Tower / Fortified Tower (Two Crowns exclusive)
+- **Appearance**: Same as triplet tower but with a protective roof structure
+- **Cost**: Varies (can be given free with Iron Castle upgrade)
+- **Capacity**: 3 archers
+- **Visual**: Stone tower with visible wooden/stone roof providing shelter
+- **Roof**: Protects archers from floater abduction attacks
+- **Key feature**: The roof is the primary visual distinction from tier 4
+
+### Tier 6: Quadruplet Tower / Iron Tower (Two Crowns exclusive)
+- **Appearance**: The largest tower type with four archer positions
+- **Cost**: Additional coins over tier 5
+- **Capacity**: 4 archers
+- **Visual**: Tallest tower structure with full roof coverage; iron reinforcement visible
+- **Height**: All archers elevated enough to shoot over any wall type
+- **Floater immunity**: Full roof protection
+
+### Hermit Tower Variants
+- **Ballista Tower**: Replaces archers with a single large crossbow weapon; operated by one builder; taller than standard towers; distinct mechanical crossbow mechanism visible
+- **Bakery Tower**: Converted archer tower that features a small bakery building on top; chimney may be visible; bread is produced here
+- **Knight/Warrior Tower**: Upgraded triplet tower that houses shield-wielding knights instead of archers
+
+---
+
+## 10. Farms
+
+### Farm Placement
+- Built near waterfalls/water features on the landscape
+- Appear as cleared plots of land between the town and the outer walls
+
+### Tier 1: Water Well Farm
+- **Appearance**: A simple well structure with surrounding crop plots
+- **Cost**: 3 coins
+- **Crop fields**: Supports up to 4 fields
+- **Visual states of crops**:
+  1. Clean/freshly plowed field (brown soil)
+  2. Small green sprouts emerging
+  3. Growing crops (taller green plants)
+  4. Mature golden crops ready for harvest
+  5. Harvested: crops disappear, replaced by coins on the ground
+- **Farmer behavior**: At tier 1, farmers retreat to the kingdom every evening and walk back every morning
+
+### Tier 2: Mill House Farm
+- **Appearance**: A small mill building replaces the water well
+- **Cost**: 8 coins
+- **Crop fields**: Supports up to 6 fields
+- **Visual**: A windmill or water-powered mill structure
+- **Farmer behavior**: Farmers stand idly by the farm at night (they stay rather than retreating)
+
+### Farm Seasonal Changes
+- **Spring/Summer/Autumn**: Active crop growth cycles, green and golden fields
+- **Winter**: Farms become dormant; no crops grow; fields appear empty/snow-covered
+- **Berry bushes** appear in winter as an alternative food source for farmers
+
+### Stable (Hermit Upgrade)
+- A mill house can be converted into a stable using the Stable Hermit
+- **Appearance**: Transforms from mill into a barn/stable structure where mounts can be stored
+- **Visual**: Distinct animal shelter design, different from the mill
+- **Cost**: 3 coins to switch mounts at the stable
+
+---
+
+## 11. Special Structures
+
+### Lighthouse
+- **Location**: Built at the far side dock on each island's cape
+- **Building process**: Instant construction (no workers needed); monarch pays at the dock's far end
+- **Tier progression**:
+  - **Wooden** (6 coins): Light wood frame construction with a lamp/flame at top
+  - **Stone** (12 additional coins): Reinforced stone structure, darker and sturdier
+  - **Iron** (18 additional coins): Metal-reinforced with iron plating, the most durable version
+- **Light effect**: The lighthouse emits visible light, serving as a beacon for safe ship arrival
+- **Decay**: Fully decayed lighthouse completely disappears, leaving no visible remnant
+- **Map icon**: Distinct icon on pause screen map that changes appearance by tier
+
+### Forge
+- **Appearance**: Generated inside an iron wall when one is constructed within the kingdom's territory
+- **Visual**: An anvil and forge fire visible within/near the iron wall structure
+- **Function**: Produces iron swords (12 coins each) that upgrade squires to knights
+- **Animation**: Sword appears on the forge when purchased; nearest squire retrieves it
+
+### Banker's Building
+- **Spawns**: Automatically when town center reaches tier 4 (church/town hall)
+- **Appearance**: The banker operates from within the tier 4+ town center building
+- **Banker NPC**: A distinct character who stands near the town center during daytime
+- **Night behavior**: Banker retreats inside the building, making stored money safe from greed
+- **Interest visual**: Banker produces 7% daily interest on stored coins (up to 8 coins/day)
+
+### Siege Workshop
+- **Location**: Near each outer wall (one per side in Two Crowns)
+- **Appearance**: A wooden workshop structure with mechanical elements
+- **In Classic/New Lands**: Single workshop on left side of town center with two halves
+- **Products**: Catapults and fire barrel ammunition
+
+### Catapult
+- **Appearance**: Medieval siege weapon; wooden frame with a throwing arm
+- **Position**: Near outer walls, pushed forward by builders
+- **Ammunition types**:
+  - **Boulder**: Large gray/brown rock projectile; disintegrates on impact with minor splash
+  - **Fire barrel**: Flaming projectile; 5 coins each; unlocked at castle keep tier
+- **Firing animation**: Arm swings forward, launching projectile in an arc
+- **Movement**: Builders push it; can only move in the forward direction (toward enemies)
+
+### Ballista
+- **Appearance**: Large crossbow-like weapon mounted on an upgraded triplet tower
+- **Visual**: Taller than standard towers; distinct mechanical crossbow mechanism
+- **Operation**: One builder operates it
+- **Projectile**: Large bolts that pierce through multiple enemies
+
+### Vagrant Camps
+- **Location**: In forests on both sides of the kingdom
+- **Appearance**: Small, rustic shelters or huts in the woods
+- **Population**: Hold up to 2 vagrants; spawn 1 new vagrant every 2 minutes
+- **Visual**: Simple stick/branch construction, fire pit may be nearby
+
+### Merchant Settlement
+- **Location**: In the forest
+- **Appearance**: A camp with choppable trees on each side
+- **Norse Lands variant**: Features Highland cattle instead of a donkey
+- **Call of Olympus variant**: Solid permanent building that persists even if surrounding trees are cut
+- **Visual**: A small woodland trading post with the merchant and pack animal
+
+### Gem Chests
+- **Location**: Found in forest ruins
+- **Appearance**: Small treasure chests that automatically open when the monarch walks past
+- **Contents**: 2-3 gems that spill out visually
+- **Interaction**: Running past keeps them closed; slowing down or stopping opens them
+
+### Coin Chests
+- **Location**: Various locations
+- **Appearance**: Similar to gem chests
+- **Contents**: Approximately 12 coins that scatter visually when opened
+
+---
+
+## 12. Portals
+
+### Small Portals
+- **Location**: Scattered throughout forests on both sides of the kingdom
+- **Appearance**: Stone arch/gateway structures
+- **Material**: Light grey stone construction
+- **Active state**: Filled with "swirling, pink and purple goo" that hums menacingly; the fluid churns visibly
+- **Inactive/Closed state**: No fluid inside; empty stone archway appears dormant
+- **Spawning animation**: Greedlings emerge from the swirling portal fluid, pushing through from the other side
+- **Under attack**: Portal activates and begins spawning defense waves; fluid churns more intensely
+- **Destroyed**: Stone archway crumbles; portal is permanently removed from the landscape
+
+### Cliff Portals
+- **Location**: On cliff faces at the edge of each island
+- **Appearance**: Larger portal set into a rock cliff face
+- **Function**: Provides access to the Greed cave
+- **Visual difference**: Larger than small portals; integrated into natural rock formation
+- **Destruction**: Permanently destroyed when the cave bomb detonates; cliff face remains but portal vanishes
+
+### Dock Portals (Living Portals)
+- **Location**: At docks on island edges
+- **Appearance**: Similar to small portals but with organic elements
+- **Unique feature**: Has "a tentacle for extra self defense"
+- **Visual**: More organic/living appearance compared to the stone portals
+- **Behavior**: Must be destroyed before building a lighthouse
+
+---
+
+## 13. The Monarch
+
+### Base Appearance
+- Small pixel art character wearing a crown
+- Monarch walks/runs on foot or rides a mount
+- Character design is relatively simple and small in the game world
+- Crown is the most prominent visual feature, sitting atop the character's head
+- Cape/dress color matches the first tincture of the coat of arms
+
+### Movement States
+- **Walking (unmounted)**: Slow walking animation, crown bobs gently
+- **Running (unmounted)**: Faster movement, more animated stride
+- **Mounted idle**: Sitting atop mount, gentle sway
+- **Mounted walking**: Mount walks with monarch sitting
+- **Mounted galloping**: Mount at full speed, stamina particles visible when momentum is ready
+- **Coin dropping**: Monarch reaches down, coin falls from pouch with a small arc
+
+### Crown Loss Sequence
+- When the monarch has zero coins and is hit by greed, the crown is knocked off
+- The crown physically flies off the monarch's head
+- The monarch becomes a "crownless" character (visually smaller/dimmer without the crown)
+- In co-op, the other player can rebuild the crown using coins
+- Losing the crown forces retreat to island 1
+
+### Ghost of Ancestor
+- **Appearance**: Ethereal, translucent spirit figure
+- **Animation**: Waves and beckons to guide the monarch, points to indicate direction
+- **Visual**: Ghostly/glowing appearance, mirrors the previous playthrough's monarch character
+- **When**: Appears at the start of each island
+
+### Dead Lands Monarchs
+- **Queen Miriam**: Blue clothes (player 1) or green clothes (player 2)
+- Four different monarchs available in the Dead Lands DLC, each with unique visual characteristics and abilities
+
+---
+
+## 14. Mounts
+
+All mounts share core visual states: standing still, walking, and galloping. Stamina is indicated by small luminous particles around the mount when momentum/stamina has reached maximum value.
+
+### Standard Horse
+- **Appearance**: Light brown equine, standard horse proportions
+- **Stamina recovery**: Grazes on grass patches (lowers head to eat animation)
+- **Special visual**: None, baseline mount
+
+### War Horse
+- **Appearance**: Battle-equipped horse with visible armor plating
+- **Stamina recovery**: Grazes on grass
+- **Special visual**: Armor glows when sprinting; nearby subjects (~20) receive a temporary defensive buff indicated by a visual glow effect on them
+- **Distinguishing feature**: Metallic armor clearly visible, larger/stockier than standard horse
+
+### Draft Horse
+- **Appearance**: Heavier, stockier horse build
+- **Stamina recovery**: Grazes on grass
+- **Visual**: Wider body, thicker legs than standard horse
+
+### Stag / Deer Mount
+- **Appearance**: Large deer with prominent antlers
+- **Color**: Brown/tan body with visible antler rack
+- **Speed**: Faster in forests than open grassland
+- **Stamina recovery**: Grazes on grass
+- **Special ability**: Attracts nearby deer to follow (automatic activation)
+
+### Griffin
+- **Appearance**: Mythical creature combining eagle (head, wings, front legs) and lion (body, hind legs, tail)
+- **Color**: Brown/gold feathers and fur
+- **Stamina recovery**: Can feed "anywhere" (unrestricted)
+- **Special visual**: Wings visible; flight-related ability with distinct airborne animation
+
+### Bear
+- **Appearance**: Large brown four-legged mammal
+- **Size**: Significantly larger than horse mounts
+- **Speed**: Faster in forests than open terrain
+- **Stamina recovery**: Grazes on grass
+- **Special visual**: Uses ability when sprinting (charging/swipe attack animation)
+
+### Unicorn
+- **Appearance**: White/light-colored horse with a single horn on forehead
+- **Color**: White/cream body, prominent spiral horn
+- **Speed**: Slower in forests than open grassland
+- **Stamina recovery**: Grazes on grass
+- **Special ability**: Automatic activation based on situation; coins may generate around grazing
+
+### Lizard
+- **Appearance**: Reptilian mount, lower to the ground than horse-type mounts
+- **Color**: Green/brown scales
+- **Stamina recovery**: Sunbathing mechanic (must stand in sunlight, unique among mounts)
+- **Special visual**: Distinct resting/basking pose when recovering stamina
+- **Limitation**: Cannot recover stamina at night, in forests, during rain, or fog
+
+### Norse Lands Mounts
+
+#### Fluffy Horse
+- **Appearance**: Standard horse with enhanced fur/shaggy coat
+- **Visual**: Thicker, warmer-looking fur suitable for Norse climate
+
+#### Day-Night Horse
+- **Appearance**: Horse that visually transforms between day and night states
+- **Visual**: Appearance changes with the time of day (lighter during day, darker at night)
+
+#### Water Horse (Kelpie)
+- **Appearance**: Aquatic-themed equine, water-associated visual elements
+- **Stamina recovery**: Can feed "anywhere" (unrestricted)
+
+#### Sleipnir
+- **Appearance**: Eight-legged horse from Norse mythology
+- **Visual**: Most distinctive feature is the eight visible legs during movement animation
+- **Stamina recovery**: Grazes on grass
+
+#### Norse Wolf
+- **Appearance**: Large canine/wolf mount
+- **Stamina recovery**: Howling at the moon (special howling animation, works only at night with moonlight)
+- **Special visual**: Moonlight howling animation is visually distinct
+
+#### Golden Boar (Gullinbursti)
+- **Appearance**: Golden-colored pig/boar mount
+- **Color**: Bright gold metallic sheen
+- **Stamina recovery**: Can feed "anywhere" (unrestricted)
+
+#### Cat Chariot (Freya's Cats)
+- **Appearance**: A chariot/cart pulled by feline creatures
+- **Visual**: Distinct from riding mounts; monarch sits in a vehicle
+- **Stamina recovery**: Can feed "anywhere" (unrestricted)
+
+---
+
+## 15. Friendly NPCs and Subjects
+
+### Vagrants / Beggars
+- **Appearance**: Tattered clothing, ragged appearance
+  - **Europe/Shogun**: Black clothing with visible holes
+  - **Dead Lands**: Ghostly, translucent figures
+  - **Norse Lands**: Blue clothing, carrying mead tankards
+  - **Call of Olympus**: White tunics with red hoods
+- **Size**: Same as other villager characters
+- **Behavior animations**:
+  - Idle: Walk around aimlessly, slow pace
+  - Running to coin: Sprint toward nearby dropped coins
+  - Frightened: Freeze in place, crouch down, cover their heads when monsters approach
+  - Resume: Return to normal behavior once danger passes
+- **Recruitment**: When given a coin, they transform into a villager and walk toward the town center (run if recruited at night)
+
+### Villagers / Peasants
+- **Appearance**: Plain robes of various colors; unarmed
+- **Coin capacity**: Hold up to 2 coins
+- **Behavior**: Wait near tool shops; can pick up hammer, bow, or scythe to become a worker, archer, or farmer respectively
+- **Visual distinction**: Unarmed and wearing simple clothing, clearly different from equipped subjects
+
+### Workers / Builders
+- **Tool**: Carry a visible hammer
+- **Coin capacity**: 2 coins
+- **Appearance**: Villager with a hammer tool visible in hand or on belt
+- **Behavior animations**:
+  - Building: Hammering/construction animation near structures
+  - Carrying: Walking with tools/materials
+  - Night patrol: Wander near outer walls
+  - Fleeing: Run away from greed; if hit, drop hammer and revert to peasant
+  - Pushing catapult: Lean forward pushing the siege weapon
+
+### Archers
+- **Tool**: Carry a visible bow
+- **Coin capacity**: 11 coins in Two Crowns
+- **Appearance**: Villager with a bow, slightly more alert posture
+- **Behavior animations**:
+  - Hunting: Walking through forests, stopping to aim and shoot at rabbits/deer
+  - Patrolling: Walking between outer walls and forest during daytime
+  - Defending: Standing behind walls at night, firing arrows at approaching greed
+  - Shooting: Draw bow, aim, release arrow (approximately 33% hit accuracy without bonuses)
+  - Retreating: Running back toward walls when overwhelmed
+  - Tower position: Standing on tower platforms at various heights
+- **Accuracy**: ~33% base hit rate; improved by Statue of Archery blessing
+
+### Farmers
+- **Tool**: Carry a visible scythe (or pitchfork in some settings)
+- **Coin capacity**: 14 coins
+- **Appearance**: Villager with agricultural tool
+- **Speed**: Slowest running speed among all subjects
+- **Behavior animations**:
+  - Plowing: Working the soil in crop fields
+  - Harvesting: Cutting crops, coins appear where crops were
+  - Foraging berries: Walking to berry bushes in winter, collecting coins
+  - Idle: Standing at town center or farm when not working
+  - Night: Standing idle at tier 2 farm, or retreating to kingdom from tier 1 farm
+- **Winter behavior**: In Two Crowns, farmers keep their scythes and wait for foraging orders
+
+### Pikemen
+- **Tool**: Carry a visible pike/spear
+- **Appearance**: Distinct from archers and workers due to longer weapon
+- **Behavior animations**:
+  - Day: Wander aimlessly; occasionally use spears to hunt fish in the river (even in winter)
+  - Night: Defend the furthest constructed wall, stabbing enemies as they attack
+  - Combat: Forward stabbing motion with pike
+- **Spear durability**: Weapons visually break after 2-4 uses
+
+### Ninjas (Shogun Setting)
+- **Appearance**: Two distinct visual modes:
+  - Daytime: Casual clothing for fishing activities
+  - Nighttime: Traditional ninja attire (dark clothing)
+- **Weapons**: Shurikens (thrown) and katana (melee slash)
+- **Visual transition**: Clothing change between day and night is a visual transformation
+
+### Squires (Shield Bearers)
+- **Appearance**: Carry a shield and wear lighter armor than knights
+- **Coin capacity**: 5 coins
+- **Color**: Pick colors randomly from the monarch's two coat of arms colors
+- **Banner/flag**: Each squire has a colored flag matching their chosen color combination
+- **Group**: Lead a squad of up to 4 archers
+- **Torn banner**: When defeated, their banner appears "torn to shreds"
+
+### Knights
+- **Appearance**: Full armor and helmet, carry sword and shield
+- **Coin capacity**: 11 coins (double the squire's health effectively)
+- **Visual distinction from squires**: More elaborate armor, sword instead of just shield
+- **Promotion visual**: Squire retrieves a sword from the forge, transforming into a knight with new equipment visible
+- **Shield display on castle**: Shields hang on the castle facade; when taken by a villager to become a squire, a colored banner replaces the shield on the wall
+
+### The Dog
+- **Appearance**: Small companion animal; sprite-sized
+- **Location found**: Stuck under a fallen tree in a forest; pay 1 coin/gem to break the tree and free the dog
+- **Behavior animations**:
+  - Following: Trots alongside the monarch
+  - Barking: Faces the direction of incoming greed, barking to warn
+  - Hiding: When greed gets close, hides behind the monarch while continuing to bark
+  - Howling: Unique howl animation before Blood Moon events (instead of barking)
+  - Boarding boat: Follows monarch onto the boat between islands
+
+### The Merchant
+- **Appearance**: A trader character with a pack animal
+  - Originally wore a turban; later updated to wear a cloak in a patch
+  - Travels with a donkey carrying bags/goods
+  - **Norse Lands variant**: Pack animal is a Highland cattle (horned breed)
+- **Behavior animations**:
+  - Arriving: Walks to the kingdom with loaded donkey/animal on day 1
+  - Trading: Drops 8 coins when the monarch approaches; waits for 1-coin payment
+  - Traveling: Walks to merchant's hut in the forest to restock, then returns
+  - Settlement: Stands to the right of the campfire when waiting
+- **Locations**: Islands 1 and 2 only
+- **Immunity**: Cannot be killed by greed
+
+### Hermits
+- **General appearance**: Short, diminutive characters living in forest cottages
+- **Cottage**: Each hermit type has a unique cottage design matching their personality
+- **Riding**: Hermits ride alongside/behind the monarch when carried
+- **Upgrade dance**: After upgrading a structure, the hermit hops off and dances around
+- **Cost to carry**: 1 coin to pick up a hermit
+- **Individual hermit appearances**:
+  - **Bakery Hermit**: Wears a pink chef's hat and apron
+  - **Ballista Hermit** (European): Crouched person with brown robe, green belt, and feathered coif
+  - **Stable Hermit** (European): Ginger-haired woman carrying a pouch of herbs
+  - **Stable Hermit** (Shogun): Small black-haired woman with bright pink clothing and bun hat
+  - **Warrior Hermit** (European): Old man with a long, white beard
+  - **Horn Hermit**: Unlocked on island 5 for 3 gems
+  - Some hermit clothing colors depend on the monarch's own colors
+
+### The Banker
+- **Appearance**: Distinguished NPC near the town center
+- **Day behavior**: Stands outside, accepts coins from the monarch
+- **Night behavior**: Retreats inside the building (visually disappears into the structure)
+- **Interest mechanic**: Produces up to 8 coins/day at 7% interest
+
+### The Ghost
+- **Appearance**: Ethereal, glowing spirit figure
+- **Function**: Appears at island starts to guide the monarch toward the kingdom
+- **Animations**: Waves to beckon, points to indicate direction, provides tutorial guidance
+
+---
+
+## 16. The Greed (Enemies)
+
+All Greed are described as "blueish grey, faceless creatures" in the game files. They are small anthropomorphic monsters.
+
+### Greedlings (Basic)
+- **Appearance**: Small, hunched, greyish-blue humanoid creatures without faces
+- **Size**: "Slightly larger and faster than villagers"
+- **Color**: Blueish-grey body
+- **Face**: Faceless (no visible eyes, nose, or mouth); in the dark, their "face" area glows faintly
+- **Behavior animations**:
+  - Running: Scamper toward the kingdom in groups
+  - Attacking: Charge into walls and subjects
+  - Stealing: Grab coins/tools and run back toward nearest portal
+  - Hit by arrow: One arrow kills; they dissipate/dissolve
+- **Game files**: Referred to as "trolls" in game data
+- **Night glow**: Faces glow in the dark of night (key visual identifier at night)
+
+### Masked / Armored Greedlings
+- **Appearance**: Same body as basic greedling but wearing protective headgear/mask
+- **HP**: 2-5 hit points (vs. 1 for basic)
+- **Visual distinction**: Visible mask or armor piece covering the head/face area
+- **Damage**: Deal significantly more damage to walls than basic greedlings
+- **Setting variants**: Mask design changes by biome:
+  - Europe: Standard medieval-style mask
+  - Shogun: Japanese-inspired mask
+  - Norse Lands: Viking-style helmet/mask
+  - Call of Olympus: Greek-style mask
+  - Dead Lands: Setting-appropriate mask
+- **Spawning**: Can be spawned by masked breeders (masked breeders create masked greedlings)
+
+### Floaters
+- **Appearance**: Flying, insect-like creature
+- **Movement**: Float/fly slowly through the air toward the center of the kingdom
+- **Color**: Legacy versions were described as "bloody red"; current version appears darker/greyer
+- **Pre-release**: Originally had bat-like wings
+- **Attack animation**: Swoop low toward townspeople, grab/lift subjects
+- **Carrying**: Can carry up to 2 villagers at once, flying back toward portals with victims visible underneath
+- **Persistence**: Unlike other greed, floaters ignore the return of daylight and continue attacking until killed or full
+- **Death**: When killed, captured villagers fall to the ground, lie prone briefly, then resume normal activity
+- **Counter**: Roofed towers (tier 5+) protect archers from floater abduction
+
+### Breeders
+- **Appearance**: Giant, bulky, imposing monster with a brownish-tan coloration and rounded, squat body
+- **Size**: Significantly larger than greedlings; the biggest standard enemy
+- **Movement**: Slow, lumbering, deliberate gait
+- **Attack animation**: Wide sweeping punch that generates significant impact
+- **Spawning animation**: "Vomiting action" that produces maskless greedlings (4 at a time)
+- **Burning**: When hit by fire barrels, engulfed in flames that intensify until the creature combusts
+- **HP**: Very high; requires many arrows or catapult hits to kill
+- **Breeder special**: Can catch and throw back catapult boulders
+- **Persistence**: Like floaters, breeders ignore the return of daylight
+
+### Masked / Armored Breeders
+- **Appearance**: Standard breeder wearing "a big mask" that varies by setting
+- **Visual**: Substantially bulkier and more heavily equipped than standard breeders
+- **Setting variants**: Each biome has a themed mask/armor design:
+  - Europe, Shogun, Dead Lands, Norse Lands, Call of Olympus each have unique designs
+- **Special**: Masked breeders spawn masked greedlings (not maskless ones)
+- **Occurrence**: Appear in very late Blood Moons, on Skull Island, and on Plague Island after certain day thresholds
+- **Crown Stealer transport**: Occasionally carry crown stealers on their backs
+
+### Crown Stealers
+- **Appearance**: Quadruped (four-legged) monster, distinctly different from bipedal greedlings
+- **Movement**: Run faster than any mount in the game
+- **Posture**: Low to the ground, running on all fours
+- **Attack**: Leap over walls to reach the monarch directly
+- **Leaping animation**: Jumps over walls with a distinct arc; short recovery time at the landing
+- **Crown theft**: Instantly knocks off the crown on contact, regardless of coin count
+- **Sound**: Produces an "eerie sound (reminiscent of a creaking noise)" audible across the entire island when spawning
+- **Transport**: Can ride on breeders' backs; dismount when approaching walls
+- **Occurrence**: Most common during Blood Moons after portal destruction; rare otherwise
+
+### Greed Nests (Cave Interior)
+- **Appearance**: "A purple tumorous octopus with its 'legs' stuck on the ground as if they were the immersing aerial roots of a mangrove plant"
+- **Color**: Purple/magenta organic mass
+- **Damage visual**: Progressively lose their appendages/legs as they take damage, until collapsing
+- **The Hive**: Located near the cave's end; described as "the heart of the cave"
+- **Spawning Pool**: Behind the hive; generates greedlings once the final nest is destroyed
+
+---
+
+## 17. Wildlife and Animals
+
+### Rabbits
+- **Appearance**: Small, white/brown animal
+- **Behavior**: Spawn periodically from tall grass patches; wander aimlessly
+- **Coin drop**: 1 coin when killed by an archer
+- **Season**: Only appear during warm seasons (spring/summer/early autumn); absent in winter
+- **Spawn location**: Tall grass patches on plains outside walls
+
+### Deer
+- **Appearance**: Brown/tan body with visible antlers (on males); graceful movement
+- **Health**: 3 HP (requires 2 archer hits to kill)
+- **Coin drop**: 3 coins when killed
+- **Behavior animations**:
+  - Idle: Random idle animations including turning head toward background, then toward the "camera" (as if looking at the player)
+  - Fleeing: Sprint away when the monarch or hunters get too close
+  - Herding: Can be slowly herded back toward the kingdom by sprinting past them
+- **Location**: Spawn periodically in the forest areas
+- **Stag interaction**: Follow the stag mount if the monarch rides one
+
+### Fish
+- **Appearance**: Small aquatic creatures in the river
+- **Availability**: Year-round in Two Crowns (exclusive to Two Crowns)
+- **Coin drop**: 1 coin when caught
+- **Interaction**: Pikemen/ninjas can fish for them from the riverbank
+
+### Boar
+- **Appearance**: Large, dark-colored pig/boar
+- **Health**: Approximately 20 HP (very tough)
+- **Coin drop**: 30-60 coins when killed (enormous reward)
+- **Season**: Winter only; spawns from a boar den
+- **Behavior**: Aggressive/defensive when approached
+
+### Birds
+- **Appearance**: White in color
+- **Behavior**: Perch on bushes; flee when approached
+- **Note**: Cannot be hunted (purely decorative)
+
+### Raccoons (Two Crowns variant)
+- **Location**: Plains
+- **Coin drop**: 1 coin when killed
+- **Season**: Warm seasons only
+
+### Chickens (Two Crowns variant)
+- **Location**: Plains
+- **Coin drop**: 1 coin when killed
+- **Season**: Warm seasons only
+
+---
+
+## 18. Coins, Gems, and Economy Visuals
+
+### Coins
+- **Appearance**: Small circular metallic tokens
+- **Color variants**: Bronze, silver, and gold (all function identically)
+- **Drop animation**: When dropped by the monarch, coins fall with a small arc/bounce, landing on the ground
+- **Ground state**: Coins sit on the ground briefly; they will vanish after a period (unlike gems)
+- **Pickup animation**: Monarch walks over coins; they fly up into the pouch
+- **Overflow**: When the pouch is overfull (~50 coins), excess coins physically fall off and can land in the water where they are permanently lost
+- **Payment animation**: When paying for structures, coins leave the pouch one by one, fitting into "coin slots" on the target structure
+- **Coin slots**: Displayed on structures as small circular receptacles; locked coin slots appear visually different (greyed out or marked)
+- **Worker/subject coins**: Subjects carry coins that are visible as small items on their person; more coins = more "health"
+
+### Gems
+- **Appearance**: Small faceted gemstones, larger/more distinct than coins
+- **Color variants**: Blue, green, and red (all function identically)
+- **Animated**: The gem sprite is animated (subtle sparkle/rotation)
+- **Permanence**: Unlike coins, gems never vanish from the ground
+- **Immunity**: Subjects will not pick up gems from the ground (only the monarch can)
+- **Drop order**: Monarch drops gems only after all coins in the pouch have been dropped
+- **Gem chests**: Found in forest ruins; appear as small ornate chests
+- **Stone coffer**: Banking container for gem storage; appears as a stone box/chest
+- **Gem slots**: Similar to coin slots but for gem-denominated purchases
+
+### Purse / Money Pouch Display
+- **Position**: Appears on/near the monarch character, visually part of their sprite
+- **Visual feedback**: The pouch fills and empties in real time
+  - Income: Coins physically arc into the pouch
+  - Spending: Coins individually disappear from the pouch
+  - Full: Pouch appears stuffed and rounded
+  - Overflowing: Coins visibly pile up on top, wobbling and at risk of falling off
+- **Dual currency**: Both coins and gems visible inside the same pouch as differently colored items
+
+---
+
+## 19. Environmental Details
+
+### Trees
+- **Forest trees**: Tall with full canopies, multiple green shading clusters
+- **Choppable trees**: Can be cut by builders; stump remains after cutting
+- **Seasonal changes**:
+  - Spring/Summer: Full green foliage
+  - Autumn: Leaves turn red, orange, and brown
+  - Winter: All leaves fall; bare branches visible as skeletal silhouettes
+- **Forest density**: Trees become denser further from the kingdom center
+- **Foreground trees**: Some tree elements appear in the foreground layer, partially obscuring gameplay
+
+### Grass
+- **Tall grass patches**: Spawn on open plains outside walls; source of rabbit spawning
+- **Short grass**: Ground cover throughout the kingdom area
+- **Seasonal behavior**: Tall grass freezes and disappears in winter
+- **Boundary function**: Walls halt the spread of grass; grass does not grow past walls
+
+### Water / River
+- **Position**: Runs through the center-bottom of each island's landscape
+- **Reflections**: Real-time reflections of sky, structures, trees, and characters
+- **Ripples**: Subtle wave/ripple distortion on reflected images
+- **Color changes**: Reflects sky colors (golden at sunset, blue at night, bright at midday)
+- **Cattails/reeds**: Grow along riverbanks; turn red in autumn
+- **Winter**: River partially freezes; floating ice chunks visible; reflections partially obscured
+- **Coins in water**: Overflowed coins that fall in water are permanently lost (visible splash)
+
+### Rocks / Stone Piles
+- **Appearance**: Natural rock outcroppings on the terrain
+- **Function**: Serve as foundations for walls and towers
+- **Visual**: Grey/brown stone piles of varying sizes scattered across the landscape
+
+### Ruins
+- **Appearance**: Crumbling stone structures in the forest
+- **Function**: Contain gem chests
+- **Visual**: Weathered, moss-covered stone architecture with visible decay and collapse
+
+### Ground Terrain
+- **Plains**: Flat green grassland between forest edges
+- **Forest floor**: Darker, earthen ground under tree canopy
+- **Snow cover**: White blanket over terrain in winter
+- **Cliff edges**: Rocky cliff faces at island boundaries
+
+### Flowers and Small Details
+- **Berry bushes**: Winter-only plants that appear as small shrubs with colored berries
+  - Regrow approximately 24 seconds after harvesting
+  - Drop 3-4 coins when foraged
+- **Small vegetation**: Ground-level plants and flowers in warm seasons
+
+---
+
+## 20. Special Effects
+
+### Particle Effects
+- **Stamina particles**: Small luminous/glowing particles around the mount when stamina is at maximum and momentum is ready
+- **War Horse glow**: Armor glows and nearby (~20) subjects receive a temporary glowing buff effect
+- **Statue blessing sparkles**: When the Statue of Scythe is active, all crop fields around farms have a sparkling effect
+- **Statue brazier flames**: Blue flames ignite on statue pillars when activated; slowly dim as blessing expires
+
+### Screen Effects
+- **Screen shake**: Occurs during cave bomb explosion; screen trembles/vibrates during detonation sequence
+- **Blood Moon tint**: Red color overlay on the entire screen during Blood Moon nights
+- **Day transition**: Smooth color gradient transitions across the sky during dawn and dusk
+
+### Glow Effects
+- **Greedling face glow**: Enemy faces glow in the dark of night (key nighttime visual)
+- **Crown glow**: The crown emits a subtle glow, making the monarch identifiable
+- **Fire glow**: Warm orange light pools around campfires, towers with lit braziers, and the town center
+- **Statue activation**: Lights on pillars next to statues slowly dim and fade when blessings expire
+- **Portal glow**: Active portals emit pink/purple light from the swirling fluid
+
+### Combat Effects
+- **Arrow flight**: Arrows arc through the air as small line projectiles
+- **Catapult boulder**: Large rock projectile arcing through the air; shatters on impact with splash
+- **Fire barrel**: Flaming projectile that ignites on impact; fire spreads briefly
+- **Breeder burning**: Flames engulf the creature progressively until it combusts
+- **Coin scatter**: When subjects or enemies are hit, coins scatter in small arcs
+
+### Structure Effects
+- **Construction**: Building animation with visual progress from foundation to completion
+- **Destruction**: Walls break apart, sections crumble; damaged structures show visible wear
+- **Decay**: Progressive visual deterioration when monarch is away; structures become weathered, cracked, and eventually collapse to stumps
+
+### Light and Shadow
+- **Dynamic lighting**: Light sources (fires, sun, moon) affect surrounding areas
+- **Sun shadows**: Cast by structures and trees, rotating with time of day
+- **Moonlight**: Cool blue ambient light at night
+- **Firelight**: Warm orange circles of light around fire sources
+- **Contrast**: Strong visual contrast between warm firelight zones and cool moonlit areas at night
+
+---
+
+## 21. Crown Visuals
+
+### The Crown
+- **Appearance**: A small golden crown sitting on the monarch's head
+- **Glow**: Emits a subtle golden glow, making the monarch stand out in the pixel art landscape
+- **Primary identifier**: The crown is the single most important visual element distinguishing the monarch from other characters
+- **Foil effect**: The crown has a slight metallic sheen/foil quality in its sprite
+
+### Crown on a Greedling
+- When a greedling successfully steals the crown, it is visible wearing the stolen crown as it runs back to a portal
+- The crown retains its appearance even on the enemy sprite
+
+### Crown Loss Animation
+- Crown physically flies/knocks off the monarch's head
+- Falls to the ground or is carried by the stealing enemy
+- Monarch's appearance immediately diminishes without the crown (less prominent, less glowing)
+
+---
+
+## 22. Title Screen and Menus
+
+### Title Screen
+- **Background**: Pixel art landscape scene with the game world visible
+- **Title text**: "KINGDOM Two Crowns" displayed in stylized pixel font
+- **Animation**: Gentle parallax movement in background layers; environmental animations (swaying trees, water reflections, drifting clouds)
+- **Atmosphere**: Peaceful, serene; emphasis on the game's beautiful environments
+- **Menu options**: Campaign selection, settings, and multiplayer options
+
+### Pause Menu
+- **Background**: The game world is visible but frozen/dimmed behind the menu
+- **Contents**: Day counter, island map with structure icons, coat of arms display
+- **Map**: Shows all visited islands with icons indicating lighthouse tier, portal states, and development level
+
+### Campaign/Setting Selection
+- **Options**: Europe (base), Shogun, Dead Lands, Norse Lands, Call of Olympus
+- **Visual**: Each setting has its own themed visual preview
+- **DLC indicators**: Premium DLC settings marked accordingly
+
+---
+
+## 23. Game Over / Crown Loss Sequence
+
+### Single Player Crown Loss
+- When the monarch has zero coins and is hit by any greed enemy:
+  1. Crown is knocked off the monarch's head (flies away visually)
+  2. Screen darkens / dramatic visual effect
+  3. Monarch becomes crownless, losing regal appearance
+  4. Player respawns as a new "heir" monarch on island 1
+  5. All day counters reset; all seasons reset
+  6. An additional decay equivalent to 100 days is applied to all previously unlocked islands
+  7. Gem-unlocked features remain accessible
+
+### Co-op Crown Loss
+- If one player loses their crown:
+  - That player becomes crownless but can still collect coins for the other player
+  - Cannot build or pay for structures
+  - The surviving player can rebuild the lost crown with coins
+- If both players lose their crowns: Full game over reset
+
+### Cave Escape Failure
+- If the monarch doesn't escape the cave explosion in time:
+  - A final quote displays: "No Crown, No King/Queen"
+  - Part of the Stats Board cutscene
+
+### Stats Board
+- **Appearance**: A brown panel/plaque
+- **Contents**: Shows statistics for the kingdom on the current island
+- **Trigger**: Appears as part of the cutscene when an island's cave is destroyed
+- **Visual**: Rustic, parchment-like panel with game stats
+
+---
+
+## 24. Island Map and Boat Travel
+
+### Island Structure
+- **Total islands**: 5 in standard campaign (6 in Norse Lands)
+- **Progression**: Only island 1 available at start; others unlock sequentially
+- **Layout**: Each island has similar geography but varies in size and difficulty
+  - Cliff portal on one side
+  - Town center in the middle
+  - Dock portals on both sea-side edges
+  - Progressively larger islands support more towers, walls, and farms
+
+### Boat / Ship
+- **Shipwreck state**: Found as a wrecked hull near a small wooden dock in the forest
+- **Repair cost**: 10 coins to spawn the ship frame from the wreck
+- **Construction**: Builders work to repair the boat over time
+- **Travel cost**: 10 coins to embark on a journey
+- **Setting sail**: Boat pushes off from dock with monarch and crew aboard
+- **Arrival**: Boat arrives at new island's dock; crew disembarks
+- **Safe arrival**: If lighthouse is built, boat arrives safely; otherwise the ship may wreck
+
+### Map Screen (Pause Menu)
+- **Display**: Shows all 5 (or 6) islands in a sequence
+- **Icons**: Each island displays:
+  - Lighthouse presence and tier
+  - Portal states
+  - Structure development level
+  - Decay indicators
+- **Locked islands**: Undiscovered islands may appear greyed out or locked
+- **Visual**: Old parchment/map aesthetic with island illustrations
+
+### Boat Travel Screen
+- **Visual**: The boat sailing between islands over water
+- **Destination selection**: After embarking, player chooses which island to travel to
+- **Crew visible**: Builders, soldiers, hermits, and the dog may be visible on the boat
+
+---
+
+## 25. Statues
+
+Statues are ancient stone shrines found in forests, one per island (on specific islands). They are surrounded by stone plinths with braziers.
+
+### General Statue Appearance
+- **Initial state**: Covered in moss, unlit braziers, recessed fire niches; weathered stone figure
+- **Unlocking cost**: 2-4 gems depending on type
+- **Activation cost**: Coins (varies by statue)
+- **Activated state**: Moss removed from surfaces; braziers light with blue flames; the stone figure gains a tool/weapon in its hands
+- **Blessing expiration**: Lights on the pillars slowly dim and fade as the blessing wears off
+
+### Statue of Archery (Island 1)
+- **Appearance**: Stone figure of an archer
+- **Activated visual**: May gain a bow in its hands
+- **Effect visual**: Archers gain "perfect aim" (increased accuracy, visible in more arrows hitting targets)
+- **Unlock cost**: Gems to unlock, coins to activate
+
+### Statue of Scythe / Farmer (Island 2)
+- **Appearance**: Stone figure; a scythe appears on the statue when activated
+- **Effect visual**: All crop fields around farms gain a sparkling/glowing effect during the blessing period
+- **Gameplay effect**: Increases farmer cap per farm by 2
+
+### Statue of Building (Island 3)
+- **Appearance**: Stone figure
+- **Unlock**: 3 gems; 9 coins to activate
+- **Effect visual**: Wall health increase (walls appear sturdier visually when blessed)
+
+### Statue of Knights (Island 4)
+- **Appearance**: Large stone figure raising a fist over her head
+- **Activated visual**: A wooden sword and shield appear in her hands when activated
+- **Effect**: Knights gain special military abilities during the blessing period
+
+---
+
+## 26. Coat of Arms / Blazon System
+
+### Display Locations
+- Pause menu escutcheon (shield shape)
+- Banner on the town center
+- Banners and shields throughout the kingdom
+- Squire and knight equipment colors
+
+### Customization Structure
+Three-component syntax: `[1st Tincture], [Ordinary] [2nd Tincture], [Charge] [3rd Tincture]`
+
+- **First tincture**: Primary color; appears on the monarch's cape and queen's dress
+- **Second tincture**: Modifies the ordinary (geometric pattern)
+- **Third tincture**: Modifies the charge (central animal/shape figure)
+
+### Available Tinctures (120 total)
+Colors organized by hue family:
+- **Metals/Neutrals**: Argent (silver), Or (gold), Sable (black), White, Black, various Grey shades
+- **Reds**: Gules, Red, Crimson, Scarlet, and red variations
+- **Blues**: Navy, Azure, RoyalBlue, MidnightBlue, DodgerBlue, and blue variations
+- **Greens**: Vert, Green, ForestGreen, LimeGreen, and green variations
+- **Purples**: Various purple and violet shades
+- **Oranges**: Orange and warm-tone variations
+- **Yellows**: Yellow, Gold, and warm variations
+- **Browns**: Various earth-tone shades
+
+### Ordinaries (Geometric Patterns)
+Vary by setting (Europe vs. Shogun vs. others):
+- Bordure, Saltire, Chevron, and others
+
+### Charges (Central Figures)
+Animals and shapes that vary by setting:
+- Europe: Various European heraldic animals
+- Shogun: Japanese-themed figures
+- Dead Lands: Setting-appropriate figures
+
+### Visual Effect on Kingdom
+- Squires randomly pick from the monarch's two colors
+- Banners, shields, and flags throughout the kingdom reflect the coat of arms
+- The color scheme is purely cosmetic with no gameplay impact
+
+---
+
+## Sources
+
+- [Kingdom Wiki (Fandom) - Town Center](https://kingdomthegame.fandom.com/wiki/Town_center)
+- [Kingdom Wiki (Fandom) - Wall](https://kingdomthegame.fandom.com/wiki/Wall)
+- [Kingdom Wiki (Fandom) - Archer Tower](https://kingdomthegame.fandom.com/wiki/Archer_tower)
+- [Kingdom Wiki (Fandom) - Blood Moon](https://kingdomthegame.fandom.com/wiki/Blood_Moon)
+- [Kingdom Wiki (Fandom) - Day](https://kingdomthegame.fandom.com/wiki/Day)
+- [Kingdom Wiki (Fandom) - Seasons](https://kingdomthegame.fandom.com/wiki/Seasons)
+- [Kingdom Wiki (Fandom) - Greedling](https://kingdomthegame.fandom.com/wiki/Greedling)
+- [Kingdom Wiki (Fandom) - Breeder](https://kingdomthegame.fandom.com/wiki/Breeder)
+- [Kingdom Wiki (Fandom) - Floater](https://kingdomthegame.fandom.com/wiki/Floater)
+- [Kingdom Wiki (Fandom) - Crown Stealer](https://kingdomthegame.fandom.com/wiki/Crown_stealer)
+- [Kingdom Wiki (Fandom) - Mounts](https://kingdomthegame.fandom.com/wiki/Mounts)
+- [Kingdom Wiki (Fandom) - Portal](https://kingdomthegame.fandom.com/wiki/Portal)
+- [Kingdom Wiki (Fandom) - Vagrant](https://kingdomthegame.fandom.com/wiki/Vagrant)
+- [Kingdom Wiki (Fandom) - Villager](https://kingdomthegame.fandom.com/wiki/Villager)
+- [Kingdom Wiki (Fandom) - Knight](https://kingdomthegame.fandom.com/wiki/Knight)
+- [Kingdom Wiki (Fandom) - Farm](https://kingdomthegame.fandom.com/wiki/Farm)
+- [Kingdom Wiki (Fandom) - Farmer](https://kingdomthegame.fandom.com/wiki/Farmer)
+- [Kingdom Wiki (Fandom) - Coin](https://kingdomthegame.fandom.com/wiki/Coin)
+- [Kingdom Wiki (Fandom) - Gem](https://kingdomthegame.fandom.com/wiki/Gem)
+- [Kingdom Wiki (Fandom) - Purse](https://kingdomthegame.fandom.com/wiki/Purse)
+- [Kingdom Wiki (Fandom) - Crown](https://kingdomthegame.fandom.com/wiki/Crown)
+- [Kingdom Wiki (Fandom) - Dog](https://kingdomthegame.fandom.com/wiki/Dog)
+- [Kingdom Wiki (Fandom) - Merchant](https://kingdomthegame.fandom.com/wiki/Merchant)
+- [Kingdom Wiki (Fandom) - Hermits](https://kingdomthegame.fandom.com/wiki/Hermits)
+- [Kingdom Wiki (Fandom) - Wildlife](https://kingdomthegame.fandom.com/wiki/Wildlife)
+- [Kingdom Wiki (Fandom) - Cave](https://kingdomthegame.fandom.com/wiki/Cave)
+- [Kingdom Wiki (Fandom) - Lighthouse](https://kingdomthegame.fandom.com/wiki/Lighthouse)
+- [Kingdom Wiki (Fandom) - Catapult](https://kingdomthegame.fandom.com/wiki/Catapult)
+- [Kingdom Wiki (Fandom) - Statues](https://kingdomthegame.fandom.com/wiki/Statues)
+- [Kingdom Wiki (Fandom) - Waves](https://kingdomthegame.fandom.com/wiki/Waves)
+- [Kingdom Wiki (Fandom) - Decay](https://kingdomthegame.fandom.com/wiki/Decay)
+- [Kingdom Wiki (Fandom) - Coat of Arms](https://kingdomthegame.fandom.com/wiki/Coat_of_arms)
+- [Kingdom Wiki (Fandom) - Islands in Two Crowns](https://kingdomthegame.fandom.com/wiki/Islands_in_Two_Crowns)
+- [Kingdom Wiki (Fandom) - Kingdom Two Crowns](https://kingdomthegame.fandom.com/wiki/Kingdom_Two_Crowns)
+- [Steam Community Guide - Complete Guide to Kingdom: Two Crowns](https://steamcommunity.com/sharedfiles/filedetails/?id=1588497381)
+- [Steam Community Guide - Complete Guide / Breakdown](https://steamcommunity.com/sharedfiles/filedetails/?id=1593999668)
+- [Game Developer - Kingdom Two Crowns Pixel Art Design Interview](https://www.gamedeveloper.com/design/-i-kingdom-two-crowns-i-and-the-practical-intersection-of-pixel-art-and-roguelike-design)
+- [TLDRLSS - Kingdom Two Crowns Beginner's Guide](https://game.tldrlss.com/en/article/2024/06/kingdom-two-crowns-intro/)
+- [Color-Hex - Kingdom Color Palette](https://www.color-hex.com/color-palette/103519)

--- a/kingdom/.research-agent2-entities.md
+++ b/kingdom/.research-agent2-entities.md
@@ -1,0 +1,1080 @@
+# Kingdom Two Crowns: Exhaustive Entity Research
+
+This document covers ALL entity types in Kingdom Two Crowns with complete behavioral details, costs, stats, and mechanics. Research sourced from the Kingdom Wiki (kingdomthegame.fandom.com), Steam community guides, and strategy resources.
+
+---
+
+## 1. Monarch
+
+### Overview
+The Monarch is the player character, the ruler of the kingdom. The Monarch cannot fight directly and interacts with the world exclusively by dropping coins and gems.
+
+### Movement
+- **On foot (no mount):** The Monarch walks left/right. Double-tapping the direction key or holding Shift allows running. Movement on foot is slow and dangerous.
+- **Mounted:** The Monarch rides a mount (always mounted; cannot voluntarily dismount except when switching mounts at a stable). Mounts have walk and gallop modes.
+- **Controls:** Left/right to move, down to drop coins/gems.
+
+### Coin Purse
+- **Comfortable capacity:** ~40 coins
+- **Overflow capacity:** ~50 coins (coins increasingly slip off and fall to the ground or into water)
+- **Gems and coins share the same purse.** Gems take more space, reducing effective coin capacity.
+- **Dropping priority:** Coins are dropped first. Gems only drop after all coins are gone.
+- **Island transfer:** Coins and gems are retained when traveling between islands in Two Crowns.
+
+### Crown Mechanics
+- **Hit with coins remaining:** Each hit from a greedling drops 1 coin from the purse.
+- **Hit with 0 coins and 0 gems:** The crown is knocked off the Monarch's head.
+- **Crown on the ground:** The Monarch can pick it back up if they reach it quickly.
+- **Crown stolen by Greed:** If a greedling carries the crown through a portal, it is lost.
+- **Crown stolen by Crown Stealer:** Crown Stealers bypass coins entirely and knock the crown off immediately regardless of coin count.
+- **No invulnerability frames:** The Monarch has no invincibility period after being hit.
+- **Crown loss (solo):** Game over for that Monarch. An heir spawns on Island 1 with all gem-unlocked content preserved. Seasons reset. 100 days of decay applied to all other islands.
+- **Crown loss (co-op):** The crownless Monarch loses the ability to spend coins. The other player can reforge a new crown for 8 coins.
+- **Both crowns lost (co-op):** Full game over.
+
+### Stamina (Mount-Based)
+- Stamina is a property of the mount, not the Monarch.
+- Galloping drains stamina. Walking slowly regenerates it. Standing still regenerates faster.
+- An exhausted mount breathes heavily and is limited to walking.
+- Forcing an exhausted mount to gallop causes it to rear up, briefly halting movement.
+- Mounts recharge stamina by grazing on grass (except lizard, which sunbathes, and griffin, which eats anywhere).
+
+---
+
+## 2. Mounts
+
+### General Mechanics
+- All mounts have walk speed, gallop speed, and stamina stats.
+- Mounts have different speeds on different terrains (open plains vs. forest).
+- Some mounts have special abilities that activate automatically or on player input.
+- Mounts recharge stamina by grazing on grass patches. Each grass patch is consumed and regrows over time.
+- **Switching mounts:** Requires the Stable Hermit upgrade. Any mount at a stable costs 3 coins to ride.
+
+### Standard Horse (Starter Mount)
+- **Location:** Starting mount on every island
+- **Cost to ride:** 3 coins (4 in Call of Olympus)
+- **Speed:** Average
+- **Stamina:** Average (~15 seconds of galloping; ~45 seconds with grazing bonus)
+- **Special ability:** None
+- **Terrain:** Slower in forests
+
+### Draft Horse (Two Crowns Upgrade)
+- **Location:** 3rd island
+- **Unlock cost:** 1 gem
+- **Cost to ride:** 3-4 coins
+- **Speed:** Slightly faster than standard horse
+- **Stamina:** Much more than standard horse
+- **Special ability:** None
+
+### Stag (Great Stag)
+- **Location:** 2nd island
+- **Unlock cost:** 1 gem
+- **Cost to ride:** 3 coins
+- **Speed:** Slow walk, very fast gallop in forests, comparable to black horse on open land. Slow in caves.
+- **Stamina:** Slightly above standard horse
+- **Special ability:** Deer Attraction. Nearby wild deer are charmed (harp sound + heart particles) and follow the Monarch. Charmed deer match the stag's speed. Charm breaks on damage but can be reapplied. In Two Crowns, deer do not need to complete a "looking around" animation first.
+- **Use case:** Herding deer toward archers for efficient hunting income.
+
+### Bear
+- **Location:** 4th island (forest den)
+- **Unlock cost:** 3 gems
+- **Cost to ride:** 8 coins
+- **Speed:** Above average walk; faster in forests
+- **Stamina:** Extremely low (but recovers quickly)
+- **Special ability:** Charge/Pounce Attack. When galloping, the bear pounces forward dealing 2 damage. Kills greedlings or wildlife in its path. In Two Crowns, uses a separate 3-hit pool (does not consume regular stamina). Hits multiple enemies in range simultaneously.
+- **Danger:** Mistimed attacks risk losing coins or the crown.
+
+### Lizard
+- **Location:** 4th island (Aztec-styled fountain area)
+- **Unlock cost:** 3 gems
+- **Cost to ride:** 10 coins
+- **Speed:** Above average walk and run
+- **Stamina:** Very low
+- **Special ability:** Fire Breathing. Spits fire onto the ground ahead, lasting 5 seconds. Burns greedlings on contact. Fire spreads between clustered enemies. Damages masked greedlings over multiple ticks. Significantly harms breeders and crown stealers. Does NOT damage structures, wildlife, or subjects (but immobilizes subjects caught in fire).
+- **Unique mechanic:** Sunbathing. Does not graze. Recharges stamina by standing in open sunlight (not forest/caves). Noon is optimal. Weather (fog, clouds, rain) reduces available sunbathing time from ~2.5 minutes to ~1 minute on bad days.
+
+### Griffin
+- **Location:** 1st island (crashes when first approached)
+- **Unlock cost:** 2 gems
+- **Cost to ride:** 8 coins
+- **Speed:** Fast in forest, fastest on plains
+- **Stamina:** Good
+- **Special ability:** Wing Flap. Spreads and flaps wings, pushing and momentarily paralyzing greedlings, breeders, and crown stealers within short distance. Push force increases with proximity.
+- **Unique mechanic:** Does NOT require grass to recharge stamina. Can graze anywhere, any season. Ideal for winter exploration and cave traversal.
+- **Appearance:** Changes color by setting (blue/white in Europe, red/black in Shogun).
+
+### Unicorn
+- **Location:** 5th island (deep forest, large blossoming tree with mushrooms, magic chiming sound)
+- **Unlock cost:** 4 gems
+- **Cost to ride:** 12 coins
+- **Speed:** Average (faster on plains)
+- **Stamina:** Average
+- **Special ability:** Coin Generation. Produces coins while grazing. In Two Crowns, generates coins after a flashing animation roughly every 45 seconds. Yields approximately 16 coins per full day-night cycle. Functions passively on grass.
+- **Visibility:** Mount is invisible until gems are paid at its special tree habitat.
+
+### Warhorse
+- **Location:** 3rd island (abandoned battlefield with fallen skeleton)
+- **Unlock cost:** 2 gems
+- **Cost to ride:** 8 coins
+- **Speed:** Second slowest mount when galloping (barely faster than lizard)
+- **Stamina:** Low (Two Crowns); High (New Lands)
+- **Special ability:** Defensive Buff. When activated (manual trigger in Two Crowns via ability button), grants temporary defense buff to ~20 nearby subjects (villagers, builders, farmers, archers, squires, knights). Activates roughly every 15 seconds, lasts ~12 seconds. Does NOT protect tower-stationed archers/builders against floaters.
+
+### Reindeer (Christmas Event)
+- **Location:** Any island during Christmas event period (plain with small Christmas cottage)
+- **Behavior:** Aesthetic variant of the Stag with same mechanics
+- **Special:** Required along with Santa clothes to control the Christmas sleigh
+- **Note:** A regular stag and reindeer can coexist on the same island
+
+### Norse Lands Mounts
+- **Fluffy Horse, Day-Night Horse, Sleipnir, Water Horse, Golden Boar, Norse Wolf** (each with unique Norse Lands abilities)
+
+### Dead Lands Mounts
+- **Chimera, Undead Horse, Arachne, Gamigin, Cerberus, Golem, Donkey, Beetle, Argos, Sea-horse, Pegasus**
+
+---
+
+## 3. Vagrants
+
+### Overview
+Vagrants are the only source of new subjects in the game. They are unaffiliated wanderers found at vagrant camps in the forest.
+
+### Spawn Mechanics
+- Spawn exclusively from vagrant camps located in forests
+- Each camp supports a maximum of 2 vagrants at a time
+- New vagrants spawn approximately every half day (~2 real-time minutes) after one is recruited
+- Camps require at least 1 tree on each side to persist (Shogun: 2 trees per side recommended)
+- Destroying forest around a camp removes it permanently
+
+### Recruitment
+- **Cost:** 1 coin (drop a coin near a vagrant)
+- **Alternative:** Bread from a bakery (costs 4 coins per loaf in Two Crowns). Vagrant eats bread and instantly becomes a villager.
+- Vagrants run toward dropped coins. If a coin lands directly on a cowering vagrant, they are still recruited.
+- Vagrants ignore gems.
+
+### Behavior
+- **Idle:** Slowly walk around aimlessly near their camp
+- **Coin detected:** Run toward the nearest dropped coin
+- **Nighttime:** Run (instead of walk) toward camps
+- **Greed nearby:** Freeze in place, crouch down, cover their heads. Resume normal behavior only after enemies move far away.
+- **Greed interaction:** Vagrants are completely ignored by the Greed. Enemies do not attack or interact with them.
+- **Post-recruitment:** Walk toward the town center. At night, they run instead.
+
+### Bread Recruitment (Bakery)
+- Bakery lures vagrants from camps toward the kingdom
+- Vagrants walk to the bakery table, eat bread, and instantly become villagers
+- Bakery holds up to 7 loaves at a time
+- Clever monarchs can recruit vagrants before they eat the bread, saving loaves
+
+### Edge Cases
+- Recruited citizens who lose all coins revert to vagrants and return to camps
+- In Two Crowns, extra vagrants arriving at full camps remain as unattached wanderers
+- Bread-converted villagers drop coins if damaged, even though they never received one
+
+---
+
+## 4. Builders
+
+### Overview
+Builders are the construction and labor workforce of the kingdom. They handle all building, upgrading, repairing, tree cutting, and siege equipment operation.
+
+### Recruitment
+- **Tool:** Hammer (from hammer vendor, unlocked at Campfire/Tier 1 town center)
+- **Hammer cost:** 3 coins each
+- **Vendor stock:** Up to 4 hammers at a time
+- **Coin capacity:** 2 coins for personal defense
+
+### Tasks (All Builder Duties)
+1. Building and upgrading structures (walls, towers, farms, town center)
+2. Repairing damaged walls
+3. Cutting down trees (produces coins: 1 coin per regular tree, more for large trees)
+4. Constructing teleportation portals on destroyed portal sites
+5. Operating catapults (1-2 builders per catapult)
+6. Operating ballista towers (1 builder per ballista)
+7. Building boats and pushing them to docks
+8. Rolling fire barrels to catapults
+9. Pushing bombs to cliff portals (up to 3 builders)
+10. Operating fire towers (1 builder per fire tower)
+
+### Behavioral AI
+- **Idle (Two Crowns):** March toward the nearest outer wall when no tasks are available
+- **Task priority:** Builders prioritize the most recently issued command
+- **Night behavior:** Builders execute assigned tasks regardless of time of day or danger. They do not retreat for safety.
+- **Repair behavior:** Automatically repair damaged walls during the day, unless Greed are still actively attacking the wall
+- **Morning routine:** Leave their catapult post to repair walls in the mornings
+- **Task cancellation:** Tasks cannot be cancelled once assigned, but new tasks can be queued
+
+### Combat Interaction
+- Builders are not combatants. They flee when attacked.
+- Each hit from Greed removes 1 coin. When all coins are gone, the next hit removes their hammer.
+- A builder who loses their hammer reverts to a villager.
+- Tools (hammers) dropped by builders can be stolen by greedlings.
+
+---
+
+## 5. Archers
+
+### Overview
+Archers are the primary military unit, serving as hunters during the day and defenders at night.
+
+### Recruitment
+- **Tool:** Bow (from bow vendor, unlocked at Campfire/Tier 1)
+- **Bow cost:** 2 coins each
+- **Vendor stock:** Up to 4 bows at a time
+- **Coin capacity:** 11 coins total (2 as villager + 9 as archer)
+
+### Daytime Behavior (Hunting)
+- Venture beyond outer walls into the forest to hunt rabbits and deer
+- In Two Crowns, archers penetrate much deeper into forests for extended hunting sessions
+- Archers usually avoid going deep into forest unless chasing deer
+- Archers stationed in towers do not hunt rabbits but will shoot nearby deer
+- Archers assigned to knight/squire companies do not hunt
+
+### Nighttime Behavior (Defense)
+- Reposition toward outer walls at sunset
+- Self-balance firepower: "Archers try to equalize firepower on each side"
+- In Two Crowns, physical space at walls limits how many can fire simultaneously
+- Fire at approaching Greed enemies
+
+### Tower Behavior
+- Archers stationed in towers gain increased range from elevation
+- Roofed towers (Tier 5-6) protect archers from floater abduction
+- Tower archers are still vulnerable to breeder-thrown boulders
+- Tower archers do NOT hunt small game but will shoot deer nearby
+
+### Target Selection
+- Archers fire at the nearest enemy in range
+- They split fire between killing incoming monsters and damaging portals during assaults
+- The Statue of Archery blessing grants "perfect aim" (never miss)
+
+### Combat Stats
+- **Damage:** 1 per arrow (standard)
+- **Range:** Increases significantly with tower height
+- **Rate of fire:** Approximately 1 arrow per second
+
+### Special Interactions
+- Archers may accidentally trigger portal defense waves while hunting near portals
+- Lost bows (from Greed attacks) can be stolen by greedlings
+- Archers losing all coins + bow revert to villagers
+
+---
+
+## 6. Farmers
+
+### Overview
+Farmers provide steady income through crop cultivation and winter foraging.
+
+### Recruitment
+- **Tool:** Scythe/Pitchfork (from field tool vendor, unlocked at Tier 3 wooden fortifications)
+- **Scythe cost:** 4 coins (Two Crowns)
+- **Coin capacity:** Similar to villagers
+
+### Farming Cycle
+1. Farmer walks to an unoccupied farm field near a waterfall/stream
+2. Plows and works the field during daytime
+3. Each farmer is assigned to exactly one field; no sharing
+4. Crops grow only when a farmer is actively working the field
+5. Harvest yields 4-6 coins per harvest (6 coins in Two Crowns)
+6. Harvest cycle takes just under one full day
+
+### Farm Structures
+- **Water Well (Basic):** Irrigates up to 4 crop plots
+- **Mill House (Upgraded):** Irrigates up to 6 crop plots
+- **With Statue of Scythe blessing:** +2 plots each (6 and 8 respectively)
+- Farms are built by builders on water streams in open land (plains)
+
+### Day/Night Behavior
+- **Daytime:** Work their assigned field
+- **Nighttime (no shelter):** Walk to the center of town
+- **Nighttime (with shelter):** Idle inside shelter
+
+### Seasonal Effects
+- **Spring/Summer/Autumn:** Normal farming operation
+- **Winter (Two Crowns):** Farmers retain their tools and switch to foraging instead of farming
+  - Berry bushes appear in groups of 4
+  - Each bush yields 3-4 coins per harvest
+  - Total per bush group: 12-16 coins
+  - Winter lasts 16 in-game days
+
+### Farm Placement
+- Fields cannot be created under walls, in forests, or on bridges
+- Farmers prioritize farms closer to town center
+- New plots auto-balance on both sides of the stream
+
+---
+
+## 7. Knights and Squires
+
+### Overview
+Knights and squires are squad leaders who command groups of archers for defense and offensive portal assaults.
+
+### Recruitment and Upgrade Path
+1. **Shield purchase:** Available at castle keep (Tier 6 town center)
+   - Cost: 4 coins per shield (Two Crowns)
+   - Up to 4 shields available (2 per side of castle)
+2. **Villager picks up shield:** Becomes a Squire
+3. **Squire upgrade to Knight:** Requires a sword from the forge
+   - Sword cost: 12 coins (Europe), 15 coins (Shogun)
+   - Forge unlocked at Iron Keep (Tier 7)
+
+### Squire vs. Knight Stats
+| Stat | Squire | Knight |
+|------|--------|--------|
+| Coins held | 5 | 11 |
+| Defense | Weak | Strong |
+| Can lead assaults | Yes | Yes |
+| Can block boulders | Limited | Yes (with enough coins) |
+
+### Company Structure
+- Each squire/knight leads exactly 4 archers as a military unit
+- They recruit free archers they pass until they have 4
+- Company colors match the kingdom's coat-of-arms tinctures
+
+### Defense Behavior
+- Guard the outermost walls on their assigned side
+- During combat, position themselves at the front of their squad
+- Block incoming greedlings, sometimes killing them immediately
+- Retreat in combat position (walking backward, facing the enemy) when overwhelmed
+- Resume forward position when threat subsides
+
+### Portal Assault Mechanics
+1. **Initiation:** Pay 4 coins at the attack banner
+2. **This sends one squad** (squire/knight + 4 archers) toward nearest portal on that side
+3. **Multiple squads:** Each additional squad costs another 4 coins
+4. **At the portal:** Squad leader stands in front, protecting archers while they shoot
+5. **Archers split fire:** Between incoming defense wave monsters and the portal itself
+6. **Portal damage is permanent:** Health does not regenerate
+
+### Defeat
+- When a squad leader loses all coins, they revert to a villager and drop their shield
+- Their banner appears torn, indicating defeat
+- A new shield must be purchased to restore the unit
+
+### Statue of Knights Blessing
+- Grants "combat mastery" in Two Crowns
+- Unlocked with 2 gems, activated with 8-coin offering
+
+### Bomb Escort
+- In Two Crowns, knights escort the bomb to cliff portals
+- Two squad leaders with their soldiers follow the bomb
+- Chosen "from the sea side first and then from the proximities of the bomb"
+
+---
+
+## 8. Pikemen
+
+### Overview
+Pikemen are melee defenders exclusive to the European/standard campaign. They defend walls at night and fish during the day.
+
+### Recruitment
+- **Tool:** Pike (from pike vendor, unlocked at stone/iron back walls)
+- **Pike cost:** 2 coins each
+- **Vendor stock:** Up to 4 pikes at a time
+- **Coin capacity:** 2 coins
+
+### Combat Formation
+- Up to 8 pikemen per wall, with up to 4 actively engaged at the wall's front
+- **Spear positioning by position:**
+  - 1st pikeman: Horizontal thrust through the wall (hits ground-level enemies)
+  - 2nd pikeman: Pike tilted at ~65 degrees upward (hits leaping enemies)
+  - 3rd pikeman: Pike at 90 degrees / vertical (targets crown stealers)
+  - 4th+ pikemen: Pike tilted backward at opposing angles
+- Pikeman thrusts deal area-of-effect damage, eliminating multiple greedlings simultaneously
+
+### Durability
+- Pike durability depends on creatures killed rather than thrust count
+- Dense enemy groups deplete weapons faster than sparse approaches
+- Pikes do not drop when broken; equipment simply vanishes after enough use
+- Pikemen revert to villagers when pikes break
+
+### Daytime Behavior (Fishing)
+- Fish using their pikes from dawn until dusk
+- Each fish sells for 1 coin
+- Fishing income "more than pays for one pike"
+- Fishing does NOT affect pike durability
+
+### Crown Stealer Counter
+- Pikemen are one of the best counters to crown stealers
+- The 2nd and 3rd pikemen (angled/vertical) specifically target leaping crown stealers
+- Crown stealers have a brief recovery period after each wall jump, during which pikemen can strike
+
+### Limitations
+- Cannot accompany the Monarch between islands
+- Remain bound to their recruitment side
+
+---
+
+## 9. Ninjas (Shogun DLC)
+
+### Overview
+Ninjas (shinobi) are temporary military and economic units exclusive to the Shogun campaign setting. They fish during the day and ambush Greed in bamboo at night.
+
+### Recruitment
+- **Facility:** Dojo (unlocked at stone fortifications tier)
+- **Cost:** 2 coins per ninja kit (fishing pole, shurikens, ninjato, and uniform)
+- **Vendor stock:** Up to 4 ninjatos on the weapon stand
+- **Coin capacity:** 2 coins
+
+### Daytime Behavior
+- Wander around town in casual clothing
+- Fish using fishing poles, catching fish worth 1 coin each
+- Fishing continues year-round, including winter
+
+### Nighttime Behavior (Stealth Ambush)
+- Hide in bamboo forests to ambush passing Greed
+- Use a katana for melee attacks and shurikens for low-range attacks
+- Operate ONLY on their trained side (do not cross town to defend the other side)
+
+### Equipment Durability
+- Ninjatos have limited durability
+- Once they've killed enough Greed or lose their weapons from being attacked, they disappear in a puff of smoke and reappear at the dojo as villagers
+
+### Special Abilities
+- **Plague Island immunity:** Ninjas do NOT get infected when attacked by greedlings (unique advantage over other units)
+- **Smoke escape:** If attacked in the woods outside the kingdom, ninjas vanish in a puff of smoke and reappear at the dojo
+
+---
+
+## 10. Animals / Wildlife
+
+### Rabbits (Small Game)
+- **Habitat:** Plains (tall grass/bushes outside walls)
+- **Health:** 1 HP
+- **Coin reward:** 1 coin per kill
+- **Behavior:** Wander aimlessly, do not react to being hunted
+- **Availability:** Warm seasons only (spring/summer/autumn); disappear in winter
+- **Spawn:** From rabbit dens in tall grass
+
+### Deer
+- **Habitat:** Forests
+- **Health:** 2-3 HP (depending on game version; 2 in Two Crowns)
+- **Coin reward:** 3 coins per kill (Two Crowns)
+- **Behavior:** Flee when hunted (run away from archers/Monarch)
+- **Availability:** Warm seasons only
+- **Population cap:** Maximum 7 deer per island
+- **Hunting difficulty:** Require multiple hits and flee, making them harder to hunt than rabbits
+- **Stag synergy:** The Stag mount's charm ability draws deer toward archers for efficient kills
+
+### Raccoons/Chickens (Setting Variants)
+- **Habitat:** Plains
+- **Health:** 1 HP
+- **Coin reward:** 1 coin each
+- **Behavior:** Same as rabbits (do not react to hunting)
+- **Note:** Setting-specific visual variants of small game
+
+### Fish
+- **Habitat:** Rivers
+- **Coin reward:** 1 coin per fish
+- **Availability:** Year-round (including winter)
+- **Caught by:** Pikemen (using pikes) and Ninjas (using fishing poles)
+- **Exclusive to:** Two Crowns
+
+### Boars
+- **Habitat:** Forests
+- **Health:** ~20 HP
+- **Coin reward:** 30-60 coins
+- **Availability:** Winter only
+- **Behavior:** Aggressive; charges at the Monarch
+- **Exclusive to:** Two Crowns
+- **Note:** Critical winter income source
+
+### General Wildlife Notes
+- Only free-roaming archers can hunt animals
+- Archers stationed in towers or accompanying knights ignore animals
+- All wildlife (except fish and boars) disappears during winter
+- Hunting income diminishes as kingdom expands and forests shrink
+
+---
+
+## 11. Hermits
+
+### General Mechanics
+- Found in old cottages deep in forests
+- **Hiring cost (Two Crowns):** Gems (varies by hermit type)
+- **Mounting cost:** 1 coin to ride on the Monarch's steed
+- Hermits ride behind the Monarch and enable special upgrades on specific structures
+- Once carried to a structure, the upgrade option appears
+- Only one hermit can ride with the Monarch at a time
+- If Greed kidnap a hermit, they must be re-rescued
+
+### Bakery Hermit
+- **Location:** 3rd island
+- **Unlock cost:** 4 gems
+- **Enables:** Upgrading triplet+ archer towers into bakeries
+- **Upgrade cost:** 15 coins (Two Crowns)
+- **Bakery function:** Produces bread loaves that lure vagrants toward the kingdom for remote recruitment. Each loaf costs 4 coins to purchase. Bakery holds up to 7 loaves.
+- **Appearance:** Baker with chef's hat (Europe), plague doctor (Dead Lands), brewer (Norse Lands)
+
+### Ballista Hermit (Hermit of Tide)
+- **Location:** 1st island
+- **Unlock cost:** 3 gems
+- **Enables:** Upgrading triplet+ towers into ballista towers
+- **Upgrade cost:** 15 coins (triplet) or 18 coins (quadruplet)
+- **Ballista mechanics:** See Catapults/Ballistas section below
+
+### Warrior Hermit (Hermit of Valor)
+- **Location:** 4th island
+- **Unlock cost:** 2 gems
+- **Enables:** Upgrading triplet+ towers into knight towers
+- **Upgrade cost:** 15 coins
+- **Knight tower function:** Provides an additional shield purchase point. Knights hired here guard the outermost walls on that side.
+
+### Stable Hermit
+- **Location:** 2nd island
+- **Unlock cost:** 1 gem
+- **Enables:** Converting a mill house (upgraded farm) into a stable
+- **Stable function:** Houses unused mounts, allowing the Monarch to switch between any unlocked mount for only 3 coins
+- **Appearance:** Ginger woman with herbs and pet bird (Europe)
+
+### Horn Hermit
+- **Location:** 5th island
+- **Unlock cost:** 3 gems
+- **Enables:** Converting tall stone walls or iron walls into rally walls
+- **Upgrade cost:** 12 coins (stone wall) or 16 coins (iron wall)
+- **Rally wall function:** A war horn is installed atop the wall. Paying 1 coin activates it, calling archers and knights from the other side to defend this wall for one night (until the morning bell). Paying 1 more coin sends reinforcements back early.
+- **Note:** Upgrading a rally wall tier does not remove the horn
+
+### Fire Tower Hermit
+- **Location:** 3rd island (Norse Lands)
+- **Unlock cost:** 3 gems
+- **Enables:** Upgrading tier 4+ archer towers into fire towers
+- **Upgrade cost:** 15 coins (tier 4) or 18 coins (tier 5-6)
+- **Fire tower function:** Builder throws flasks of flammable liquid; archer shoots flaming arrow. If arrow hits the liquid pool, it ignites, creating a fire patch. Deals 1 damage and sets greed on fire. Fire patches are roughly the size of the lizard's fire ability.
+- **Placement:** Best outside walls or at innermost wall edge to avoid obstruction
+- **Can shoot backwards** (unlike ballistas)
+
+### Catapult Hermit
+- Not a separate hermit; catapults are unlocked through town center progression
+
+### Berserker Hermit (Norse Lands Exclusive)
+- **Location:** 6th island (Norse Lands)
+- **Enables:** Berserker recruitment through potion vendor
+- See Berserkers section below
+
+---
+
+## 12. Dog Companion
+
+### Overview
+The dog is a non-combat intelligence companion that helps the Monarch predict enemy attack directions.
+
+### Acquisition
+- **Location:** Found trapped under a fallen tree in forest on the 2nd island
+- **Cost:** 1 coin or gem (dropped on the tree to break it and free the dog)
+- **Note:** The coin/gem is returned upon freeing
+- **Persistence:** Follows the Monarch between islands by boarding the boat
+
+### Behavior and Warnings
+- **Stares** toward portals as they open
+- **Barks** in the direction of incoming monsters
+- **Hides** behind the Monarch when Greed approach closely
+- **Directional intel:** On regular nights with two-sided attacks, barks toward one direction first, then turns to bark toward the other
+- **Blood Moon warning:** Howls at dusk instead of barking before Blood Moon waves
+- This is "especially useful just before one-sided waves" and the only reliable way to detect counterattack wave direction
+
+### Kidnapping and Rescue
+- Greedlings can abduct the dog by dragging it into portals
+- **Prevention:** Drop coins to distract enemies, use fast mounts to outrun portal triggers
+- **Rescue methods (Two Crowns):**
+  1. Kill the greedling before it crosses the portal
+  2. Lose your crown and free a new dog on the 2nd island
+  3. Destroy the cave with a bomb to recover the stolen dog
+
+### Limitations
+- Only one dog can accompany the Monarch at a time
+- Freeing a new dog causes the old one to disappear permanently
+- Does not engage in combat
+
+---
+
+## 13. Merchant
+
+### Overview
+A traveling trader who provides reliable early-game income through an investment model.
+
+### Two Crowns Mechanics
+- **Location:** Forest settlement (available only on islands 1-2)
+- **Investment:** Give 1 coin to the Merchant
+- **Return:** 8 coins (7 coins profit per trip)
+- **Payout timing:** Anytime in Two Crowns (not restricted to dawn)
+- **Collection:** Offers earnings only when the Monarch comes close and slows down
+- **Availability:** Accepts payment during daytime only, when portals are safe
+
+### Special Properties
+- Neither the Merchant nor his pack animal are attacked by the Greed
+- In Norse Lands, the pack animal is Highland cattle
+- The merchant settlement includes two trees; cutting them removes the camp permanently
+- Reliable but limited income source (only 2 islands)
+
+---
+
+## 14. Banker
+
+### Overview
+The Banker operates from the town hall, providing coin storage with daily interest.
+
+### Access
+- **Location:** Town hall (Tier 4 town center)
+- **Operating hours:** Dawn to sunset (approximately 2 minutes 45 seconds real time)
+- **Restrictions:** Does not emerge during greed waves or counterattack waves
+
+### Deposit System
+- Players can deposit coins incrementally
+- Amounts under 10 coins are held but not visibly stored
+- At 10 coins, the Banker walks to the castle to deposit them visually
+- No hard cap on total storage
+
+### Withdrawal Mechanics
+- Minimum 7 coins required in bank to withdraw
+- Receives whichever is smaller: 1/3 of stored coins or a full pouch
+- As of the Conquest Update, depositing no longer locks withdrawals for the day
+
+### Interest Rates
+| Coins Stored | Daily Interest |
+|-------------|---------------|
+| 0-2 | 0% |
+| 3-100 | 7% daily (rounded up) |
+| 101+ | Flat 8 coins daily |
+
+- At 100+ coins, the Monarch can refill their purse completely every 5 days on interest alone
+
+### Island Persistence
+- Two Crowns preserves stored funds across islands
+- Funds transfer to heir successors
+
+---
+
+## 15. Greed Enemies
+
+### General Behavior
+- All Greed spawn from portals at night
+- Wave strength scales with the overall day count
+- Enemies attack walls, steal coins/tools, and abduct subjects
+- At sunrise, most Greed retreat toward the nearest portal (except floaters and crown stealers)
+- Dropped coins and gems on the ground distract most Greed types (except floaters and crown stealers)
+
+### Greedlings (Basic)
+- **Health:** 1 HP
+- **Speed:** Slightly larger and faster than villagers, but cannot outrun a mounted Monarch
+- **Attack rate:** ~1 attack per second
+- **Attack behavior:**
+  - Against Monarch: Each hit drops 1 coin
+  - Against subjects: Removes items in priority order:
+    1. Warhorse protective aura
+    2. Extra defense coins
+    3. Tools/weapons (hammers, scythes, bows DROP and can be stolen; shields, swords, pikes, ninjatos VANISH)
+    4. Final coin (subject reverts to vagrant)
+- **Stealing:** Steal hammers, scythes, bows, coins, gems (gems only in Two Crowns), ship parts, dogs, hermits, and crowns
+- **Retreat:** At sunrise or after grabbing items, run toward nearest portal. During retreat, bypass obstacles without damage but still collect items encountered.
+- **Wall damage:** 1 HP damage per charge attack
+
+### Masked Greedlings
+- **Variants by mask count:**
+  - 1 mask: 2 HP (1 extra arrow)
+  - 2 masks: 3 HP (2 extra arrows)
+  - 3 masks: 5 HP (4 extra arrows)
+- **Behavior:** Same as regular greedlings but significantly more durable
+- **Wall damage:** Higher damage to walls than regular greedlings in Two Crowns
+- **Appearance:** Begin appearing in later nights as difficulty scales
+
+### Floaters
+- **Health:** 12 HP
+- **Type:** Flying insect-like monster
+- **Capacity:** Abducts up to 2 villagers per trip
+- **Speed:** Fly slowly toward center of kingdom
+- **Behavior:**
+  - Fly toward kingdom center until targeting a subject
+  - Swoop low to capture villagers
+  - Return to nearest portal after capturing 2 subjects or reaching the castle
+  - **Prioritize archers in towers** as abduction targets
+  - **Ignore coins and tools entirely** (cannot be distracted)
+  - **Ignore sunrise:** Continue attacking until killed or fully loaded, even after dawn
+  - **Bypass walls:** Walls do not slow or block floaters
+- **Rescue:** Captured villagers are rescued if the floater dies before reaching a portal (they fall prone, then resume normal activity)
+- **First appearance:** During the 3rd Blood Moon
+- **Defense:**
+  - Roofed towers (Tier 5-6) protect archers from abduction
+  - Catapults can kill floaters in one hit
+  - Ballista towers deal serious damage
+  - Heavy archer fire is the most common defense
+
+### Breeders
+- **Health:** ~70 HP
+- **Damage:** ~20 per punch
+- **Attacks:**
+  1. **Punch:** Knocks down groups of subjects with a single blow, disarming them. Steals substantial gold from the Monarch.
+  2. **Boulder throw:** Retrieves discarded catapult projectiles and hurls them at walls/soldiers. Area damage (up to 5 targets). Can dislodge archers from towers.
+  3. **Greedling spawning:** Regularly vomits unmasked greedlings. In Two Crowns, summoned greedlings retreat at sunrise.
+- **Mount fear:** Mounts rear up in panic when the Monarch tries to ride past a breeder, creating dangerous vulnerability windows
+- **Armored variant (late-game Two Crowns):**
+  - Spawns masked greedlings instead of regular ones
+  - Requires significantly more damage to defeat
+  - Deals increased wall damage
+- **Retreat:** In Two Crowns, breeders retreat at dawn
+- **Vulnerability:** Fire persists on breeders and does not extinguish
+
+### Crown Stealers
+- **Health:** 8 HP
+- **Speed:** Faster than any available mount
+- **Behavior:**
+  - Leap over walls (recovering briefly after each jump)
+  - Ignore coins and gems entirely
+  - Instantly knock the crown off regardless of Monarch coin count
+  - If crown is picked up, it is considered lost forever after a few seconds
+  - Can ride on breeders' backs (rare)
+- **First appearance:** Blood Moons after day 130 (year 3)
+- **Regular waves:** After day 190 (year 4)
+- **Indicator:** Crown-shaped constellation appears before they become active
+- **Scaling:** Appear more frequently and in increasing numbers the longer you play
+- **Audio cue:** Eerie creaking noise audible across the entire island
+- **Weaknesses:**
+  - Fire from catapults or lizard mount
+  - Knight/pikeman melee attacks during post-jump recovery
+  - Multiple wall segments force more jumps with recovery periods
+  - Pikemen specifically position spears vertically to target leaping crown stealers
+
+---
+
+## 16. Portals
+
+### Portal Types
+
+#### Small Portals
+- **Location:** Scattered throughout forests
+- **Health:** Lower than dock/cliff portals
+- **Function:** Spawn greedlings for nightly waves and defense waves
+- **Destruction:** Attack squads led by knights
+- **Post-destruction:** Can be converted to teleporters (8 coins)
+
+#### Dock Portals (Living Portals)
+- **Location:** One per island at the dock's edge
+- **Health:** ~320 HP
+- **Unique feature:** Tentacle self-defense appendage
+  - Strikes every 2-3 seconds
+  - Remains active even when portal is inactive
+  - Drops coins from the Monarch on hit
+- **Function:** Blocks access to the far-side dock and lighthouse
+- **Spawning:** Produces more greedlings when threatened than small portals
+- **Post-destruction:** Can build lighthouse (6 coins) or teleporter (8 coins)
+
+#### Cliff Portals
+- **Location:** Cliff face at the edge of the land
+- **Health:** More than small portals
+- **Function:** Entry point to the cave (Greed home base) in Two Crowns
+- **Regeneration:** Rebuilds after 3 days once destroyed (except on Skull Island)
+- **Post-destruction period:** 3 nights of peace while portal reconstructs
+- **Cave access:** Destroying the cliff portal facilitates bomb delivery to the cave
+
+### Portal States
+- **Active vs. Inactive:** Only the closest portal per side is active. Inactive portals cannot open or recognize threats.
+- **Exhausted vs. Non-exhausted:** After a wave, portals become exhausted until noon. Exhausted portals are insensitive to threats but will react if directly attacked.
+- **Open vs. Closed:** Open portals have "swirling pink/purple goo" and actively launch waves.
+
+### Hostile Presence Detection
+Portals detect threats through:
+- Archer attacks (single arrow triggers response)
+- Monarch/subject proximity within plaza-width range for several seconds
+- Accelerated movement does NOT trigger detection (mounted monarchs pass too quickly)
+
+### Destruction Mechanics
+- Portals do NOT regenerate health (damage is permanent)
+- Destroying a portal immediately triggers a retaliation/counterattack wave
+- Counterattack strength increases with each portal destroyed on that island
+- Wave composition scales with island day count
+
+### Post-Destruction
+- Destroyed small/dock portals can be converted to teleporters
+- Teleporters allow fast travel between portal sites
+
+---
+
+## 17. The Bomb
+
+### Overview
+A massive explosive weapon used to permanently destroy the cave (Greed home base) on each island.
+
+### Acquisition
+- **Cost:** 18 coins
+- **Location:** Purchased at the Iron Keep (Tier 7 town center)
+- **Requirement:** Iron technology must be unlocked
+
+### Assault Sequence
+1. **Purchase the bomb** at the Iron Keep
+2. **Builders push the bomb** (up to 3 builders) toward the cliff portal
+3. **Monarch leads the march** to the cave
+   - Builders halt if they reach the Monarch or the Monarch goes behind them
+   - Builders resume when the Monarch goes ahead
+4. **Two squire/knight companies escort** the bomb
+   - Chosen from the sea side first, then from near the bomb
+5. **At the cliff portal:** Monarch pays 5 coins to enter the cave
+6. **Inside the cave:** Archers destroy nests (each nest has 80 HP)
+   - Island 1: 1 nest, Island 2: 2 nests, Island 3: 3, Island 4: 4, Island 5: 5 nests
+   - Nests spawn groups of 4-6 greedlings when they sense hostiles
+7. **At the hive:** Monarch pays 5 coins to light the bomb
+8. **Final wave:** The hive unleashes a last, stronger wave of greedlings
+9. **Escape:** Monarch has 15-30 seconds to escape before detonation
+
+### Result
+- The cave and cliff portal are permanently destroyed
+- No more Greed ever spawn on that island
+- Remaining Greed on the island retreat into any remaining portals (or flee the island if none exist)
+
+### Total Cost Breakdown
+- Bomb: 18 coins
+- Entry fee: 5 coins
+- Ignition fee: 5 coins
+- **Minimum total: 28 coins** (plus military and builder costs)
+
+---
+
+## 18. Catapults and Ballistas
+
+### Catapults
+
+#### Acquisition and Stats
+- **Cost:** 6 coins
+- **Unlock:** Stone fortifications town center
+- **Operators:** 1-2 builders (permanent assignment)
+- **HP:** 4 HP
+- **Damage:** ~15 HP per boulder
+- **Limit:** 1 catapult per side maximum
+- **Direction:** Only fires outward (away from kingdom)
+
+#### Operation
+- Builders construct, move, and reload the catapult
+- Fires automatically once loaded
+- Can only move catapults forward (backward in Two Crowns during wall upgrades)
+- Position adjusts outward as walls expand
+
+#### Boulder Mechanics
+- Most boulders disintegrate on impact
+- Some persist on the ground
+- **Breeders can retrieve and hurl remaining boulders** back at walls and subjects
+- Boulder splash effect damages tightly-packed enemies
+
+#### Fire Barrels (Two Crowns Only)
+- **Cost:** 5 coins each at siege workshop
+- **Unlock:** Stone castle keep
+- **Effect:** Splash of flammable liquid that ignites greed on contact
+- **Damage:** Fire causes damage every second; greedlings and masked greedlings die in 1-3 seconds
+- **Advantage:** Cannot be thrown back by breeders
+
+#### Combat Effectiveness
+- Can eliminate floaters in a single hit
+- Effective against tightly-packed enemy formations
+- Recent balance: Better accuracy and damage from increased boulder bouncing
+
+### Ballistas
+
+#### Acquisition and Stats
+- **Cost:** 15 coins (triplet tower) or 18 coins (quadruplet tower) in Two Crowns
+- **Unlock:** Ballista Hermit required
+- **Operator:** 1 builder (single)
+- **Damage:** ~12 per shot (approximate)
+- **Range:** ~1.33 plazas (~2 screens) in Two Crowns (post-patch 1.1.13)
+- **Direction:** Only fires outward (one direction away from kingdom, NEVER backwards)
+
+#### Operation
+- Builder automatically loads and fires bolts
+- Only occupies ballistas relatively close to the outer wall
+- Abandons distant towers if kingdom defenses collapse
+
+#### Piercing Mechanics
+- Fires piercing bolts that penetrate multiple enemies in a line
+- Can eliminate entire rows of masked greedlings with a single shot
+- Deals serious damage to all greed types including crown stealers
+
+#### Advantages Over Catapults
+- Requires only 1 builder (vs. 1-2 for catapults)
+- Longer range
+- Piercing projectiles
+- Projectiles cannot be thrown back by breeders
+
+#### Vulnerabilities
+- Builder is exposed to floater abduction
+- Builder is exposed to breeder boulders
+- Cannot shoot enemies approaching from behind (inside the kingdom)
+
+---
+
+## 19. Berserkers (Norse Lands)
+
+### Overview
+Norse-exclusive temporary military units that attack Greed during nightly waves.
+
+### Recruitment
+- **Facility:** Potion vendor (unlocked at Tier 2 back wall + Tier 2 fortifications)
+- **Cost:** 3 coins per potion
+- **Vendor stock:** Up to 2 potions, can appear on either side
+- **Process:** Builders drink potions to become berserkers (permanently stop construction work)
+
+### Combat Mechanics
+- Wield dual axes (cannot form shield walls)
+- Sprint into battle at night, jumping toward enemies
+- Deal "blows which knock back and severely damage" monsters
+- After eliminating threats, roar, glow, and sprint back safely
+- Exceptional durability: Can walk over fire from fire towers (unique among all units)
+- Fall quickly to breeder attacks
+
+### Day/Night Behavior
+- **Day:** Idle (cannot fish or perform profitable work, unlike pikemen/ninjas)
+- **Night:** Active defense during greed attacks, retreat when threat ends
+
+### Stats
+- No coin-carrying capacity
+- Cannot be upgraded with shields
+- Introduced in patch 1.1.13
+
+---
+
+## 20. Supporting Systems
+
+### Day-Night Cycle
+- **Total day length:** ~4 real-life minutes
+- **Daytime:** ~2 minutes 45 seconds
+  - Sunrise to noon: ~70 seconds
+  - Noon to sunset: ~75 seconds
+- **Nighttime:** ~1 minute 15 seconds
+  - Pre-midnight: ~40 seconds
+  - Post-midnight: ~35 seconds
+
+### Seasons (Two Crowns)
+- **Spring:** Wildlife spawns, farms productive, grass grows
+- **Summer:** Peak productivity
+- **Autumn:** Visual cues (red leaves, red cattails). Warning of approaching winter.
+- **Winter:** 16 days. No wildlife except boars and fish. Farms stop. Streams freeze. Grass and rabbit dens destroyed.
+- Seasons do NOT cycle. Once winter arrives, it stays until the Monarch moves to a new island or an heir starts.
+- Seasons reset on island change or heir succession.
+
+### Blood Moons
+- **Frequency (Years 1-2):** One per season (~every 16 days)
+- **Frequency (Year 3+):** Two per season, with 7-day intervals
+- **Type:** Timed, one-sided massive wave
+- **Duration:** Does not end until all monsters are defeated
+- **Post-event:** Recovery day (no attacks the following night)
+- **Visual cues:** Red sky and moon, stormy daytime, extended red dusk, reddish day counter
+- **Audio cues:** Sinister music at sunset, rumbling sound ~40 seconds before midnight
+- **New island nerf:** Blood Moon waves are weaker on the first or second day on a brand-new island
+
+### Wave System
+- **Wave types:**
+  1. Nightly waves (timed, two-sided)
+  2. Blood Moons (timed, one-sided)
+  3. Defense waves (trigger-based, one-sided, from attacked portals)
+  4. Counterattack waves (trigger-based, one-sided, after portal destruction)
+- **Scheduling:** Waves launch based on portal distance to walls. Close portals = late release. Distant portals = early release.
+- **Scaling:** Wave strength increases with overall day count across all islands
+- **Grace period:** ~4-day grace period with diminished greed on a brand-new island
+
+### Walls
+| Tier | Name | Build Cost | Repair Cost | Base HP | Blessed HP |
+|------|------|-----------|-------------|---------|------------|
+| 1 | Spikes | 1 coin | 1 coin | 25 | 45 |
+| 2 | Palisade | 3 coins | 1 coin | 50 | 90 |
+| 3 | Stone Wall | 6 coins | 2 coins | 200 | 360 |
+| 4 | Tall Stone | 9 coins | 4 coins | 300 | 552 |
+| 5 | Iron Wall | 12 coins | 6 coins | 400 | 736 |
+
+- "Blessed" HP = with Statue of Building active (~80% bonus)
+- Norse Lands walls are half as strong as standard counterparts
+- Walls block grass spread and slow all enemies except floaters and crown stealers
+
+### Town Center Tiers
+| Tier | Name | Cost | Key Unlocks |
+|------|------|------|-------------|
+| 0 | Unlit Campfire | Free | Starting state |
+| 1 | Campfire | 3 coins | Hammer + Bow vendors |
+| 2 | Village Tents | 3 coins | Basic shelters |
+| 3 | Wooden Fort | 6 coins | Scythe vendor, free spike walls |
+| 4 | Town Hall | 12 coins | Siege workshop, Banker |
+| 5 | Stone Fort | 15 coins | Stone tech, free stone walls |
+| 6 | Castle Keep | 18 coins | Shields, fire barrels, Gem Keeper |
+| 7 | Iron Keep | 20 coins | Bomb, Forge, free iron walls/roofed towers |
+
+### Archer Tower Tiers
+| Tier | Cost | Archer Capacity | Notes |
+|------|------|-----------------|-------|
+| 1 | 3 coins | 1 | Rock platform, minimal elevation |
+| 2 | 5 coins | 1 | Wooden watchtower, medium height |
+| 3 | 7 coins | 2 | Stone tower, requires stone tech |
+| 4 | 9 coins | 3 | Triplet tower, hermit-upgradable |
+| 5 | Varies | 3 | Roofed triplet, floater-proof |
+| 6 | Varies | 4 | Quadruplet, roofed, maximum defense |
+
+### Statues
+| Statue | Island | Gem Cost | Coin Offering | Effect |
+|--------|--------|----------|---------------|--------|
+| Archery | 1st | Gems | Coins | Perfect aim for all archers (never miss) |
+| Scythe | 2nd | Gems | Coins | +2 crop plots per farm type |
+| Building | 3rd | 3 gems | 9 coins | ~80% more HP on all walls (builders must re-apply after damage/upgrade) |
+| Knights | 5th | 2 gems | 8 coins | Combat mastery for knights |
+
+### Decay (Island Absence)
+- Walls deteriorate while the Monarch is away from an island
+- Decay progresses from outermost to innermost walls
+- Higher-tier walls endure more days before decaying
+- Iron walls survive ~30 days
+- Heir succession applies 100 days of additional decay to all previously unlocked islands
+
+### Island Persistence
+- Destroyed portals remain destroyed
+- Gem-unlocked content (mounts, hermits, statues) persists permanently
+- Banker funds persist across islands and heir succession
+- Buildings decay but structures can be rebuilt
+
+---
+
+## Sources
+
+- [Kingdom Wiki: Mounts](https://kingdomthegame.fandom.com/wiki/Mounts)
+- [Kingdom Wiki: Griffin](https://kingdomthegame.fandom.com/wiki/Griffin)
+- [Kingdom Wiki: Lizard](https://kingdomthegame.fandom.com/wiki/Lizard)
+- [Kingdom Wiki: Bear](https://kingdomthegame.fandom.com/wiki/Bear)
+- [Kingdom Wiki: Unicorn](https://kingdomthegame.fandom.com/wiki/Unicorn)
+- [Kingdom Wiki: Warhorse](https://kingdomthegame.fandom.com/wiki/Warhorse)
+- [Kingdom Wiki: Stag](https://kingdomthegame.fandom.com/wiki/Stag)
+- [Kingdom Wiki: Horse](https://kingdomthegame.fandom.com/wiki/Horse)
+- [Kingdom Wiki: Vagrant](https://kingdomthegame.fandom.com/wiki/Vagrant)
+- [Kingdom Wiki: Vagrant Camp](https://kingdomthegame.fandom.com/wiki/Vagrant_camp)
+- [Kingdom Wiki: Builder](https://kingdomthegame.fandom.com/wiki/Builder)
+- [Kingdom Wiki: Archer](https://kingdomthegame.fandom.com/wiki/Archer)
+- [Kingdom Wiki: Farmer](https://kingdomthegame.fandom.com/wiki/Farmer)
+- [Kingdom Wiki: Farm](https://kingdomthegame.fandom.com/wiki/Farm)
+- [Kingdom Wiki: Knight](https://kingdomthegame.fandom.com/wiki/Knight)
+- [Kingdom Wiki: Pikeman](https://kingdomthegame.fandom.com/wiki/Pikeman)
+- [Kingdom Wiki: Ninja](https://kingdomthegame.fandom.com/wiki/Ninja)
+- [Kingdom Wiki: Greedling](https://kingdomthegame.fandom.com/wiki/Greedling)
+- [Kingdom Wiki: Breeder](https://kingdomthegame.fandom.com/wiki/Breeder)
+- [Kingdom Wiki: Floater](https://kingdomthegame.fandom.com/wiki/Floater)
+- [Kingdom Wiki: Crown Stealer](https://kingdomthegame.fandom.com/wiki/Crown_stealer)
+- [Kingdom Wiki: Hermits](https://kingdomthegame.fandom.com/wiki/Hermits)
+- [Kingdom Wiki: Bakery Hermit](https://kingdomthegame.fandom.com/wiki/Bakery_Hermit)
+- [Kingdom Wiki: Ballista Hermit](https://kingdomthegame.fandom.com/wiki/Ballista_Hermit)
+- [Kingdom Wiki: Warrior Hermit](https://kingdomthegame.fandom.com/wiki/Warrior_Hermit)
+- [Kingdom Wiki: Stable Hermit](https://kingdomthegame.fandom.com/wiki/Stable_Hermit)
+- [Kingdom Wiki: Horn Hermit](https://kingdomthegame.fandom.com/wiki/Horn_Hermit)
+- [Kingdom Wiki: Fire Tower Hermit](https://kingdomthegame.fandom.com/wiki/Fire_Tower_Hermit)
+- [Kingdom Wiki: Fire Tower](https://kingdomthegame.fandom.com/wiki/Fire_tower)
+- [Kingdom Wiki: Berserker](https://kingdomthegame.fandom.com/wiki/Berserker)
+- [Kingdom Wiki: Dog](https://kingdomthegame.fandom.com/wiki/Dog)
+- [Kingdom Wiki: Merchant](https://kingdomthegame.fandom.com/wiki/Merchant)
+- [Kingdom Wiki: Banker](https://kingdomthegame.fandom.com/wiki/Banker)
+- [Kingdom Wiki: Portal](https://kingdomthegame.fandom.com/wiki/Portal)
+- [Kingdom Wiki: Dock Portal](https://kingdomthegame.fandom.com/wiki/Dock_portal)
+- [Kingdom Wiki: Cliff Portal](https://kingdomthegame.fandom.com/wiki/Cliff_portal)
+- [Kingdom Wiki: Bomb](https://kingdomthegame.fandom.com/wiki/Bomb)
+- [Kingdom Wiki: Catapult](https://kingdomthegame.fandom.com/wiki/Catapult)
+- [Kingdom Wiki: Ballista](https://kingdomthegame.fandom.com/wiki/Ballista)
+- [Kingdom Wiki: Wildlife](https://kingdomthegame.fandom.com/wiki/Wildlife)
+- [Kingdom Wiki: Purse](https://kingdomthegame.fandom.com/wiki/Purse)
+- [Kingdom Wiki: Town Center](https://kingdomthegame.fandom.com/wiki/Town_center)
+- [Kingdom Wiki: Wall](https://kingdomthegame.fandom.com/wiki/Wall)
+- [Kingdom Wiki: Archer Tower](https://kingdomthegame.fandom.com/wiki/Archer_tower)
+- [Kingdom Wiki: Waves](https://kingdomthegame.fandom.com/wiki/Waves)
+- [Kingdom Wiki: Blood Moon](https://kingdomthegame.fandom.com/wiki/Blood_Moon)
+- [Kingdom Wiki: Day](https://kingdomthegame.fandom.com/wiki/Day)
+- [Kingdom Wiki: Seasons](https://kingdomthegame.fandom.com/wiki/Seasons)
+- [Kingdom Wiki: Statues](https://kingdomthegame.fandom.com/wiki/Statues)
+- [Kingdom Wiki: Bakery](https://kingdomthegame.fandom.com/wiki/Bakery)
+- [Steam Guide: Complete Guide to Kingdom Two Crowns](https://steamcommunity.com/sharedfiles/filedetails/?id=1588497381)
+- [The Best Mounts in Kingdom Two Crowns (GameRant)](https://gamerant.com/kingdom-two-crowns-best-mounts/)

--- a/kingdom/.research-agent3-world.md
+++ b/kingdom/.research-agent3-world.md
@@ -1,0 +1,819 @@
+# Kingdom Two Crowns: Exhaustive World Systems Research
+
+Research compiled for the Kingdom TUI game (Agent 3: Combat + Structures + Spawning).
+Sources: Kingdom wiki (kingdomthegame.fandom.com), community strategy guides, training data.
+
+---
+
+## Table of Contents
+
+1. [Structure Types and Upgrade Paths](#1-structure-types-and-upgrade-paths)
+2. [Tower Types](#2-tower-types)
+3. [Castle / Keep System (Town Center)](#3-castle--keep-system-town-center)
+4. [Farms and Farm Mechanics](#4-farms-and-farm-mechanics)
+5. [The Forge](#5-the-forge)
+6. [Siege Weapons (Bomb/Catapult)](#6-siege-weapons-bombcatapult)
+7. [Lighthouse Mechanics](#7-lighthouse-mechanics)
+8. [Shrine and Hermit Mechanics](#8-shrine-and-hermit-mechanics)
+9. [Greed Enemy Types](#9-greed-enemy-types)
+10. [Boss Greed Mechanics](#10-boss-greed-mechanics)
+11. [Wave Scaling and Composition](#11-wave-scaling-and-composition)
+12. [Blood Moon Mechanics](#12-blood-moon-mechanics)
+13. [Portal Mechanics](#13-portal-mechanics)
+14. [Day/Night Cycle](#14-daynight-cycle)
+15. [Island Progression (All 5+ Islands)](#15-island-progression)
+16. [The Boat and Sailing](#16-the-boat-and-sailing)
+17. [Gems and Gem Mechanics](#17-gems-and-gem-mechanics)
+18. [Decay Mechanic](#18-decay-mechanic)
+19. [Seasons (Norse/Shogun/Dead Lands)](#19-seasons-norseshogundead-lands)
+20. [Economy and Tech Tree](#20-economy-and-tech-tree)
+21. [Mounts](#21-mounts)
+22. [NPC Types and Recruitment](#22-npc-types-and-recruitment)
+23. [Counter-Attack Mechanics](#23-counter-attack-mechanics)
+24. [Cost Reference Tables](#24-cost-reference-tables)
+
+---
+
+## 1. Structure Types and Upgrade Paths
+
+### Walls
+
+#### Dirt Mound (Tier 0)
+- **Cost:** 1 coin
+- **HP:** Very low (~2 hits from basic Greed)
+- **Appearance:** Small pile of dirt/logs
+- **What it adds:** Slows Greed; archers cannot stand behind it effectively
+
+#### Wood Wall (Tier 1)
+- **Cost:** 1-2 coins to upgrade from dirt mound
+- **HP:** Low-medium (~5 hits from basic Greed)
+- **Appearance:** Wooden palisade, shorter than stone
+- **What it adds:** Archers can stand behind it and shoot over it
+- **Upgrade trigger:** Monarch drops a coin on the wall
+
+#### Stone Wall (Tier 2)
+- **Cost:** 3 coins to upgrade from wood wall
+- **Requires:** Stone technology (Town Center at Town tier)
+- **HP:** Medium-high (~12 hits from basic Greed)
+- **Appearance:** Taller stone fortification with archer platform
+- **What it adds:** More durable, higher; archers have slight elevation advantage
+
+#### Iron Wall (Tier 3)
+- **Cost:** 6 coins to upgrade from stone wall
+- **Requires:** Town Center at Iron Keep tier (final castle upgrade)
+- **HP:** Very high (~20-25 hits from basic Greed)
+- **Appearance:** Metal-reinforced fortification
+- **What it adds:** Maximum durability; can potentially be upgraded to a tower
+
+### Wall Mechanics
+- Walls are built and repaired by Builders
+- Walls can only be built outward from the Town Center (expanding kingdom)
+- Each side of the kingdom has its own wall line
+- Walls are placed sequentially; you cannot skip positions
+- If a wall is destroyed, Greed can pass through until rebuilt
+- Greed attack the outermost wall first
+- During Blood Moons, Greed deal extra damage to walls
+
+### Gates
+- Auto-placed at regular intervals in wall lines
+- Allow friendly units (archers, knights, builders) to pass through
+- Block Greed just like walls but with slightly lower HP
+- In our implementation: GATE_TYPE = 15, auto-placed every 10 tiles from settlement center
+
+### Wall Chains (Our Implementation)
+- Adjacent connected walls form chains
+- Each wall in a chain of N gets +N bonus HP
+- Encourages building continuous wall lines rather than scattered segments
+
+---
+
+## 2. Tower Types
+
+Towers are upgraded from maxed-out walls (stone or iron tier).
+
+### Archer Tower
+- **Cost:** 6 coins (upgrade from outermost wall)
+- **What it does:** Elevated platform for up to 3 archers with extended range and damage boost
+- **HP:** Higher than the wall it replaces
+- **Key:** Primary defense against Floaters (flying Greed)
+
+### Ballista Tower (Norse Lands DLC)
+- **Cost:** 8+ coins to upgrade from archer tower
+- **What it does:** Fires a single powerful bolt hitting multiple Greed in a line
+- **Cooldown:** Slower than archers but massive damage
+- **Crew:** Operated by a builder, not archers
+- **Best against:** Large waves, Breeders
+
+### Bomb Tower (Dead Lands DLC)
+- **Cost:** Similar to ballista, upgrade from archer tower
+- **What it does:** Drops an explosive on Greed clusters below
+- **AoE:** Significant area of effect
+- **Cooldown:** Very slow (every 5-8 seconds)
+- **Best against:** Dense waves
+
+### Our Implementation
+- TOWER_TYPE = 13, TOWER_COST = 15, TOWER_HP = 40
+- TOWER_ARCHER_RANGE_BONUS = 5, TOWER_ARCHER_SLOTS = 2
+- Towers are the final upgrade beyond iron walls
+- Ballista (siege.ts): BALLISTA_COST = 12, BALLISTA_HP = 15, BALLISTA_DAMAGE = 3
+  - 3-tile radius AoE, 5-second cooldown
+  - Available on island 3+
+
+---
+
+## 3. Castle / Keep System (Town Center)
+
+The Town Center is the heart of the kingdom. Upgrading it unlocks new technologies.
+
+### Upgrade Path
+
+```
+Campfire (ruins) -> Camp -> Village -> Town -> Castle -> Iron Keep
+```
+
+| Tier | Cost | Unlocks |
+|------|------|---------|
+| Campfire | 0 (found) | Gathering point for vagrants |
+| Camp | 2 coins | Recruit vagrants via tool stands |
+| Village | 5 coins | Farms become available |
+| Town | 8 coins | Stone walls, Knights |
+| Castle | 12 coins | Castle walls, teleportation portals |
+| Iron Keep | 15-18 coins | Iron walls, siege weapons, bomb/ballista towers |
+
+### Key Notes
+- Each island starts with a destroyed campfire that must be rebuilt
+- Town Center tier does NOT carry between islands
+- Some islands have unique final tiers (Norse Keep, Plague Castle)
+
+---
+
+## 4. Farms and Farm Mechanics
+
+### Farm Upgrade Path
+
+```
+Cleared Land -> Farm (basic) -> Irrigated Farm -> Windmill Farm
+```
+
+| Tier | Cost | Output | Workers |
+|------|------|--------|---------|
+| Basic Farm | 5 coins | 1x base (2 coins/harvest) | 1 farmer |
+| Irrigated Farm | 3-5 upgrade | 1.5x base (3 coins/harvest) | 2 farmers |
+| Windmill Farm | 5-8 upgrade | 2x base (4 coins/harvest) | 3 farmers |
+
+### Crop Cycle
+- Crops take roughly one full day-night cycle to mature
+- Farmers harvest automatically at end of day
+- Growth time: ~10 seconds before producing (in our implementation)
+
+### Farmer Behavior
+- **Day:** Walk to assigned farm, plant/harvest crops
+- **Dusk:** Begin retreating behind walls
+- **Night:** Hide behind walls, do not farm
+- **Threat response:** Flee from nearby Greed (even during day, 10-tile threat range)
+- **Farm destruction:** If Greed reach a farm, it is destroyed
+
+### Seasonal Effects
+- **Spring/Summer:** Normal production
+- **Autumn:** Reduced production (~75%)
+- **Winter:** Farms produce nothing; farmers idle (major economic challenge)
+
+### Limits
+- Max 3 farms per side of the camp (6 total)
+- Destroyed farms lose all progress; must be rebuilt
+
+---
+
+## 5. The Forge
+
+Found on certain islands (typically island 3+).
+
+### What It Does
+- Upgrades tools/weapons for archers, builders, and knights
+- **Archer upgrade:** Improved arrow damage or fire arrows
+- **Builder upgrade:** Increased build/repair speed
+- **Knight upgrade:** Increased HP and damage
+
+### How It Works
+1. Find the Forge ruin on the island
+2. Pay 6-10 coins to repair it
+3. Once active, upgrades weapons for units passing nearby
+4. Some versions require additional coin payments per upgrade
+
+### Key Notes
+- Not available on all islands (typically island 3+)
+- One Forge per island maximum
+- Upgrades do not carry between islands
+
+---
+
+## 6. Siege Weapons (Bomb/Catapult)
+
+### Catapult (Base Game)
+- **Cost:** 8 coins to build (near dock/ship area)
+- **Mechanic:** Knights push catapult toward portals; builders load it
+- **Damage:** Destroys Greed portals in a few hits
+- **Limitation:** Slow to move, vulnerable during transit
+
+### Bomb
+- **Cost:** Expensive (varies by DLC)
+- **Purpose:** Required to destroy cave portals / the Greed Nest
+- **Mechanic:** Builders push the bomb toward the cave portal. Once there, it detonates.
+- **Escort required:** Knights must escort it; Greed will try to stop it
+- **Risk:** If destroyed before reaching the cave, resources are lost
+
+---
+
+## 7. Lighthouse Mechanics
+
+- **Found on:** Specific islands (typically island 2-3)
+- **Starting state:** Ruined/destroyed
+- **Repair cost:** 5-8 coins
+- **Function:** Activates the ship dock on that island for inter-island travel
+- **Permanent:** Once repaired, remains active on that island
+- **Some DLC:** Has defensive properties (illuminates area, scares Greed at night)
+
+---
+
+## 8. Shrine and Hermit Mechanics
+
+### Shrines
+Scattered across each island; provide temporary buffs when coins are offered.
+
+| Buff | Effect | Duration |
+|------|--------|----------|
+| Archer Damage | 2x arrow damage | 60s |
+| Builder Speed | 2x build/repair speed | 60s |
+| Wall Durability | 2x wall HP (effectively) | 60s |
+
+- Only one buff active at a time
+- Buffs rotate in order
+- Shrines are indestructible
+- Cost: 4 coins base (+2 per use in our implementation)
+
+### Hermits (Special NPCs)
+Found in the wilderness; unlock unique abilities when brought back to kingdom.
+
+| Hermit | Location | Unlocks |
+|--------|----------|---------|
+| Hermit of Tide | Shore/water | Bakery (income source) |
+| Hermit of Valor | Forest | Knight upgrades |
+| Hermit of Stable | Plains | Special mounts |
+| Hermit of Horn | Mountains/ruins | Siege weapons |
+
+- Ride on monarch's mount; only one at a time
+- If monarch is hit by Greed while carrying hermit, hermit is lost
+- Island-specific; must be found on each new island
+
+---
+
+## 9. Greed Enemy Types
+
+### Small Greedling (Basic)
+- **HP:** 1 arrow
+- **Speed:** Moderate
+- **First appears:** Island 1, Night 1
+- **Behavior:** Run from portals toward kingdom center; steal coins and tools
+- **When stealing:** Turn around and flee back to portal. Drop item if killed.
+- **Tool theft:** Stolen tool causes subject to revert to vagrant
+
+### Masked Greedling (Armored)
+- **HP:** 2 from front (mask absorbs first hit), 1 from behind
+- **Speed:** Slightly slower than basic
+- **First appears:** Island 2 (some late Island 1)
+- **Behavior:** Front mask blocks first incoming arrow, then breaks off
+- **Counter:** Knights/squires can hit from side/behind, bypassing mask
+
+### Floater (Breeder)
+- **HP:** 5-8 arrows
+- **Speed:** Slow (floating/flying)
+- **First appears:** Island 2-3
+- **Behavior:** Float OVER walls, completely bypassing ground defenses
+- **Spawning:** Once past walls, periodically spawn 2-4 greedlings from body
+- **Counter:** Archer towers (elevated archers can engage them)
+- **Key threat:** Bypasses walls and creates internal enemies
+
+### Crown Stealer
+- **HP:** 1 arrow
+- **Speed:** Moderate
+- **Mechanic:** Any greedling reaching monarch with 0 coins triggers crown steal
+- **Game over:** If crown reaches a portal, game ends
+- **Recovery:** Crown can be recovered if greedling is killed
+
+### Breeder (In Our Implementation)
+- **HP:** 3
+- **Speed:** 2 tiles/sec (slow)
+- **First damage:** Spawns 2 mini-greeds (1 HP each, basic type)
+- **Only spawns once:** breederSpawned Set tracks this
+
+### Giant Floater (Late Game)
+- **HP:** 12-20 arrows
+- **Speed:** Very slow
+- **First appears:** Island 4-5
+- **Behavior:** Like floater but spawns more greedlings, more frequently
+
+---
+
+## 10. Boss Greed Mechanics
+
+Kingdom Two Crowns does not have traditional bosses. Instead, difficulty scales through:
+
+1. **Retaliation waves:** Triggered by portal destruction. Significantly larger than blood moon waves.
+2. **Blood moons:** Semi-regular massive waves (~2-3x normal).
+3. **Day count scaling:** Waves naturally grow each night.
+4. **Island number:** Higher islands have higher base difficulty.
+5. **Giant Floaters:** Late-game enemies that serve as mini-bosses.
+
+---
+
+## 11. Wave Scaling and Composition
+
+### Factors Determining Wave Difficulty
+
+**Day Count (Global Counter)**
+- Tracks across all islands
+- Each day increases base wave strength
+- Formula: `base_strength = day_number * island_multiplier`
+
+**Island Multiplier**
+
+| Island | Multiplier |
+|--------|-----------|
+| 1 | 1.0x |
+| 2 | ~1.25x |
+| 3 | ~1.5x |
+| 4 | ~1.75x |
+| 5 | ~2.0x |
+
+### Wave Composition by Day
+
+| Day Range | Composition | Approx. Total per Side |
+|-----------|-------------|----------------------|
+| 1-5 | All basic greedlings | 3-8 |
+| 6-12 | Basic + 1-3 masked | 8-15 |
+| 12-20 | Mixed + 1 floater | 15-25 |
+| 20-30 | Majority masked + 2-3 floaters | 25-40 |
+| 30-40 | Heavy masked + 3-4 floaters | 40-60 |
+| 40+ | Maximum difficulty, giant floaters | 60+ |
+| Blood Moon | ~2-3x normal for that day count | Varies |
+
+### Wave Distribution
+- Waves come from both sides (left and right portals)
+- Total strength split between sides, not necessarily evenly
+- Fewer active portals means remaining portals spawn larger groups
+- Total wave strength does NOT decrease proportionally when portals are destroyed
+
+### Per-Portal Difficulty (Our Implementation)
+- Each portal has independent difficulty: +0.1 per night survived
+- `getPortalDifficulty(x) = 1 + nights * 0.1`
+- Incrementing only for active portals
+
+---
+
+## 12. Blood Moon Mechanics
+
+### Schedule
+- Occur approximately every 4-6 nights (some randomness)
+- First blood moon typically around day 5-8
+- On later islands, can occur every 3-4 nights
+- Pattern: ~Normal, Normal, Normal, Blood Moon, Normal, Normal, Normal, Blood Moon...
+
+### Differences from Normal Nights
+- **Wave size:** 2-3x larger than normal night's wave
+- **Composition:** Higher ratio of masked greedlings and floaters
+- **Duration:** Longer; enemies keep spawning throughout most of night
+- **Multiple sub-waves:** 2-3 sub-waves rather than single burst
+- **Both sides attacked:** Always features attacks from both sides
+
+### Our Implementation
+- Blood Moon every 7 days
+- All special enemy percentages doubled, 3x wave size
+- isBloodMoon flag triggers in spawn.ts
+
+---
+
+## 13. Portal Mechanics
+
+### Portal Types
+
+| Portal Type | HP (Catapult Hits) | Gem Reward | Location |
+|-------------|-------------------|-----------|----------|
+| Small Cliff Portal | 4-6 | 1-2 | Near kingdom |
+| Large Cliff Portal | 8-12 | 2-4 | Further out |
+| Dock Portal | ~15-20 | 3-5 | Island edge |
+| Cave Portal (Nest) | Very high | 4-8 | Deep wilderness |
+
+### Portal Count per Island
+- **Island 1:** 2 cliff portals + dock portal
+- **Island 2:** 4-6 cliff portals + dock portal
+- **Island 3:** 6-8 cliff portals + dock + cave portal
+- **Island 4:** Similar to Island 3 with more portals
+- **Island 5:** Most portals (hardest island)
+
+### On Portal Destruction
+1. Portal crumbles, stops spawning Greed
+2. Drops 2-4 gems (cliff) or 4-8 gems (cave)
+3. Triggers large retaliation wave from remaining portals (even during day)
+4. Permanent removal (does not regenerate)
+5. Remaining portals compensate with slightly larger nightly waves
+
+### Our Implementation
+- 5 portals at positions: [30, 220, 540, 880, 1170]
+- PORTAL_HP from types.ts
+- Portal destruction: clears area permanently, triggers retaliation
+- Victory: all portals destroyed on island 5 (FINAL_ISLAND)
+
+---
+
+## 14. Day/Night Cycle
+
+### Timing
+- Full day/night cycle: approximately 3-4 minutes real time
+
+### Phases
+- **Dawn:** Sun rises; remaining Greed retreat to portals (passive, don't attack)
+- **Day:** Safe period. No Greed spawn. Archers hunt, builders build, farmers farm.
+- **Dusk:** Warning bell tolls. Archers and workers retreat to walls.
+- **Night:** Greed waves spawn from active portals shortly after full darkness.
+
+### Day Activities
+- All construction and economic activity
+- Knights and catapults can attack portals offensively
+- Drop coins at recruitment camps to attract new subjects
+- Monarch can safely explore and expand
+
+### Night Activities
+- Greed spawn and attack
+- Archers man walls and towers
+- Workers hide behind innermost walls
+- Farmers retreat to town center area
+- Monarch should stay behind walls
+- Knights form defensive lines at outermost wall
+
+---
+
+## 15. Island Progression
+
+### Island 1: Tutorial Island
+- **Portals:** 2 cliff portals (1 per side)
+- **Difficulty:** Easy. Basic greedlings only for first several nights.
+- **Unique features:** Simple layout; serves as tutorial
+- **Key unlocks:** Basic walls, archers, builders
+- **Strategy:** Learn core mechanics. Build walls and recruit.
+
+### Island 2: Expansion
+- **Portals:** 3-4 cliff portals
+- **Difficulty:** Moderate. Masked greedlings appear.
+- **Unique features:** Larger map; stable for mounts
+- **Key unlocks:** Stone walls, more unit types
+- **Strategy:** Establish strong defenses before pushing outward.
+
+### Island 3: The Forge Island
+- **Portals:** 4-6 cliff portals + cave portal appears
+- **Difficulty:** Hard. Floaters/breeders start appearing.
+- **Unique features:** Forge ruin for weapon upgrades
+- **Key unlocks:** Iron walls, siege weapons, tool upgrades
+- **Strategy:** Upgrade weapons at forge. Build siege weapons for portal assault.
+
+### Island 4: Advanced Warfare
+- **Portals:** Many cliff portals + cave
+- **Difficulty:** Very hard. Multiple floaters per wave.
+- **Unique features:** More complex terrain; multiple threat vectors
+- **Key unlocks:** Advanced towers, bomb access
+- **Strategy:** Full use of all unlocked technologies. Balance offense and defense.
+
+### Island 5: The Final Island
+- **Portals:** Maximum portals
+- **Difficulty:** Extreme. Giant floaters, maximum scaling.
+- **Unique features:** The final challenge. Destroying all portals here wins the game.
+- **Key unlocks:** Everything available
+- **Strategy:** Systematic portal destruction from closest to furthest. Full escort for bomb to cave portal.
+- **Victory condition:** Destroy ALL portals on this island
+
+### Cross-Island Mechanics
+- Global day counter persists across islands
+- Gems persist across islands (carried in gem pouch)
+- Coins do NOT persist (must rebuild economy each island)
+- Town Center tier resets (must upgrade from campfire each time)
+- Walls and structures reset (but may partially survive via decay system)
+- Each island increases base difficulty by +0.5 multiplier
+
+---
+
+## 16. The Boat and Sailing
+
+### Ship Mechanics
+- Found at one edge of each island (at dock)
+- Starts damaged; must be repaired
+- Repair cost: varies (15 coins in our implementation)
+- After repair, monarch interacts to travel to next island
+- Travel is one-way until you can repair the boat on the next island
+
+### Key Details
+- Cannot sail past Island 5 (final island)
+- Can sail back to previous islands (to reinforce or complete objectives)
+- Sailing triggers island transition screen
+- New island starts with ruins of a campfire (must rebuild)
+- Some subjects may travel with you (limited slots)
+
+### Our Implementation
+- Ship at x=0 (left edge), starts at 0 HP
+- SHIP_REPAIR_COST = 15 coins
+- sailToNextIsland caps at FINAL_ISLAND = 5
+- Each island: +0.5 difficulty multiplier
+
+---
+
+## 17. Gems and Gem Mechanics
+
+### Gems as Currency
+- Premium currency, more valuable than coins
+- Persist across islands (in gem pouch on mount)
+- Maximum capacity varies by mount type
+
+### How to Obtain Gems
+- **Portal destruction:** Each cliff portal drops 1-4 gems
+- **Cave portal:** Yields 4-8 gems upon destruction
+- **Treasure chests:** Found in ruins on some islands
+
+### Uses for Gems
+- Activate special shrine effects (powerful one-time abilities)
+- Unlock secret mounts
+- Pay for unique island-specific features (lighthouse, special structures)
+
+### Key: Greed Cannot Steal Gems
+- Unlike coins, Greed never interact with gems
+- Gems are safe even if monarch is hit
+
+---
+
+## 18. Decay Mechanic
+
+### What Decays When You Leave an Island
+- **Walls:** Lose ~1 tier of upgrade per 10-15 days away
+- **Farmland:** Reverts to wild land; farmers become idle
+- **Subjects:** May be lost if defenses cannot hold nightly waves
+- **Coins in treasury:** Persist, but protecting structures may decay
+
+### Decay Rate
+- Ticks at regular intervals while away
+- Game simulates simplified day/night cycle for absent islands
+- Each simulated night has a chance to damage walls and lose subjects
+
+### Decay Mitigation
+- Build strongest possible walls before leaving
+- Leave full complement of archers and knights
+- Destroy all portals on the island before leaving (no waves = no decay)
+- Islands with ALL portals destroyed experience NO Greed-caused decay
+
+---
+
+## 19. Seasons (Norse/Shogun/Dead Lands)
+
+### Norse Lands DLC
+- **Seasons cycle:** Spring -> Summer -> Autumn -> Winter -> Spring...
+- **Winter:** Farms produce nothing. Water freezes (expands traversable terrain but Greed can cross too). Shorter days, longer nights.
+- **Unique units:** Berserkers (aggressive melee, charge portals)
+- **Unique structures:** Norse Keep, Odin statue
+- **Unique mounts:** Bear (slow, scares Greed), Reindeer (eats berries for stamina)
+
+### Shogun DLC
+- **Setting:** Feudal Japan aesthetic
+- **Unique features:** Ninja units, samurai (replace knights), specific structure aesthetics
+- **Seasons:** Similar cycle with cherry blossom spring
+- **Unique structures:** Torii gates, Japanese castle tiers
+
+### Dead Lands DLC
+- **Setting:** Plague/undead themed
+- **Unique mechanic:** Plague/curse that affects subjects
+- **Decay accelerated:** Structures decay faster
+- **Unique enemies:** Undead Greed variants with additional abilities
+- **Unique mounts:** Griffin (can fly short distances over obstacles)
+- **Unique structures:** Plague castle, bomb towers
+
+### Seasonal Impact on Economy
+
+| Season | Farm Output | Day Length | Night Length | Special |
+|--------|-----------|-----------|-------------|---------|
+| Spring | 100% | Normal | Normal | Crops plant fast |
+| Summer | 100% | Long | Short | Peak production |
+| Autumn | 75% | Normal | Normal | Reduced output |
+| Winter | 0% | Short | Long | No farming, water freezes |
+
+---
+
+## 20. Economy and Tech Tree
+
+### Income Sources
+
+| Source | Amount | Frequency | Requirements |
+|--------|--------|-----------|-------------|
+| Dawn bonus | 2 coins | Every morning | None |
+| Basic farm | 2 coins | Per harvest cycle | Farm + farmer |
+| Irrigated farm | 3 coins | Per harvest cycle | Upgraded farm |
+| Windmill farm | 4 coins | Per harvest cycle | Upgraded farm |
+| Animal hunting (rabbit) | 1 coin | Per kill | Archer in forest |
+| Animal hunting (deer) | 3 coins | Per kill | Archer in forest |
+| Food cache | 3 coins | One-time | Find in ruins |
+| Merchant | 5-8 coins | Every 3-4 days | Intercept the NPC |
+| Banker interest | 1 coin/night | Per night | Town tier 3+ |
+| Gold vein mining | 1 coin | Every 10 seconds | Miner at vein |
+
+### Tech Unlock Timeline
+
+| Day/Condition | Unlocked |
+|--------------|----------|
+| Day 1 | Basic walls, archers, builders |
+| Day 3 | Farms, farmer recruitment |
+| Day 5 | Knights, shrine activation |
+| Town tier 3 | Stone walls, banker |
+| Island 3+ | Forge, siege weapons |
+| Castle tier | Iron walls, advanced towers |
+| Iron Keep | Maximum upgrades |
+
+### Unit Caps (Our Implementation)
+- MAX_ARCHERS = 10
+- MAX_BUILDERS = 8
+- MAX_FARMERS = 6
+- MAX_KNIGHTS = 4
+
+### Scaling Costs
+- `scaledCost(baseCost, state, role) = baseCost + existing count of that role`
+- More expensive as you recruit more of the same type
+
+---
+
+## 21. Mounts
+
+### Default: Horse
+- Speed: 1.5x walking, 2x sprinting
+- Stamina: 100 max, depletes at 20/sec sprinting, recharges at 10/sec
+- Grass bonus: +5/sec recharge near forest/grass tiles
+
+### Special Mounts
+
+| Mount | Where Found | Special Ability |
+|-------|------------|----------------|
+| War Horse | Island 2+ | Higher stamina, no slowdown on hit |
+| Stag/Lizard | Forest islands | Graze to restore stamina, slower sprint |
+| Bear (Norse) | Norse DLC | Slow but powerful; scares Greed |
+| Reindeer (Norse) | Norse DLC | Eats berries to restore stamina |
+| Griffin (Dead Lands) | Dead Lands DLC | Fly short distances over obstacles |
+| Unicorn | Secret | Grazes on grass, generates coins slowly |
+
+### Mount Mechanics
+- Mounts can be lost if monarch is knocked off by Greed
+- Lost mounts return to nearest stable
+- Only one mount active at a time
+- Sprint depletes stamina; without stamina, moves at walking speed
+
+---
+
+## 22. NPC Types and Recruitment
+
+### Vagrants
+- Wander near campfire
+- Must be near a tool stand for recruitment
+- Base cost: 1 coin
+
+### Recruitment Paths
+
+| Tool Stand | Becomes | Base Cost | Mechanic |
+|-----------|---------|----------|---------|
+| Bow Stand | Archer | 2 coins | Picks up bow |
+| Hammer Stand | Builder | 2 coins | Picks up hammer |
+| (Farm nearby) | Farmer | 1 coin | Day 3+ required |
+| (Shrine/campfire) | Knight | 5 coins | Day 5+ required |
+
+### Special NPC Subtypes (Our Implementation)
+
+| Subtype | Color | Becomes | Cost | Bonus |
+|---------|-------|---------|------|-------|
+| Warrior | Red | Knight | 3 coins | Direct knight recruitment |
+| Scout | Green | Archer | 2 coins | +3 range |
+| Craftsman | Blue | Builder | 2 coins | 1.5x build speed |
+| Peasant | Yellow | Farmer | 1 coin | +50% farm output |
+
+### Banker (Town Tier 3+)
+- Stores excess coins (cap ~10-12)
+- Generates 1 coin interest per night
+- Loses all coins if Greed breach to Town Center
+
+### Merchant (Traveling NPC)
+- Appears every 3-4 days during daytime
+- Carries 5-8 coins to drop near monarch
+- Friendly; can be accidentally killed by knights
+
+### Dog Companion
+- Found on certain islands (island 2+)
+- Cost: 1-3 coins to adopt
+- Detects Greed at night (barks, faces direction of approaching enemies)
+- Can detect hidden items/treasure
+- Cannot be killed; if hit, yelps and runs behind monarch
+- Does NOT persist between islands
+
+---
+
+## 23. Counter-Attack Mechanics
+
+### Knights and Squires
+1. Recruit knight by dropping coins at knight shield
+2. Knights rally up to 2-4 squires/archers who follow
+3. Drop coin at outermost wall banner to send knight on offense
+4. Knight + squad march toward nearest portal, engaging Greed en route
+5. At portal, squad attacks dealing damage over time
+
+### Catapults
+1. Build at workshop/forge
+2. Builder operates; fires boulders for area damage
+3. Can be pushed outward to attack portals
+4. Slow to reposition, vulnerable if undefended
+
+### The Bomb (For Cave Portal)
+1. Built at forge (island 3+, expensive)
+2. Builders push toward cave portal
+3. Knights must escort (Greed actively try to stop it)
+4. On reaching cave, detonates and destroys the portal
+5. If destroyed en route, resources are lost
+
+### Strategy for Portal Assault
+1. Clear cliff portals closest to kingdom first (larger buffer zone)
+2. Always attack during daytime (maximum time before nightfall)
+3. Ensure opposite side is well-defended (retaliation wave may come from there)
+4. Build bomb last (for cave portal, after all cliff portals cleared on that side)
+5. Full escort: knight squad + catapult for support
+
+---
+
+## 24. Cost Reference Tables
+
+### Structure Costs
+
+| Structure/Action | Cost (Coins) | Requirements |
+|-----------------|-------------|-------------|
+| Dirt mound wall | 1 | Open ground |
+| Wood wall | 1-2 upgrade | Dirt mound |
+| Stone wall | 3 upgrade | Wood wall + Town tier |
+| Iron wall | 6 upgrade | Stone wall + Iron Keep |
+| Tower | 6-15 | Maxed wall |
+| Basic farm | 5 | Cleared land |
+| Irrigated farm | 3-5 upgrade | Basic farm |
+| Windmill farm | 5-8 upgrade | Irrigated farm |
+| Catapult | 8 | Forge |
+| Ballista | 12 | Island 3+ |
+| Ship repair | 15 | Ship structure |
+| Shrine activation | 4 + (2 x uses) | Shrine |
+
+### Recruitment Costs
+
+| Unit | Base Cost | Scaling | Requirements |
+|------|----------|---------|-------------|
+| Vagrant | 1 | None | Near campfire |
+| Archer | 2 | +count | Bow stand + vagrant |
+| Builder | 2 | +count | Hammer stand + vagrant |
+| Farmer | 1 | +count | Day 3+, farm nearby |
+| Knight | 5 | +count | Day 5+, shrine/campfire |
+| Warrior NPC | 3 | None | Warrior vagrant |
+| Scout NPC | 2 | None | Scout vagrant |
+| Craftsman NPC | 2 | None | Craftsman vagrant |
+| Peasant NPC | 1 | None | Peasant vagrant |
+
+### Enemy Stats Summary
+
+| Type | HP (Arrows) | Speed | First Appears | Special |
+|------|------------|-------|--------------|---------|
+| Basic Greedling | 1 | Moderate | Island 1, Night 1 | Steals coins/tools |
+| Masked Greedling | 2 (front), 1 (rear) | Slightly slow | Island 2 | Front mask absorbs first hit |
+| Floater/Breeder | 5-8 | Slow (flying) | Island 2-3 | Flies over walls, spawns greedlings |
+| Crown Stealer | 1 | Moderate | Any (behavioral) | Steals crown when 0 coins = game over |
+| Breeder (our impl) | 3 | 2 tiles/sec | Based on wave % | Spawns 2 mini-greeds on first damage |
+| Giant Floater | 12-20 | Very slow | Island 4-5 | More HP, spawns more greedlings |
+
+### Our Implementation Mappings
+
+| K:TC Concept | Our Implementation | File |
+|-------------|-------------------|------|
+| Cliff portals | PORTAL_POSITIONS_WORLD | structures/portal.ts |
+| Settlements | SETTLEMENT_CENTERS | world/map.ts |
+| Wall chain bonus | getWallChainLength/applyWallChainBonuses | structures/wall.ts |
+| Auto-gates | shouldAutoGate (every 10 tiles) | structures/wall.ts |
+| Ballista | BALLISTA_TYPE = 14 | structures/siege.ts |
+| Tower | TOWER_TYPE = 13 | structures/wall.ts |
+| Gate | GATE_TYPE = 15 | structures/wall.ts |
+| Auto-protection | checkSettlementVisits/planSettlementDefenses | systems/construction.ts |
+| Retaliation wave | isRetaliationPending/clearRetaliation | structures/portal.ts |
+| Per-portal difficulty | getPortalDifficulty/incrementPortalDifficulty | structures/portal.ts |
+| Settlement defense rating | getSettlementDefenseRating | structures/portal.ts |
+| Greed target weakest | getWeakestSettlement (2s cache) | entities/greed.ts |
+| Camera culling | isInCullRange (50 tiles) | systems/combat.ts |
+| Resource nodes | GoldVein, BerryBush | structures/resources.ts |
+| Shrine buffs | ArcherDamage, BuilderSpeed, WallDurability | structures/shrine.ts |
+
+---
+
+## Notes and Caveats
+
+- Kingdom Two Crowns has received multiple updates and DLC (Dead Lands, Shogun, Norse Lands, Challenge Islands) that may alter specific numbers.
+- Exact HP values, wave sizes, and scaling formulas are not fully documented in official sources. Numbers above represent best-known approximations from community wiki and player research.
+- Some mechanics may have been rebalanced in patches released after May 2025.
+- Cross-reference with the Kingdom wiki at `kingdomthegame.fandom.com` for most current values.

--- a/kingdom/KINGDOM_TODO.md
+++ b/kingdom/KINGDOM_TODO.md
@@ -1,0 +1,743 @@
+# Kingdom TUI: Complete Feature Todo List
+
+> Full recreation of Kingdom Two Crowns as a terminal-based game using blECSd.
+> Current status: ~20-25% complete. Core ECS framework, basic units, walls, day/night, and combat exist.
+> This document tracks EVERY feature needed for a complete recreation (minus graphics/pixel art).
+
+---
+
+## STATUS LEGEND
+- [ ] Not started
+- [x] Implemented
+- [~] Partially implemented (needs work)
+
+---
+
+## 1. TOWN CENTER / CASTLE PROGRESSION
+
+The heart of the kingdom. Upgrading unlocks new technologies and unit types.
+
+- [ ] **Town Center upgrade system** (6 tiers with costs and cooldowns)
+  - [ ] Tier 0: Unlit Campfire (starting ruins, found on each island)
+  - [ ] Tier 1: Campfire (1-3 coins) - unlocks hammer + bow tool stands
+  - [ ] Tier 2: Camp (3-6 coins) - unlocks second tool stand set
+  - [ ] Tier 3: Village (6-9 coins) - unlocks scythe vendor (farmers), free inner spike walls
+  - [ ] Tier 4: Town Hall (7-12 coins) - unlocks Banker NPC, siege workshop
+  - [ ] Tier 5: Stone Fortifications (8-15 coins, requires Stone tech) - free stone walls + watchtowers, pike shop
+  - [ ] Tier 6: Castle Keep (9-18 coins, requires Iron tech) - shields for knights, gem keeper
+  - [ ] Tier 7: Iron Keep (20 coins, Two Crowns only) - bomb banner, forge, free roofed triplet towers
+- [ ] Upgrade cooldown timer between tiers
+- [ ] Visual representation for each tier (distinct TUI chars)
+- [ ] Town center generates tool stands automatically per tier
+- [ ] Town center destruction = game over
+
+---
+
+## 2. WALL SYSTEM
+
+- [~] **Wall tiers** (currently 3: wood/stone/iron, need 5 tiers)
+  - [ ] Tier 1: Spikes/Dirt Mound (1 coin, 25 HP)
+  - [~] Tier 2: Wooden Palisade (3 coins, 50 HP)
+  - [~] Tier 3: Stone Wall (6 coins, 200 HP, requires Stone tech)
+  - [ ] Tier 4: Tall Stone Wall (9 coins, 300 HP)
+  - [~] Tier 5: Iron Wall (12 coins, 400 HP, requires Iron tech)
+- [ ] Blessed wall HP bonus (statue buff: +30-83% HP)
+- [ ] Proper decay resistance per tier (Tier 1: 2 days, Tier 5: 20 days)
+- [x] Wall chain bonuses (adjacent walls get +N HP)
+- [x] Auto-gates every 10 tiles from settlement center
+- [x] Gates block greed, allow friendlies
+- [ ] Walls expand outward only from town center (sequential placement rule)
+- [ ] Wall destruction drops builders' tools (builders revert to vagrant)
+
+---
+
+## 3. TOWER SYSTEM
+
+- [~] **Tower tiers** (currently 1 type, need 6 tiers)
+  - [ ] Tier 1: Rock Platform (3 coins, 1 archer)
+  - [ ] Tier 2: Wooden Watchtower (5 coins, 1 archer, medium height)
+  - [ ] Tier 3: Stone Tower (7 coins, 2 archers, requires Stone tech)
+  - [ ] Tier 4: Triplet Tower (9 coins, 3 archers)
+  - [ ] Tier 5: Roofed Triplet (requires Iron tech, 3 covered archers, floater-proof)
+  - [ ] Tier 6: Quadruplet Tower (4 covered archers, all elevated)
+- [~] Tower archer slots and range bonus (basic version exists)
+- [ ] Roofed towers protect archers from floater abduction
+- [ ] Tower placement only on outermost maxed walls
+
+### Special Tower Conversions (via Hermits)
+- [ ] Ballista Tower (Ballista Hermit, 6 coins, 1 builder operates)
+- [ ] Fire Tower (Fire Tower Hermit, 1 builder + 1 archer)
+- [ ] Bakery Tower (Bakery Hermit, 6 coins, produces 7 bread loaves)
+- [ ] Knight Tower (Knight Hermit, 6 coins, produces 1 shield)
+- [ ] Berserker Tower (Berserker Hermit, produces 1 potion)
+
+---
+
+## 4. FARM SYSTEM
+
+- [~] **Farm tiers** (basic version exists, needs proper mechanics)
+  - [~] Water Well / Basic Farm (3-5 coins, up to 4 crop plots, 1 farmer)
+  - [~] Mill House / Farmhouse (8 coins upgrade, up to 6 plots, overnight shelter)
+  - [ ] Farmer Statue blessing (+2 additional plots per farm)
+- [~] Crop growth cycle (~1 day to mature)
+- [~] Harvest amounts (4 coins Classic, 6 coins Two Crowns per plot)
+- [ ] Farmers retreat to town at night if no farmhouse
+- [ ] Farmers stay at farmhouse if upgraded
+- [ ] Farm destruction by greed (farm reverts to wild land)
+- [ ] Seasonal effects on farming (spring/summer normal, autumn 75%, winter 0%)
+- [ ] Berry bush foraging in winter (Two Crowns)
+- [ ] Max 3 farms per side (6 total)
+- [ ] Farms built near water streams
+
+---
+
+## 5. SIEGE WEAPONS
+
+- [~] **Ballista** (basic version in siege.ts)
+  - [~] 12 coin cost, 3 damage in 3-tile AoE
+  - [ ] Operated by builders (1-2 crew)
+  - [ ] Proper piercing damage (hits multiple greed in a line)
+- [ ] **Catapult** (NOT implemented)
+  - [ ] 6 coins to build, requires siege workshop (Town Tier 4+)
+  - [ ] 1-2 builders operate
+  - [ ] ~15 damage per shot, AoE
+  - [ ] Can one-shot floaters
+  - [ ] Stone ammunition (standard)
+  - [ ] Fire barrels (5 coins each, Two Crowns castle keep+)
+  - [ ] Breeders can pick up and throw back boulders
+  - [ ] One catapult per side maximum
+- [ ] **Bomb** (NOT implemented)
+  - [ ] 18 coins at Iron Keep
+  - [ ] 3 builders push it toward cave portal
+  - [ ] 5 coins to enter cave
+  - [ ] 5 coins to ignite at hive
+  - [ ] 15-30 second escape timer
+  - [ ] Destroys cave portal permanently
+  - [ ] Knights must escort
+
+---
+
+## 6. LIGHTHOUSE
+
+- [ ] **Lighthouse structure** (NOT implemented)
+  - [ ] Found at island edge (cape side)
+  - [ ] 3 upgrade tiers: Wooden (6 coins), Stone (12 coins), Iron (18 coins)
+  - [ ] Enables safe boat landing when returning to island
+  - [ ] Decay prevention: adds 10/20/30 days per tier
+  - [ ] Without lighthouse, returning boat crashes
+  - [ ] Only decays after ALL walls on island destroyed
+
+---
+
+## 7. FORGE
+
+- [ ] **Forge structure** (NOT implemented)
+  - [ ] Found on islands 3+ as ruins
+  - [ ] 6-10 coins to repair
+  - [ ] Produces iron swords (12 coins each)
+  - [ ] Squires pick up swords to become full Knights
+  - [ ] Requires Iron Keep tier + iron back wall
+
+---
+
+## 8. MONARCH & MOUNTS
+
+- [x] Monarch movement (walking, running)
+- [x] Coin dropping mechanic (one-shot rising edge)
+- [x] Basic horse mount (1.5x speed, 2x sprint)
+- [x] Stamina system (100 max, depletion/recharge)
+- [~] Speed boost (exists but was moved from index.ts)
+- [ ] **Crown mechanic** (NOT implemented)
+  - [ ] Crown knocked off when hit with 0 coins
+  - [ ] Crown can be recovered if greedling killed before reaching portal
+  - [ ] Crown lost = game over (currently just GamePhase.GameOver)
+  - [ ] Crown animation/visual when dropped
+- [ ] **Multiple mount types** (only horse exists)
+  - [ ] Griffin (2 gems, 8 coins) - wing-flap knockback, faster
+  - [ ] Stag (1 gem, 3 coins) - forest speed bonus, attracts deer
+  - [ ] Warhorse (2 gems, 8 coins) - ally invincibility skill (10s)
+  - [ ] Wild Horse (1 gem, 4 coins) - highest stamina, forest speed
+  - [ ] Bear (3 gems, 11 coins) - creature pounce instakill, slow
+  - [ ] Lizard (3 gems, 10 coins) - fire breath, sun-dependent recovery
+  - [ ] Unicorn (4 gems, 12 coins) - grass eating generates 3 coins
+- [ ] Mount loss on monarch hit (mount returns to stable)
+- [ ] Mount switching at stables (3 coins per switch)
+- [ ] Mount-specific grazing mechanics (grass, berries, sun, etc.)
+- [ ] Gem costs for mount unlocks
+
+---
+
+## 9. UNIT TYPES
+
+### Vagrants & Recruitment
+- [x] Vagrant spawning from camps
+- [x] 5 NPC origin types (Standard/Warrior/Scout/Craftsman/Peasant)
+- [x] Coin-based recruitment
+- [ ] Bread-based recruitment (from Bakery)
+- [ ] Vagrant camp locations in forest
+- [ ] Vagrants freeze and crouch when threatened
+
+### Archers
+- [x] Bow recruitment (2 coins)
+- [x] Daytime hunting behavior
+- [x] Nighttime wall defense
+- [x] Kill-based leveling (range/cooldown)
+- [x] Scout origin bonus (+3 range)
+- [ ] Tower assignments (dedicated tower archers vs ground hunters)
+- [ ] Accuracy: 33% ground, ~100% from towers
+- [ ] Can carry up to 11 coins
+- [ ] Even distribution between left/right sides
+- [ ] Blessed aim (statue buff: perfect accuracy)
+
+### Builders
+- [x] Hammer recruitment (3 coins, currently 2)
+- [x] Build/repair walls
+- [x] Auto-defensive wall placement
+- [x] Craftsman origin bonus (1.5x speed)
+- [ ] Tree cutting for coins/clearing land
+- [ ] Operate catapults and ballistas (1-2 builders)
+- [ ] Push bombs toward caves
+- [ ] Push boats to dock
+- [ ] Roll fire barrels to catapults
+- [ ] No self-preservation at night (execute orders regardless of danger)
+- [ ] Idle behavior: head toward nearest outer wall
+- [ ] Can carry up to 2 coins
+
+### Farmers
+- [x] Farm working with production multipliers
+- [x] Peasant origin bonus (+50% output)
+- [ ] Proper scythe/pitchfork recruitment (4 coins, Town Center Tier 3)
+- [ ] Return to town center at night (no farmhouse)
+- [ ] Stay at farmhouse overnight (upgraded farm)
+- [ ] Winter behavior: idle or berry foraging
+- [ ] Can carry up to 14 coins
+
+### Knights / Squad Leaders
+- [~] Knight recruitment (exists, needs squire/knight split)
+- [ ] **Squire tier** (4 coins for shield)
+  - [ ] Squire commands 4 archers as a squad
+  - [ ] Shield absorbs multiple hits
+  - [ ] Can carry 5 coins
+- [ ] **Knight tier** (12 coins for iron sword at forge)
+  - [ ] Promoted from squire
+  - [ ] Enhanced combat capability
+  - [ ] Can carry 11 coins
+- [ ] Portal assault mechanic (drop coin at wall banner to send knight + squad)
+- [ ] Knight charge behavior
+- [ ] Defensive shield wall formation at outer walls
+- [ ] Knight escort for bomb transport
+- [ ] Boat escort duty
+
+### Pikemen / Ninjas (NOT implemented)
+- [ ] Pike recruitment (2 coins, requires pike vendor at Stone tier)
+- [ ] Daytime fishing (1 coin per fish, riverside)
+- [ ] Nighttime defense at outer walls
+- [ ] Pike thrust: AoE damage killing multiple greedlings
+- [ ] Formation of 8 per wall section (alternating pike angles)
+- [ ] Effective against floaters and crown stealers
+- [ ] Pike durability (degrades per kill, not per thrust)
+- [ ] Ninja variant (Shogun DLC)
+
+### Hermits (NOT implemented - 7 types)
+- [ ] **Hermit system** (ride on monarch's mount, one at a time)
+- [ ] Hermit cottages in forests (island-specific)
+- [ ] Gem cost to coax + coin to mount
+- [ ] Hermit kidnapping by greed (rescue via bomb/cave destruction)
+- [ ] **Ballista Hermit** (Island 1, 3 gems) - converts towers to ballistas
+- [ ] **Stable Hermit** (Island 2, 1 gem) - farmhouse conversion, mount summoning
+- [ ] **Bakery Hermit** (Island 3, 4 gems) - tower to bakery, bread production
+- [ ] **Knight Hermit** (Island 4, 2 gems) - tower to squire tower, armor forging
+- [ ] **Horn Hermit** (Island 5, 3 gems) - wall to horn wall, nightly troop reinforcement
+- [ ] **Fire Tower Hermit** - converts towers to fire towers
+- [ ] **Berserker Hermit** - converts towers to berserker towers
+
+### Dog Companion (NOT implemented)
+- [ ] Found under fallen tree on Island 2
+- [ ] 1 coin to free (coin returned)
+- [ ] Follows monarch, warns of approaching greed (barks toward threat)
+- [ ] Can be kidnapped by greedlings
+- [ ] Recovery via bomb, crown loss, or ransom
+
+### Merchant NPC (NOT implemented)
+- [ ] Appears on Islands 1-2 only
+- [ ] Pay 1 coin, returns 8 coins (7-coin profit)
+- [ ] Daytime only, not during danger
+- [ ] Camp in forest (destroyed if trees cut)
+
+### Banker NPC (NOT implemented)
+- [ ] Appears at Town Hall (Tier 4+)
+- [ ] Daytime only (dawn bell to sunset)
+- [ ] Deposit coins (walks to castle door at 10+ coins)
+- [ ] Withdrawal: smaller of 1/3 stored or pouch capacity
+- [ ] Interest: 7% daily (3-100 coins), 8 coins max (101+ coins)
+- [ ] Coins persist across islands in Two Crowns
+- [ ] Transfer to heirs on crown loss
+
+---
+
+## 10. GREED ENEMY TYPES
+
+### Basic Greedling
+- [x] 1 HP, moderate speed
+- [x] Steal coins from monarch
+- [x] Wall damage
+- [ ] Tool theft (stolen tool = subject reverts to vagrant)
+- [ ] Flee at sunrise (retreat to portal)
+- [ ] ~1 charge per second attack rate
+
+### Masked Greedling
+- [x] 2+ HP (mask absorbs first hit)
+- [x] 50% armor vs basic arrows (bypassed by tower archers)
+- [ ] Significantly more wall damage than basic
+- [ ] Front mask visual (breaks off after first hit)
+
+### Floater
+- [~] Flies over walls (basic version exists)
+- [ ] 12 HP (currently much less)
+- [ ] Slow flight speed
+- [ ] **Abducts 2 villagers** (grab and carry to portal) - NOT stealing coins
+- [ ] Ignores coins and tools entirely
+- [ ] Targets townspeople exclusively
+- [ ] First appears during 3rd Blood Moon
+- [ ] Does NOT flee at sunrise (fights until dead)
+- [ ] Countered by roofed towers, catapults, heavy archer fire
+- [ ] Creates "trains of floaters" in late game
+
+### Breeder
+- [~] Basic version exists (3 HP, spawns 2 mini-greeds)
+- [ ] Proper breeder: ~70 HP tank
+- [ ] Punch attack (knocks down swathes of defenders, disarms them)
+- [ ] Boulder throwing (picks up catapult stones, hurls at walls/soldiers)
+- [ ] Continuous greedling spawning (4 greed every few seconds)
+- [ ] Mount fear (monarch's mount panics briefly near breeders)
+- [ ] Does NOT flee at sunrise
+- [ ] Armored variant (late game, wears mask, spawns masked greedlings)
+
+### Crown Stealer
+- [~] Basic version exists (pathfinds around walls)
+- [ ] 8 HP (currently 2)
+- [ ] Faster than any mount
+- [ ] Bypasses walls, coins, gems entirely
+- [ ] Instantly knocks crown off on contact
+- [ ] Crown lost forever if not recovered in seconds
+- [ ] Can ride breeders
+- [ ] Constellation warning in sky before first appearance
+- [ ] Eerie creaking sound on portal exit
+- [ ] First appears: Blood Moons around day 130, regular waves day 190+
+
+### Crusher (NOT implemented - Norse Lands / Call of Olympus)
+- [ ] ~20 hits to defeat
+- [ ] Armored shell (invulnerable to arrows)
+- [ ] Charge attack (destroys weak walls, knocks down subjects)
+- [ ] Slower than greedlings, faster than breeders
+- [ ] Stunned after charge against strong walls or shield walls
+- [ ] Appears around night 30+
+- [ ] Retreats when all accompanying greedlings eliminated
+
+---
+
+## 11. WAVE SYSTEM
+
+- [~] Nightly waves from active portals
+- [x] Per-portal difficulty scaling
+- [x] Wave composition by day count (basic -> masked -> floater -> breeder -> crown stealer)
+- [x] Blood moons every 7 days (3x multiplier)
+- [x] Roaming bands during day
+- [x] Retaliation waves on portal destruction
+- [ ] **Proper wave scaling formula** based on day count + island multiplier
+  - [ ] Island 1: 1.0x, Island 2: 1.25x, Island 3: 1.5x, Island 4: 1.75x, Island 5: 2.0x
+- [ ] Waves timed to reach kingdom borders by midnight
+- [ ] Blood moon duration: does not end until ALL monsters defeated
+- [ ] Recovery: peaceful night after blood moon
+- [ ] One-sided waves (attack one flank from random portal)
+- [ ] Portal defense waves (triggered when attacking a portal)
+  - [ ] Continuous small groups during portal assault
+  - [ ] Difficulty ramps smoothly over time
+- [ ] Proper blood moon schedule (every 4-6 days, not fixed 7)
+  - [ ] Two Crowns: ~2 days before season change
+  - [ ] Year 3+: frequency doubles (two per season)
+- [ ] Blood moon visual indicators (red sky, stormy day, reddish day counter)
+- [ ] Audio cue: rumbling 40 seconds before midnight
+
+---
+
+## 12. ISLAND PROGRESSION
+
+- [~] 5 islands with difficulty scaling (basic ship transition exists)
+- [ ] **Island 1: Tutorial**
+  - [ ] Smallest map, no small portals, no gem chests
+  - [ ] 1 cliff portal, 2 dock portals
+  - [ ] Unlockables: Archery Statue (3 gems, 10 coins), Griffin (2 gems, 8 coins), Ballista Hermit
+  - [ ] 3 vagrant camps, merchant present, 3 coin chests (36 coins)
+  - [ ] Ghost of past monarch tutorial
+- [ ] **Island 2: Stone Tech**
+  - [ ] Introduces gem chests, 1 small portal per side
+  - [ ] Unlockables: Stone Mine (10 coins), Farmer Statue (1 gem), Stag (1 gem), Stable Hermit
+  - [ ] Dog companion available
+- [ ] **Island 3: Forge Island**
+  - [ ] 4-6 cliff portals + cave portal appears
+  - [ ] Unlockables: Warhorse (2 gems), Baker Hermit (4 gems), Builder Statue (3 gems), Pony (1 gem)
+  - [ ] Forge ruin for weapon upgrades
+- [ ] **Island 4: Advanced Warfare**
+  - [ ] No merchant, many portals
+  - [ ] Unlockables: Bear (3 gems), Lizard (3 gems), Knight Hermit (2 gems)
+  - [ ] First bomb access for cave destruction
+- [ ] **Island 5: Final Island**
+  - [ ] Maximum portals, extreme difficulty
+  - [ ] Unlockables: Unicorn (4 gems), Knight Statue (2 gems), Horn Hermit (3 gems)
+  - [ ] Victory: destroy ALL portals
+- [ ] Island-specific map generation (size increases per island)
+- [ ] Island-specific unlockable placement
+- [ ] Island stats board tracking accomplishments
+- [ ] Campaign completion message
+
+---
+
+## 13. GEM CURRENCY
+
+- [ ] **Gem system** (NOT implemented)
+  - [ ] Secondary currency, more valuable than coins
+  - [ ] Persists across islands
+  - [ ] Total gems available per campaign: 38 (standard), 41 (Norse)
+  - [ ] Gem chests in forests (island 2+)
+  - [ ] Portal destruction drops gems (cliff: 1-4, cave: 4-8)
+  - [ ] Gems never vanish from ground
+  - [ ] Gems only knocked out after ALL coins lost
+  - [ ] Permanently lost if crown is lost
+  - [ ] Gem Keeper NPC (Castle Keep tier) stores gems across islands
+  - [ ] 1 coin per gem deposit/retrieval transaction
+  - [ ] Uses: unlock mounts, statues, hermits
+
+---
+
+## 14. BOAT & SAILING
+
+- [~] Ship exists for island transition (basic version in ship.ts)
+- [ ] **Proper boat mechanics**
+  - [ ] Boat wreck found at island edge
+  - [ ] 10 coins to begin restoration
+  - [ ] Hull pieces: 59 at 2 coins each (118 coins total)
+  - [ ] Island 1: all pieces free, Island 2: 40 free
+  - [ ] Builders hammer pieces into place
+  - [ ] Uninstalled parts can be stolen by greedlings
+  - [ ] 2 coins to launch (drops into river)
+  - [ ] Builders push vessel toward dock
+  - [ ] Dock bell: 2 coins to summon 3 workers + 3 knights
+  - [ ] 10 coins to depart
+  - [ ] Dog/hermits auto-board
+  - [ ] Archers in crow's nest during transit (New Lands)
+- [ ] Return to previous islands
+- [ ] Island select screen
+
+---
+
+## 15. DECAY SYSTEM
+
+- [ ] **Structure decay** (NOT implemented)
+  - [ ] Begins when monarch leaves an island
+  - [ ] Walls decay from outermost to innermost, by tier
+  - [ ] Decay rates per wall tier: Tier 1 (2 days), Tier 2 (4 days), Tier 3 (8 days), Tier 4 (12 days), Tier 5 (20 days)
+  - [ ] Lighthouse adds 10/20/30 days decay protection per tier
+  - [ ] Subjects lose tools when all walls on one side decay
+  - [ ] Archers abandon towers (towers remain intact)
+  - [ ] Farms unprotected but intact
+  - [ ] Crown loss = 100 days decay across ALL unlocked islands
+  - [ ] Completed islands (all portals destroyed) no longer decay (since v2.0.0)
+  - [ ] Banker coins persist through decay
+  - [ ] Gems never decay
+
+---
+
+## 16. SEASONS
+
+- [ ] **Seasonal system** (NOT implemented)
+  - [ ] 4 seasons cycling: Spring -> Summer -> Autumn -> Winter
+  - [ ] 16 days per season, 64 days full cycle
+  - [ ] Seasons persist across islands (global day count)
+
+### Spring
+- [ ] Green grass, foliage appears
+- [ ] Wildlife spawns regularly
+- [ ] Farms fully productive
+- [ ] Occasional rainfall visual
+
+### Summer
+- [ ] Peak farm productivity
+- [ ] Maximum wildlife and tall grass
+- [ ] No rainfall
+- [ ] Ideal time to stockpile coins
+
+### Autumn
+- [ ] Leaves/cattails turn red (visual warning)
+- [ ] Similar mechanics to earlier seasons
+- [ ] Farm output reduced to ~75%
+
+### Winter (16 days)
+- [ ] Farms produce nothing, streams freeze
+- [ ] Rabbit dens destroyed, deer cease spawning
+- [ ] Berry bushes appear (farmer foraging, 12-16 coins per bush group)
+- [ ] Single boar appears (worth 30 coins if killed)
+- [ ] Only merchant income and banker interest remain
+- [ ] Pikemen fishing continues (Europe)
+- [ ] Mounts lose well-fed buff
+- [ ] Shorter daylight, longer nights
+- [ ] Snow visual effects
+
+---
+
+## 17. PORTAL MECHANICS
+
+- [x] 5 portals across map
+- [x] Per-portal difficulty scaling
+- [x] Portal destruction (permanent)
+- [x] Retaliation waves on destruction
+- [x] Victory: all portals destroyed on island 5
+- [ ] **Portal types** (currently all same)
+  - [ ] Small cliff portals (scattered in forest)
+  - [ ] Large cliff portals (further out)
+  - [ ] Dock portals (at far side dock, has tentacle defense)
+  - [ ] Cave portal (The Greed Nest, requires bomb to destroy)
+- [ ] Portal-to-teleporter conversion (destroyed portals become teleport points)
+- [ ] Portal assault by knight squads
+- [ ] Portal defense waves during assault (continuous spawning)
+- [ ] Portal HP that persists (damage is permanent)
+- [ ] Gem drops from destroyed portals
+
+---
+
+## 18. STATUES
+
+- [ ] **Statue system** (NOT implemented)
+  - [ ] Found on specific islands, unlocked with gems, activated with coins
+  - [ ] **Archer Statue** (Island 1, 4 gems unlock, 10 coins activate) - perfect accuracy
+  - [ ] **Farmer Statue** (Island 2, 1 gem unlock, 7 coins activate) - +2 farmers per farm
+  - [ ] **Builder Statue** (Island 3, 3 gems unlock, 9 coins activate) - wall HP amplification
+  - [ ] **Knight Statue** (Island 5, 2 gems unlock, 9 coins activate) - jump-slash ability
+  - [ ] Statue blessings increase wall HP by 30-83%
+  - [ ] Statue effects are temporary (duration-based)
+
+---
+
+## 19. ECONOMY & INCOME
+
+- [x] Coin economy (basic)
+- [x] Hunting income (rabbits 1, deer 3)
+- [x] Farm income with multipliers
+- [x] Scaled recruitment costs
+- [x] Gold vein mining
+- [~] Shrine costs (base + inflation)
+- [ ] **Dawn bonus** (2 coins every morning)
+- [ ] **Merchant income** (1 coin investment -> 8 coins return)
+- [ ] **Banker interest** (7% daily, capped at 8 coins)
+- [ ] **Pikeman fishing** (1 coin per fish, daytime)
+- [ ] **Food cache** consumables (+3 coins one-time, found in ruins)
+- [ ] **Coin bag capacity** per unit type:
+  - [ ] Peasant/Builder: 2 coins
+  - [ ] Archer/Knight: 11 coins
+  - [ ] Farmer: 14 coins
+  - [ ] Pikeman/Ninja: 0 coins
+  - [ ] Squire: 5 coins
+- [ ] Coin overflow: 50/50 drop or discard into water
+- [ ] **Tax chest** (Classic: 5 coins/day at Tier 1, increases with tier)
+
+---
+
+## 20. COUNTER-ATTACK / OFFENSIVE SYSTEM
+
+- [~] Knights attack portals (basic version)
+- [ ] **Proper portal assault**
+  - [ ] Drop coin at outermost wall banner to dispatch knight + squad
+  - [ ] Knight + 4 archers march toward nearest portal
+  - [ ] Knights defend archers, archers split attention (greed + portal)
+  - [ ] Portal damage is permanent (does not regenerate)
+  - [ ] Portal defense waves scale smoothly over time
+- [ ] **Catapult assault** (builders push catapult toward portal)
+- [ ] **Bomb assault** (builders push bomb to cave, knights escort)
+  - [ ] Cave interior: hives equal to island number
+  - [ ] Greed Nest core requires coin to light bomb
+  - [ ] 4-day restoration timer
+  - [ ] Escape sequence (15-30 seconds)
+
+---
+
+## 21. SAVE / LOAD / PERSISTENCE
+
+- [x] JSON save/load to ~/.kingdom-save.json
+- [x] Auto-save every 30 seconds
+- [ ] Per-island save state (multiple islands with independent state)
+- [ ] Cross-island persistence (gems, global day count, unlocks)
+- [ ] Banker coins persist across islands
+- [ ] Heir succession on crown loss (return to same island with some decay)
+- [ ] Island unlock tracking
+- [ ] Stats board per island
+
+---
+
+## 22. RENDERING & UI
+
+- [x] Terminal-based TUI with blECSd CellBuffer
+- [x] Day/night sky color transitions
+- [x] Structure rendering (walls, campfire, farms, towers)
+- [x] Unit rendering with distinct chars/colors
+- [x] NPC subtype visual distinction
+- [x] Greed rendering
+- [x] Projectile rendering
+- [x] Animal rendering (rabbits/deer)
+- [x] Dropped coin rendering (pulsing)
+- [x] Blueprint/construction rendering
+- [x] Wall HP bars above damaged walls
+- [x] HUD with coins, day count, time, unit counts
+- [x] Interactable prompt display
+- [x] Night overlay
+- [x] Parallax stars/clouds
+- [x] Screen shake on wall breach
+- [x] Message log (last 3 messages)
+- [ ] **Title screen** (proper menu with New Game / Continue / Island Select)
+- [ ] **Game over screen** (crown lost animation)
+- [ ] **Victory screen** (campaign completion)
+- [ ] **Island select / map screen**
+- [ ] **Blood moon visual** (red sky tint, stormy daytime)
+- [ ] **Seasonal visual changes** (green spring, yellow autumn, white winter snow)
+- [ ] **Weather effects** (rain, snow, wind)
+- [ ] **Crown animation** (bouncing when knocked off)
+- [ ] **Coin sparkle effects** when picked up
+- [ ] **Sunrise/sunset color gradient** transitions
+- [ ] **Water reflections** / animated water
+- [ ] **Campfire glow radius** (warm light around fire)
+- [ ] **Northern lights** (Norse Lands winter)
+- [ ] **Constellation warning** (crown stealer sky pattern)
+- [ ] **Minimap** or expanded map view
+
+---
+
+## 23. AUDIO / SOUND
+
+- [~] Terminal bell on events (basic)
+- [ ] **Sound effects** (terminal beep patterns)
+  - [ ] Coin pickup sound
+  - [ ] Wall breach alert
+  - [ ] Blood moon warning rumble
+  - [ ] Sunrise/sunset bell
+  - [ ] Greed approach warning (dog bark)
+  - [ ] Crown stealer creaking sound
+  - [ ] Build completion sound
+  - [ ] Recruitment sound
+
+---
+
+## 24. INPUT & CONTROLS
+
+- [x] Arrow keys / A/D for movement
+- [x] Shift for sprint
+- [x] Space for coin drop
+- [x] Held-key tracking (120ms expiry)
+- [ ] **Additional controls**
+  - [ ] Enter/E for interaction (recruit, activate shrine, enter boat)
+  - [ ] Number keys for quick actions
+  - [ ] Tab for minimap toggle
+  - [ ] Q for quit/menu
+  - [ ] P for pause
+  - [ ] Direction-specific coin drop (left/right)
+
+---
+
+## 25. CHALLENGE ISLANDS (Post-Game Content)
+
+- [ ] Skull Island (survive as long as possible, hourglass statue delays defeat)
+- [ ] Dire Island (harder variant)
+- [ ] Plague Island (parasites that climb walls)
+- [ ] Trade Routes
+- [ ] Lost Islands
+
+---
+
+## 26. CO-OP / MULTIPLAYER
+
+- [ ] Two-monarch system
+- [ ] Shared kingdom
+- [ ] Split resources
+- [ ] Both monarchs must board boat to sail
+- [ ] Independent crown mechanics
+
+---
+
+## PRIORITY ORDER FOR IMPLEMENTATION
+
+### Phase 6: Core Systems Foundation
+1. Town Center upgrade system (6-7 tiers)
+2. Proper wall tiers (5 levels with costs/HP)
+3. Proper tower tiers (6 levels with archer capacity)
+4. Gem currency system
+5. Seasonal system (4 seasons, 16 days each)
+
+### Phase 7: NPCs & Economy
+6. Banker NPC (interest, deposits, withdrawals)
+7. Merchant NPC (income source)
+8. Pikemen/Ninja unit type (fishing + pike combat)
+9. Squire/Knight progression (shield -> sword)
+10. Dog companion
+
+### Phase 8: Structures & Tech
+11. Catapult (build, operate, fire)
+12. Bomb (build, push, cave destruction)
+13. Lighthouse (decay prevention, safe landing)
+14. Forge (iron swords, knight promotion)
+15. Proper farm upgrades (farmhouse with shelter)
+
+### Phase 9: Enemy Overhaul
+16. Proper breeder (70 HP, punch, boulder throw, continuous spawning)
+17. Proper floater (12 HP, villager abduction, ignore coins)
+18. Proper crown stealer (8 HP, faster than mounts, bypass walls)
+19. Crusher/Boss greed (armored, charge attack)
+20. Improved wave scaling (day count + island multiplier)
+
+### Phase 10: Island & Progression
+21. Island-specific map generation (size, portals, features)
+22. Island-specific unlockables (mounts, hermits, statues)
+23. Proper boat mechanics (hull pieces, boarding, dock bell)
+24. Decay system (structure degradation on island departure)
+25. Portal-to-teleporter conversion
+
+### Phase 11: Hermits & Mounts
+26. Hermit system (7 types, cottage locations, gem costs)
+27. Multiple mount types (7+ with unique abilities)
+28. Statue system (4+ types with gem unlocks and activation buffs)
+29. Special tower conversions (ballista, bakery, knight, fire, berserker)
+
+### Phase 12: Polish & Completeness
+30. Counter-attack system (knight portal assault with banner mechanic)
+31. Title screen, game over, victory, island select screens
+32. Seasonal visual effects (spring green, autumn red, winter snow)
+33. Blood moon visual/audio indicators
+34. Proper save/load with per-island state
+35. Weather effects (rain, snow)
+36. Challenge islands (post-game content)
+37. Co-op multiplayer (stretch goal)
+
+---
+
+## IMPLEMENTATION NOTES
+
+### File Ownership (Agent Assignments)
+- **Agent 1 (Rendering/Core):** renderer.ts, hud.ts, index.ts, types.ts, terrain.ts, map.ts, camera.ts, effects.ts, sound.ts
+- **Agent 2 (Entities/Economy):** monarch.ts, villager.ts, builder.ts, archer.ts, farmer.ts, knight.ts, animals.ts, mount.ts, economy.ts, ai.ts
+- **Agent 3 (Systems/Structures):** combat.ts, wall.ts, portal.ts, resources.ts, shrine.ts, ship.ts, siege.ts, spawn.ts, construction.ts, movement.ts, greed.ts
+
+### New Files Likely Needed
+- `entities/pikeman.ts` - Pikeman/ninja unit
+- `entities/hermit.ts` - Hermit NPC system
+- `entities/dog.ts` - Dog companion
+- `entities/merchant.ts` - Merchant NPC
+- `entities/banker.ts` - Banker NPC
+- `structures/townCenter.ts` - Town center upgrade tiers
+- `structures/catapult.ts` - Catapult weapon
+- `structures/bomb.ts` - Bomb for cave destruction
+- `structures/lighthouse.ts` - Lighthouse structure
+- `structures/forge.ts` - Forge for iron swords
+- `structures/statue.ts` - Statue blessing system
+- `systems/seasons.ts` - Seasonal cycle and effects
+- `systems/gems.ts` - Gem currency system
+- `systems/decay.ts` - Island decay mechanics
+- `systems/teleporter.ts` - Portal-to-teleporter conversion
+- `game/islandSelect.ts` - Island selection screen
+- `game/titleScreen.ts` - Title/menu screen

--- a/kingdom/entities/animals.ts
+++ b/kingdom/entities/animals.ts
@@ -1,0 +1,398 @@
+/**
+ * Animal entities - rabbits, deer, and boars that spawn in forest areas.
+ * Archers hunt them during the day for coin rewards.
+ * Animals flee from nearby entities and respawn over time.
+ *
+ * Seasonal effects:
+ * - Spring/Summer: normal spawning
+ * - Autumn: 1.5x respawn interval (reduced spawn rate)
+ * - Winter: no rabbits or deer spawn at all. Instead, 1 boar spawns.
+ *   Boar: 30 coins reward, 5 HP, slow, aggressive (charges nearby entities).
+ *
+ * Animal data is stored in module-level state since GameState
+ * doesn't have an animals field (types.ts is shared/locked).
+ */
+import { addEntity, removeEntity, getPosition, setPosition, setVelocity } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  Season,
+  GROUND_Y,
+  MAP_WIDTH,
+  TimeOfDay,
+  clamp,
+  distance,
+} from '../types';
+import { collectCoins } from '../game/economy';
+import { getBiome, Biome } from '../world/terrain';
+import { isStagMounted } from './mount';
+
+// ─── Animal Constants ─────────────────────────────────────────────
+const MAX_ANIMALS = 12;
+const MAX_BOARS = 1;
+const RESPAWN_INTERVAL = 12; // seconds between spawns
+const FLEE_RANGE = 8;        // tiles: animals flee if entity is closer
+const RABBIT_SPEED = 10;
+const DEER_SPEED = 4;
+const BOAR_SPEED = 3;
+const BOAR_CHARGE_SPEED = 6;
+const RABBIT_REWARD = 1;
+const DEER_REWARD = 3;
+const BOAR_REWARD = 30;
+const BOAR_CHARGE_RANGE = 10;
+
+// Forest zones derived from terrain biome layout
+const FOREST_ZONES: ReadonlyArray<{ min: number; max: number }> = [
+  { min: 10, max: 60 },
+  { min: 180, max: 260 },
+  { min: 520, max: 570 },
+  { min: 830, max: 940 },
+  { min: 1140, max: 1190 },
+];
+
+export type AnimalType = 'rabbit' | 'deer' | 'boar';
+
+export interface AnimalData {
+  eid: Entity;
+  type: AnimalType;
+  x: number;
+  y: number;
+  vx: number;
+  hp: number;
+  reward: number;
+  fleeing: boolean;
+}
+
+// ─── Rabbit Den ──────────────────────────────────────────────────
+const DEN_SPAWN_INTERVAL = 45; // seconds per rabbit
+const DEN_MAX_RABBITS = 2;
+const STAG_ATTRACT_RANGE = 20;
+const STAG_ATTRACT_SPEED = 1.5; // slow approach
+
+export interface RabbitDen {
+  x: number;
+  rabbitsAlive: number;
+  spawnTimer: number;
+}
+
+// Fixed den positions in forest zones
+const DEN_POSITIONS = [35, 220, 545, 870, 1160];
+
+// ─── Module State ─────────────────────────────────────────────────
+const animals: AnimalData[] = [];
+let respawnTimer = 0;
+const rabbitDens: RabbitDen[] = [];
+let densInitialized = false;
+
+/** Get current animal list (read-only view for other modules). */
+export function getAnimals(): readonly AnimalData[] {
+  return animals;
+}
+
+/** Spawn a single animal at the given x position. */
+export function spawnAnimal(state: GameState, x: number, type?: AnimalType): AnimalData {
+  const animalType = type ?? (Math.random() < 0.6 ? 'rabbit' : 'deer');
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  let hp = 1;
+  let reward = animalType === 'rabbit' ? RABBIT_REWARD : DEER_REWARD;
+  if (animalType === 'boar') {
+    hp = 5;
+    reward = BOAR_REWARD;
+  }
+
+  const animal: AnimalData = {
+    eid,
+    type: animalType,
+    x,
+    y: GROUND_Y - 1,
+    vx: 0,
+    hp,
+    reward,
+    fleeing: false,
+  };
+
+  animals.push(animal);
+  return animal;
+}
+
+/**
+ * Kill an animal by index. Awards coins and removes the entity.
+ * Returns true if the animal was successfully killed.
+ */
+export function killAnimal(state: GameState, index: number): boolean {
+  if (index < 0 || index >= animals.length) return false;
+  const animal = animals[index];
+  collectCoins(state, animal.reward);
+  notifyDenOfDeath(animal.eid);
+  removeEntity(state.world, animal.eid);
+  animals.splice(index, 1);
+
+  state.messages.push(`Hunted a ${animal.type} (+${animal.reward} coins)`);
+  return true;
+}
+
+/** Main update: flee behavior, movement, respawn timer. */
+export function updateAnimals(state: GameState, dt: number): void {
+  // Only active during day/dawn
+  if (state.timeOfDay === TimeOfDay.Night) {
+    // Animals hide at night, stop moving (except boars which are aggressive)
+    for (const animal of animals) {
+      if (animal.type !== 'boar') {
+        animal.vx = 0;
+      }
+    }
+    return;
+  }
+
+  // Update each animal
+  for (const animal of animals) {
+    if (animal.type === 'boar') {
+      updateBoarBehavior(state, animal, dt);
+    } else {
+      updateAnimalFlee(state, animal);
+    }
+    updateAnimalMovement(state, animal, dt);
+  }
+
+  // Seasonal respawn logic
+  const effectiveInterval = getSeasonalRespawnInterval(state);
+
+  if (state.season === Season.Winter) {
+    // Winter: no rabbits/deer, only boars
+    respawnTimer += dt;
+    const boarCount = animals.filter(a => a.type === 'boar').length;
+    if (respawnTimer >= effectiveInterval && boarCount < MAX_BOARS) {
+      respawnTimer -= effectiveInterval;
+      spawnRandomBoar(state);
+    }
+  } else {
+    // Normal seasons: spawn rabbits and deer
+    respawnTimer += dt;
+    const normalCount = animals.filter(a => a.type !== 'boar').length;
+    if (respawnTimer >= effectiveInterval && normalCount < MAX_ANIMALS) {
+      respawnTimer -= effectiveInterval;
+      spawnRandomAnimal(state);
+    }
+  }
+}
+
+function getSeasonalRespawnInterval(state: GameState): number {
+  switch (state.season) {
+    case Season.Autumn:
+      return RESPAWN_INTERVAL * 1.5;
+    case Season.Winter:
+      return RESPAWN_INTERVAL * 2; // boar spawn rate
+    default:
+      return RESPAWN_INTERVAL;
+  }
+}
+
+/** Boar: aggressive, charges at nearby entities. */
+function updateBoarBehavior(
+  state: GameState,
+  animal: AnimalData,
+  _dt: number,
+): void {
+  // Find nearest target (monarch or units)
+  let closestX: number | undefined;
+  let closestDist = Infinity;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (monarchPos) {
+    const d = distance(animal.x, monarchPos.x);
+    if (d < BOAR_CHARGE_RANGE && d < closestDist) {
+      closestDist = d;
+      closestX = monarchPos.x;
+    }
+  }
+
+  for (const unit of state.units) {
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    const d = distance(animal.x, pos.x);
+    if (d < BOAR_CHARGE_RANGE && d < closestDist) {
+      closestDist = d;
+      closestX = pos.x;
+    }
+  }
+
+  if (closestX !== undefined) {
+    // Charge toward target
+    animal.fleeing = false;
+    const dir = closestX > animal.x ? 1 : -1;
+    animal.vx = dir * BOAR_CHARGE_SPEED;
+  } else {
+    // Wander slowly
+    animal.fleeing = false;
+    if (Math.random() < 0.01) {
+      animal.vx = (Math.random() - 0.5) * 2 * BOAR_SPEED;
+    }
+    animal.vx *= 0.95;
+    if (Math.abs(animal.vx) < 0.1) animal.vx = 0;
+  }
+}
+
+function spawnRandomBoar(state: GameState): void {
+  const zone = FOREST_ZONES[Math.floor(Math.random() * FOREST_ZONES.length)];
+  const x = zone.min + Math.random() * (zone.max - zone.min);
+  spawnAnimal(state, x, 'boar');
+  state.messages.push('A wild boar appears in the forest!');
+}
+
+function updateAnimalFlee(state: GameState, animal: AnimalData): void {
+  // Stag mount: deer are attracted instead of fleeing
+  if (animal.type === 'deer' && isStagMounted(state)) {
+    const monarchPos = getPosition(state.world, state.monarch.eid);
+    if (monarchPos) {
+      const d = distance(animal.x, monarchPos.x);
+      if (d < STAG_ATTRACT_RANGE && d > 2) {
+        // Slowly approach the stag-mounted monarch
+        animal.fleeing = false;
+        const dir = monarchPos.x > animal.x ? 1 : -1;
+        animal.vx = dir * STAG_ATTRACT_SPEED;
+        return;
+      }
+      if (d <= 2) {
+        // Close enough, just idle near monarch
+        animal.fleeing = false;
+        animal.vx *= 0.9;
+        if (Math.abs(animal.vx) < 0.1) animal.vx = 0;
+        return;
+      }
+    }
+  }
+
+  // Check for nearby entities (units + monarch) and flee from them
+  let closestThreatX: number | undefined;
+  let closestThreatDist = Infinity;
+
+  // Check monarch
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (monarchPos) {
+    const d = distance(animal.x, monarchPos.x);
+    if (d < FLEE_RANGE && d < closestThreatDist) {
+      closestThreatDist = d;
+      closestThreatX = monarchPos.x;
+    }
+  }
+
+  // Check all units
+  for (const unit of state.units) {
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    const d = distance(animal.x, pos.x);
+    if (d < FLEE_RANGE && d < closestThreatDist) {
+      closestThreatDist = d;
+      closestThreatX = pos.x;
+    }
+  }
+
+  if (closestThreatX !== undefined) {
+    // Flee away from threat (boars don't flee, they charge via updateBoarBehavior)
+    if (animal.type === 'boar') return;
+    animal.fleeing = true;
+    const fleeDir = animal.x > closestThreatX ? 1 : -1;
+    const speed = animal.type === 'rabbit' ? RABBIT_SPEED : DEER_SPEED;
+    animal.vx = fleeDir * speed;
+  } else {
+    animal.fleeing = false;
+    // Gentle random wandering
+    if (Math.random() < 0.01) {
+      const speed = animal.type === 'rabbit' ? RABBIT_SPEED * 0.3 : DEER_SPEED * 0.3;
+      animal.vx = (Math.random() - 0.5) * 2 * speed;
+    }
+    // Slow down over time
+    animal.vx *= 0.95;
+    if (Math.abs(animal.vx) < 0.1) animal.vx = 0;
+  }
+}
+
+function updateAnimalMovement(state: GameState, animal: AnimalData, dt: number): void {
+  animal.x = clamp(animal.x + animal.vx * dt, 1, MAP_WIDTH - 2);
+
+  // Keep animals in forest areas using biome check
+  const inForest = getBiome(animal.x) === Biome.DenseForest;
+
+  if (!inForest && !animal.fleeing) {
+    // Drift back toward nearest forest zone
+    let nearestCenter = FOREST_ZONES[0].min;
+    let nearestDist = Infinity;
+    for (const zone of FOREST_ZONES) {
+      const center = (zone.min + zone.max) / 2;
+      const d = distance(animal.x, center);
+      if (d < nearestDist) {
+        nearestDist = d;
+        nearestCenter = center;
+      }
+    }
+    const dir = nearestCenter > animal.x ? 1 : -1;
+    animal.vx += dir * 0.5;
+  }
+
+  // Update ECS position
+  setPosition(state.world, animal.eid, animal.x, animal.y);
+}
+
+function spawnRandomAnimal(state: GameState): void {
+  const zone = FOREST_ZONES[Math.floor(Math.random() * FOREST_ZONES.length)];
+  const x = zone.min + Math.random() * (zone.max - zone.min);
+  spawnAnimal(state, x);
+}
+
+// ─── Rabbit Den System ───────────────────────────────────────────
+
+/** Initialize dens once at game start. */
+function initializeDens(): void {
+  if (densInitialized) return;
+  densInitialized = true;
+  rabbitDens.length = 0;
+  for (const x of DEN_POSITIONS) {
+    rabbitDens.push({ x, rabbitsAlive: 0, spawnTimer: 0 });
+  }
+}
+
+/** Get rabbit dens (read-only). */
+export function getRabbitDens(): readonly RabbitDen[] {
+  return rabbitDens;
+}
+
+/**
+ * Update rabbit den spawning.
+ * Each den spawns 1 rabbit every 45s, max 2 alive per den.
+ * Winter: no den spawning.
+ */
+export function updateDenSpawning(state: GameState, dt: number): void {
+  initializeDens();
+
+  // No rabbit dens active in winter
+  if (state.season === Season.Winter) return;
+  if (state.timeOfDay === TimeOfDay.Night) return;
+
+  for (const den of rabbitDens) {
+    if (den.rabbitsAlive >= DEN_MAX_RABBITS) continue;
+
+    den.spawnTimer += dt;
+    if (den.spawnTimer >= DEN_SPAWN_INTERVAL) {
+      den.spawnTimer -= DEN_SPAWN_INTERVAL;
+      const rabbit = spawnAnimal(state, den.x, 'rabbit');
+      den.rabbitsAlive++;
+      // Tag this rabbit so we can decrement on death
+      denRabbitMap.set(rabbit.eid, den);
+    }
+  }
+}
+
+/** Track which den a rabbit belongs to. */
+const denRabbitMap = new Map<Entity, RabbitDen>();
+
+/** Notify den when a rabbit dies (called from killAnimal). */
+function notifyDenOfDeath(eid: Entity): void {
+  const den = denRabbitMap.get(eid);
+  if (den) {
+    den.rabbitsAlive = Math.max(0, den.rabbitsAlive - 1);
+    denRabbitMap.delete(eid);
+  }
+}

--- a/kingdom/entities/archer.ts
+++ b/kingdom/entities/archer.ts
@@ -1,0 +1,530 @@
+/**
+ * Archer entity - hunts animals during day, defends walls at night.
+ * Tracks kills for leveling: +3 range at 5 kills, 0.8x cooldown at 10 kills.
+ * Prioritizes CrownStealers over other greed at night.
+ * Targets animals (rabbits/deer) during day before targeting greed.
+ * Scout-origin archers gain an additional +3 range bonus.
+ *
+ * Tower archers: assigned to towers, stationary, +5 range/tier, 100% accuracy.
+ * Ground archers: hunt/defend as usual, patrol, ~33% accuracy (existing).
+ * Recruitment distributes archers evenly left/right.
+ */
+import { addEntity, getPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  type ProjectileData,
+  type StructureData,
+  AIState,
+  UnitRole,
+  TimeOfDay,
+  StructureType,
+  GreedType,
+  TowerTier,
+  TOWER_ARCHER_CAPACITY,
+  ARCHER_SPEED,
+  ARROW_RANGE,
+  ARROW_COOLDOWN,
+  ARROW_DAMAGE,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  clamp,
+  distance,
+} from '../types';
+import { getAnimals, killAnimal } from './animals';
+import { getRecruitBonus, NpcOrigin } from './villager';
+
+// ─── Archer Leveling ──────────────────────────────────────────────
+const RANGE_BONUS_THRESHOLD = 5;
+const RANGE_BONUS = 3;
+const COOLDOWN_BONUS_THRESHOLD = 10;
+const COOLDOWN_MULTIPLIER = 0.8;
+const SCOUT_RANGE_BONUS = 3;
+const TOWER_RANGE_PER_TIER = 5;
+
+// Per-archer kill counts (keyed by entity id)
+const archerKills = new Map<number, number>();
+// Tower assignments (archer eid -> structure x key)
+const towerAssignments = new Map<number, number>();
+
+/** Get total kills for an archer. */
+export function getArcherKills(eid: number): number {
+  return archerKills.get(eid) ?? 0;
+}
+
+export function recordKill(eid: number): void {
+  archerKills.set(eid, (archerKills.get(eid) ?? 0) + 1);
+}
+
+/** Check if an archer is assigned to a tower. */
+export function isArcherInTower(archerId: number): boolean {
+  return towerAssignments.has(archerId);
+}
+
+/**
+ * Assign an archer to a tower structure.
+ * Returns true if successful.
+ */
+export function assignArcherToTower(
+  state: GameState,
+  archerId: number,
+  towerX: number,
+): boolean {
+  const struct = state.structures.get(towerX);
+  if (!struct) return false;
+  if (!struct.towerTier) return false;
+
+  towerAssignments.set(archerId, towerX);
+  return true;
+}
+
+/** Remove archer from tower (e.g. tower destroyed). */
+export function removeArcherFromTower(archerId: number): void {
+  towerAssignments.delete(archerId);
+}
+
+function getEffectiveRange(eid: number, state?: GameState): number {
+  const kills = getArcherKills(eid);
+  let range = kills >= RANGE_BONUS_THRESHOLD ? ARROW_RANGE + RANGE_BONUS : ARROW_RANGE;
+  // Scout-origin archers get additional range
+  if (getRecruitBonus(eid) === NpcOrigin.Scout) {
+    range += SCOUT_RANGE_BONUS;
+  }
+  // Tower range bonus
+  if (state && towerAssignments.has(eid)) {
+    const towerX = towerAssignments.get(eid)!;
+    const struct = state.structures.get(towerX);
+    if (struct && struct.towerTier) {
+      range += struct.towerTier * TOWER_RANGE_PER_TIER;
+    }
+  }
+  return range;
+}
+
+function getEffectiveCooldown(eid: number): number {
+  const kills = getArcherKills(eid);
+  return kills >= COOLDOWN_BONUS_THRESHOLD ? ARROW_COOLDOWN * COOLDOWN_MULTIPLIER : ARROW_COOLDOWN;
+}
+
+/**
+ * Get the side (left/right) with fewer archers, for balanced recruitment.
+ * Returns the x offset direction: -1 for left, 1 for right.
+ */
+export function getArcherRecruitSide(state: GameState): number {
+  let leftCount = 0;
+  let rightCount = 0;
+
+  for (const unit of state.units) {
+    if (unit.role !== 'archer') continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (pos.x < CAMP_CENTER_X) leftCount++;
+    else rightCount++;
+  }
+
+  return leftCount <= rightCount ? -1 : 1;
+}
+
+export function updateArcher(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  if (unit.attackCooldown > 0) {
+    unit.attackCooldown = Math.max(0, unit.attackCooldown - dt);
+  }
+
+  // Tower archers have special behavior
+  if (towerAssignments.has(unit.eid)) {
+    updateTowerArcher(state, unit, pos, dt);
+    return;
+  }
+
+  switch (state.timeOfDay) {
+    case TimeOfDay.Dawn:
+    case TimeOfDay.Day:
+      updateArcherDay(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Dusk:
+      updateArcherDusk(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Night:
+      updateArcherNight(state, unit, pos, dt);
+      break;
+  }
+}
+
+/**
+ * Tower archer: stays at tower position, shoots with 100% accuracy and bonus range.
+ * Active day and night.
+ */
+function updateTowerArcher(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  const towerX = towerAssignments.get(unit.eid)!;
+  const struct = state.structures.get(towerX);
+
+  // If tower destroyed, revert to ground archer
+  if (!struct || !struct.towerTier) {
+    towerAssignments.delete(unit.eid);
+    return;
+  }
+
+  // Move to tower position if not there
+  const distToTower = distance(pos.x, struct.x);
+  if (distToTower > 1.0) {
+    unit.aiState = AIState.MovingTo;
+    const dir = struct.x > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * ARCHER_SPEED, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Defending;
+  setVelocity(state.world, unit.eid, 0, 0);
+
+  if (unit.attackCooldown > 0) return;
+
+  const range = getEffectiveRange(unit.eid, state);
+
+  // During day: shoot animals first
+  if (state.timeOfDay === TimeOfDay.Day || state.timeOfDay === TimeOfDay.Dawn) {
+    const animalTarget = findNearestAnimal(pos.x, range);
+    if (animalTarget !== undefined) {
+      const animals = getAnimals();
+      const animal = animals[animalTarget];
+      const direction = animal.x > pos.x ? 1 : -1;
+      createArrow(state, pos.x, pos.y, direction);
+      unit.attackCooldown = getEffectiveCooldown(unit.eid);
+      // Tower archers have 100% accuracy
+      killAnimal(state, animalTarget);
+      recordKill(unit.eid);
+      checkLevelUpMessage(state, unit.eid);
+      return;
+    }
+  }
+
+  // Shoot greed (priority: crown stealers)
+  const targetX = findGreedTarget(state, pos.x, range);
+  if (targetX !== undefined) {
+    const direction = targetX > pos.x ? 1 : -1;
+    createArrow(state, pos.x, pos.y, direction);
+    unit.attackCooldown = getEffectiveCooldown(unit.eid);
+  }
+}
+
+function updateArcherDay(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  unit.aiState = AIState.Hunting;
+  const range = getEffectiveRange(unit.eid, state);
+
+  // First priority: shoot animals in range
+  if (unit.attackCooldown <= 0) {
+    const animalTarget = findNearestAnimal(pos.x, range);
+    if (animalTarget !== undefined) {
+      const animals = getAnimals();
+      const animal = animals[animalTarget];
+      const direction = animal.x > pos.x ? 1 : -1;
+      createArrow(state, pos.x, pos.y, direction);
+      unit.attackCooldown = getEffectiveCooldown(unit.eid);
+
+      // Instant hit for simplicity (animal is in range)
+      killAnimal(state, animalTarget);
+      recordKill(unit.eid);
+      checkLevelUpMessage(state, unit.eid);
+      return;
+    }
+  }
+
+  // Patrol toward the outskirts
+  const patrolDirection = pos.x >= CAMP_CENTER_X ? 1 : -1;
+  const patrolLimit = patrolDirection > 0 ? MAP_WIDTH * 0.8 : MAP_WIDTH * 0.2;
+
+  const atEdge = patrolDirection > 0
+    ? pos.x >= patrolLimit
+    : pos.x <= patrolLimit;
+
+  if (atEdge) {
+    const dir = pos.x > CAMP_CENTER_X ? -1 : 1;
+    const vx = dir * ARCHER_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+  } else {
+    const vx = patrolDirection * ARCHER_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+  }
+}
+
+function updateArcherDusk(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  unit.aiState = AIState.Retreating;
+
+  const wallX = findNearestWallOnSide(state, pos.x);
+  const towardsCamp = pos.x > CAMP_CENTER_X ? -1 : 1;
+  const retreatX = clamp(wallX + towardsCamp * 2, 0, MAP_WIDTH - 1);
+  const dist = distance(pos.x, retreatX);
+
+  if (dist < 1.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dir = retreatX > pos.x ? 1 : -1;
+  const vx = dir * ARCHER_SPEED;
+  setVelocity(state.world, unit.eid, vx, 0);
+}
+
+function updateArcherNight(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Move to wall position first
+  const wallX = findNearestWallOnSide(state, pos.x);
+  const distToWall = distance(pos.x, wallX);
+
+  if (distToWall > 1.0) {
+    unit.aiState = AIState.MovingTo;
+    const dir = wallX > pos.x ? 1 : -1;
+    const vx = dir * ARCHER_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Defending;
+  setVelocity(state.world, unit.eid, 0, 0);
+
+  if (unit.attackCooldown > 0) return;
+
+  const range = getEffectiveRange(unit.eid, state);
+
+  const targetX = findGreedTarget(state, pos.x, range);
+  if (targetX !== undefined) {
+    const direction = targetX > pos.x ? 1 : -1;
+    createArrow(state, pos.x, pos.y, direction);
+    unit.attackCooldown = getEffectiveCooldown(unit.eid);
+  }
+}
+
+/** Find the best greed target. Priority: CrownStealers first, then any greed. */
+function findGreedTarget(state: GameState, fromX: number, range: number): number | undefined {
+  let targetX: number | undefined;
+  let targetDist = Infinity;
+
+  // Priority 1: CrownStealers
+  for (const greed of state.greeds) {
+    if (greed.type !== GreedType.CrownStealer) continue;
+    const greedPos = getPosition(state.world, greed.eid);
+    if (!greedPos) continue;
+    const d = distance(fromX, greedPos.x);
+    if (d <= range && d < targetDist) {
+      targetDist = d;
+      targetX = greedPos.x;
+    }
+  }
+
+  // Priority 2: Any greed
+  if (targetX === undefined) {
+    for (const greed of state.greeds) {
+      const greedPos = getPosition(state.world, greed.eid);
+      if (!greedPos) continue;
+      const d = distance(fromX, greedPos.x);
+      if (d <= range && d < targetDist) {
+        targetDist = d;
+        targetX = greedPos.x;
+      }
+    }
+  }
+
+  return targetX;
+}
+
+function checkLevelUpMessage(state: GameState, eid: number): void {
+  const kills = getArcherKills(eid);
+  if (kills === RANGE_BONUS_THRESHOLD) {
+    state.messages.push('Archer gained extended range!');
+  } else if (kills === COOLDOWN_BONUS_THRESHOLD) {
+    state.messages.push('Archer gained rapid fire!');
+  }
+}
+
+export function createArrow(
+  state: GameState,
+  fromX: number,
+  fromY: number,
+  direction: number,
+): void {
+  const eid = addEntity(state.world);
+
+  const projectile: ProjectileData = {
+    eid,
+    x: fromX,
+    y: fromY,
+    vx: direction * 30,
+    damage: ARROW_DAMAGE,
+    owner: 0 as any,
+  };
+
+  state.projectiles.push(projectile);
+}
+
+function findNearestAnimal(fromX: number, maxRange: number): number | undefined {
+  const animals = getAnimals();
+  let nearestIdx: number | undefined;
+  let nearestDist = Infinity;
+
+  for (let i = 0; i < animals.length; i++) {
+    const d = distance(fromX, animals[i].x);
+    if (d <= maxRange && d < nearestDist) {
+      nearestDist = d;
+      nearestIdx = i;
+    }
+  }
+
+  return nearestIdx;
+}
+
+function findNearestWallOnSide(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  let bestX = CAMP_CENTER_X;
+  let bestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== onRightSide) continue;
+
+    const d = distance(fromX, struct.x);
+    if (d < bestDist) {
+      bestDist = d;
+      bestX = struct.x;
+    }
+  }
+
+  return bestX;
+}
+
+// ─── Archer Distribution ──────────────────────────────────────────
+
+/** Get archer counts by side. */
+export function getArcherDistribution(state: GameState): { left: number; right: number } {
+  let left = 0;
+  let right = 0;
+
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Archer) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (pos.x < CAMP_CENTER_X) left++;
+    else right++;
+  }
+
+  return { left, right };
+}
+
+/**
+ * Try to fill empty tower slots with unassigned ground archers.
+ * Called periodically by ai.ts to keep towers staffed.
+ */
+export function fillTowerSlots(state: GameState): void {
+  // Collect towers with available capacity
+  for (const [, struct] of state.structures) {
+    if (!struct.towerTier) continue;
+    if (struct.hp <= 0) continue;
+
+    const capacity = TOWER_ARCHER_CAPACITY[struct.towerTier] ?? 0;
+    if (capacity <= 0) continue;
+
+    // Count archers already assigned to this tower
+    let assigned = 0;
+    for (const [, towerX] of towerAssignments) {
+      if (towerX === struct.x) assigned++;
+    }
+    if (assigned >= capacity) continue;
+
+    // Find nearest unassigned archer
+    let bestArcher: UnitData | undefined;
+    let bestDist = Infinity;
+
+    for (const unit of state.units) {
+      if (unit.role !== UnitRole.Archer) continue;
+      if (towerAssignments.has(unit.eid)) continue;
+      const pos = getPosition(state.world, unit.eid);
+      if (!pos) continue;
+      const d = distance(pos.x, struct.x);
+      if (d < bestDist) {
+        bestDist = d;
+        bestArcher = unit;
+      }
+    }
+
+    if (bestArcher) {
+      assignArcherToTower(state, bestArcher.eid, struct.x);
+    }
+  }
+}
+
+/**
+ * Reposition archers evenly along walls on their side during night.
+ * Prevents all archers from stacking at the same position.
+ */
+export function repositionNightArchers(state: GameState): void {
+  // Group ground archers by side
+  const leftArchers: UnitData[] = [];
+  const rightArchers: UnitData[] = [];
+
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Archer) continue;
+    if (towerAssignments.has(unit.eid)) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (pos.x < CAMP_CENTER_X) leftArchers.push(unit);
+    else rightArchers.push(unit);
+  }
+
+  // Spread archers along outermost wall on each side
+  spreadArchersAlongWall(state, leftArchers, false);
+  spreadArchersAlongWall(state, rightArchers, true);
+}
+
+function spreadArchersAlongWall(
+  state: GameState,
+  archers: UnitData[],
+  rightSide: boolean,
+): void {
+  if (archers.length === 0) return;
+
+  // Find outermost wall on this side
+  let outermostX = CAMP_CENTER_X;
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall || struct.hp <= 0) continue;
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== rightSide) continue;
+    if (rightSide ? struct.x > outermostX : struct.x < outermostX) {
+      outermostX = struct.x;
+    }
+  }
+
+  // Space archers evenly: 2 tiles apart, centered on outermost wall
+  const spacing = 2;
+  const towardCamp = rightSide ? -1 : 1;
+  for (let i = 0; i < archers.length; i++) {
+    archers[i].targetX = clamp(outermostX + towardCamp * spacing * i, 1, MAP_WIDTH - 2);
+  }
+}

--- a/kingdom/entities/banker.ts
+++ b/kingdom/entities/banker.ts
@@ -1,0 +1,130 @@
+/**
+ * Banker NPC - appears at TownCenterTier >= 4 (Town Hall).
+ * Stands near town center during day, hides at night.
+ * Deposits: monarch drops coin near banker (within 2 tiles of town center).
+ *   Accumulates deposits, walks to castle door at 10+ coins.
+ * Withdrawal: monarch interacts near banker.
+ *   Returns min(floor(bankedCoins / 3), pouch space remaining).
+ *   Minimum 7 coins in bank to withdraw.
+ * Interest: 7% daily (applied at dawn), capped at 8 coins/day for 101+ stored.
+ * Coins persist across islands.
+ */
+import {
+  type GameState,
+  TownCenterTier,
+  TimeOfDay,
+  CAMP_CENTER_X,
+  MAX_COINS,
+} from '../types';
+
+// ─── Module State ─────────────────────────────────────────────────
+let bankedCoins = 0;
+let lastInterestDay = 0;
+let pendingDeposit = 0;
+
+const DEPOSIT_THRESHOLD = 10;
+const WITHDRAW_MIN = 7;
+
+// ─── Public API ───────────────────────────────────────────────────
+
+/** Get current banked coins. */
+export function getBankedCoins(): number {
+  return bankedCoins;
+}
+
+/** Deposit coins into the bank. Returns the number actually deposited. */
+export function depositCoins(state: GameState, amount: number): number {
+  if (state.townCenterTier < TownCenterTier.TownHall) return 0;
+  if (amount <= 0) return 0;
+
+  const toDeposit = Math.min(amount, state.monarchCoins);
+  if (toDeposit <= 0) return 0;
+
+  state.monarchCoins -= toDeposit;
+  pendingDeposit += toDeposit;
+
+  // When pending reaches threshold, commit to bank
+  if (pendingDeposit >= DEPOSIT_THRESHOLD) {
+    bankedCoins += pendingDeposit;
+    const deposited = pendingDeposit;
+    pendingDeposit = 0;
+    state.messages.push(`Banker deposited ${deposited} coins (bank: ${bankedCoins})`);
+    return deposited;
+  }
+
+  state.messages.push(`Banker holds ${pendingDeposit} coins (need ${DEPOSIT_THRESHOLD} to deposit)`);
+  return toDeposit;
+}
+
+/** Withdraw coins from the bank. Returns coins withdrawn. */
+export function withdrawCoins(state: GameState): number {
+  if (state.townCenterTier < TownCenterTier.TownHall) return 0;
+  if (bankedCoins < WITHDRAW_MIN) {
+    state.messages.push(`Bank needs at least ${WITHDRAW_MIN} coins to withdraw (has ${bankedCoins})`);
+    return 0;
+  }
+
+  const pouchSpace = MAX_COINS - state.monarchCoins;
+  const available = Math.floor(bankedCoins / 3);
+  const amount = Math.min(available, pouchSpace);
+
+  if (amount <= 0) {
+    state.messages.push('Pouch is full!');
+    return 0;
+  }
+
+  bankedCoins -= amount;
+  state.monarchCoins += amount;
+  state.messages.push(`Withdrew ${amount} coins from bank (remaining: ${bankedCoins})`);
+  return amount;
+}
+
+/** Apply daily interest at dawn. Call once per dawn transition. */
+export function applyBankerInterest(state: GameState): void {
+  if (state.townCenterTier < TownCenterTier.TownHall) return;
+  if (state.dayCount <= lastInterestDay) return;
+
+  lastInterestDay = state.dayCount;
+
+  // Commit any pending deposits first
+  if (pendingDeposit > 0) {
+    bankedCoins += pendingDeposit;
+    pendingDeposit = 0;
+  }
+
+  if (bankedCoins < 3) return;
+
+  let interest: number;
+  if (bankedCoins <= 100) {
+    interest = Math.ceil(bankedCoins * 0.07);
+  } else {
+    interest = 8;
+  }
+
+  bankedCoins += interest;
+  state.messages.push(`Banker interest: +${interest} coins (bank: ${bankedCoins})`);
+}
+
+/** Update banker each frame. Banker is a virtual NPC (no ECS entity). */
+export function updateBanker(state: GameState, _dt: number): void {
+  // Banker only active during day at town hall tier+
+  if (state.townCenterTier < TownCenterTier.TownHall) return;
+
+  // Apply interest at dawn
+  if (state.timeOfDay === TimeOfDay.Dawn) {
+    applyBankerInterest(state);
+  }
+}
+
+/** Check if banker is available (day time, town hall tier). */
+export function isBankerAvailable(state: GameState): boolean {
+  if (state.townCenterTier < TownCenterTier.TownHall) return false;
+  return state.timeOfDay === TimeOfDay.Dawn || state.timeOfDay === TimeOfDay.Day;
+}
+
+/** Reset banker state (for new game). */
+export function resetBanker(): void {
+  bankedCoins = 0;
+  lastInterestDay = 0;
+  pendingDeposit = 0;
+}

--- a/kingdom/entities/builder.ts
+++ b/kingdom/entities/builder.ts
@@ -1,0 +1,656 @@
+/**
+ * Builder entity - constructs and repairs structures.
+ * Auto-builds walls when enemies approach outer walls.
+ * Panic-builds emergency barricades at night when greed breach defenses.
+ * Repairs damaged walls before building new structures.
+ * Expands walls outward during peaceful day periods (if coins > 15).
+ * Craftsman-origin builders work 1.5x faster.
+ */
+import { getPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  type StructureData,
+  AIState,
+  TimeOfDay,
+  TileType,
+  StructureType,
+  BUILDER_SPEED,
+  CAMP_CENTER_X,
+  GROUND_Y,
+  MAP_WIDTH,
+  clamp,
+  distance,
+} from '../types';
+import { collectCoins } from '../game/economy';
+import { getRecruitBonus, NpcOrigin } from './villager';
+import { placeWallBlueprint } from '../game/economy';
+
+const BASE_BUILD_RATE = 1.5;
+const CRAFTSMAN_MULTIPLIER = 1.5;
+const ENEMY_DETECT_RANGE = 20;
+const AUTO_EXPAND_COIN_THRESHOLD = 15;
+const WALL_EXPAND_DISTANCE = 3;
+const AUTO_EXPAND_COOLDOWN = 30; // seconds between auto-expansions
+const TREE_CHOP_TIME = 3; // seconds to chop a tree
+const TREE_CHOP_REWARD = 1;
+
+let lastAutoExpandTime = 0;
+const chopTimers = new Map<number, number>(); // keyed by builder eid
+
+export function getBuildRate(eid: number): number {
+  const bonus = getRecruitBonus(eid);
+  return bonus === NpcOrigin.Craftsman
+    ? BASE_BUILD_RATE * CRAFTSMAN_MULTIPLIER
+    : BASE_BUILD_RATE;
+}
+
+export function updateBuilder(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  switch (state.timeOfDay) {
+    case TimeOfDay.Dawn:
+    case TimeOfDay.Day:
+      updateBuilderDay(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Dusk:
+      updateBuilderDusk(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Night:
+      updateBuilderNight(state, unit, pos, dt);
+      break;
+  }
+}
+
+function updateBuilderDay(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Auto-place defensive wall if enemies approach outer walls
+  checkAutoDefensiveWall(state);
+
+  // During peaceful day with enough coins, expand walls outward
+  if (!hasNearbyEnemies(state) && state.monarchCoins > AUTO_EXPAND_COIN_THRESHOLD) {
+    tryExpandWalls(state);
+  }
+
+  // Find build target: damaged walls first, then unfinished structures
+  const target = findBuildTarget(state, pos.x);
+
+  if (!target) {
+    // Lowest priority: cut trees outside wall perimeter
+    if (tryTreeCutting(state, unit, pos, dt)) return;
+
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  // Clear chop timer if switching to build task
+  chopTimers.delete(unit.eid);
+
+  const dist = distance(pos.x, target.x);
+
+  if (dist < 1.0) {
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+  } else {
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = target.x;
+    const dir = target.x > pos.x ? 1 : -1;
+    const vx = dir * BUILDER_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+  }
+}
+
+function updateBuilderDusk(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  unit.aiState = AIState.Retreating;
+
+  const retreatX = findRetreatPosition(state, pos.x);
+  const dist = distance(pos.x, retreatX);
+
+  if (dist < 1.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dir = retreatX > pos.x ? 1 : -1;
+  const vx = dir * BUILDER_SPEED;
+  setVelocity(state.world, unit.eid, vx, 0);
+}
+
+function updateBuilderNight(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Night panic-build: if greed approaching with no wall between them and camp
+  if (tryPanicBuild(state, unit, pos, dt)) return;
+
+  // Otherwise hide behind nearest wall
+  const retreatX = findRetreatPosition(state, pos.x);
+  const dist = distance(pos.x, retreatX);
+
+  if (dist > 2) {
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = retreatX;
+    const dir = retreatX > pos.x ? 1 : -1;
+    const vx = dir * BUILDER_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+    return;
+  }
+
+  // If near a damaged wall, set Working state (construction system handles HP)
+  const nearbyDamaged = findNearbyDamagedWall(state, pos.x, 3);
+  if (nearbyDamaged) {
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Idle;
+  setVelocity(state.world, unit.eid, 0, 0);
+}
+
+/**
+ * During night, if greed are approaching and there's no wall between them
+ * and the camp, place and rush-build an emergency barricade.
+ */
+function tryPanicBuild(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): boolean {
+  const onRight = pos.x >= CAMP_CENTER_X;
+  let closestGreedX: number | undefined;
+  let closestGreedDist = Infinity;
+
+  for (const greed of state.greeds) {
+    const gPos = getPosition(state.world, greed.eid);
+    if (!gPos) continue;
+    const greedOnRight = gPos.x >= CAMP_CENTER_X;
+    if (greedOnRight !== onRight) continue;
+    const d = distance(pos.x, gPos.x);
+    if (d < closestGreedDist) {
+      closestGreedDist = d;
+      closestGreedX = gPos.x;
+    }
+  }
+
+  if (closestGreedX === undefined || closestGreedDist > 30) return false;
+
+  // Check if there's a wall between the greed and camp
+  if (hasWallBetween(state, closestGreedX, CAMP_CENTER_X)) return false;
+
+  // No wall! Emergency: place a barricade between greed and camp
+  const barricadeX = Math.round(onRight
+    ? Math.min(closestGreedX - 3, pos.x)
+    : Math.max(closestGreedX + 3, pos.x));
+
+  if (placeWallBlueprint(state, barricadeX)) {
+    state.messages.push('Emergency barricade placed!');
+  }
+
+  // Rush to build the nearest unfinished structure
+  const target = findNearestUnfinished(state, pos.x);
+  if (!target) return false;
+
+  const dist = distance(pos.x, target.x);
+
+  if (dist < 1.0) {
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return true;
+  }
+
+  unit.aiState = AIState.MovingTo;
+  unit.targetX = target.x;
+  const dir = target.x > pos.x ? 1 : -1;
+  const vx = dir * (BUILDER_SPEED * 1.5); // Run faster in panic
+  setVelocity(state.world, unit.eid, vx, 0);
+  return true;
+}
+
+/** Auto-place defensive wall if enemies approach outer walls. */
+function checkAutoDefensiveWall(state: GameState): void {
+  const outerLeft = findOutermostWallX(state, false);
+  const outerRight = findOutermostWallX(state, true);
+
+  for (const greed of state.greeds) {
+    const gPos = getPosition(state.world, greed.eid);
+    if (!gPos) continue;
+
+    if (outerLeft !== undefined
+      && gPos.x < outerLeft
+      && distance(gPos.x, outerLeft) < ENEMY_DETECT_RANGE
+    ) {
+      const newWallX = outerLeft - WALL_EXPAND_DISTANCE;
+      if (newWallX > 0 && placeWallBlueprint(state, newWallX)) {
+        state.messages.push('Defensive wall placed!');
+        return;
+      }
+    }
+
+    if (outerRight !== undefined
+      && gPos.x > outerRight
+      && distance(gPos.x, outerRight) < ENEMY_DETECT_RANGE
+    ) {
+      const newWallX = outerRight + WALL_EXPAND_DISTANCE;
+      if (newWallX < MAP_WIDTH && placeWallBlueprint(state, newWallX)) {
+        state.messages.push('Defensive wall placed!');
+        return;
+      }
+    }
+  }
+}
+
+/** During peaceful day with coins > threshold, expand walls outward. */
+function tryExpandWalls(state: GameState): void {
+  if (state.totalElapsed - lastAutoExpandTime < AUTO_EXPAND_COOLDOWN) return;
+
+  const outerLeft = findOutermostWallX(state, false);
+  const outerRight = findOutermostWallX(state, true);
+
+  // Only expand if walls exist on both sides
+  if (outerLeft === undefined || outerRight === undefined) return;
+
+  // Don't expand if there are already unfinished blueprints
+  if (countUnfinishedBlueprints(state) >= 2) return;
+
+  const expandLeft = outerLeft - WALL_EXPAND_DISTANCE;
+  if (expandLeft > 10 && placeWallBlueprint(state, expandLeft)) {
+    state.messages.push('Expanding defenses outward');
+    lastAutoExpandTime = state.totalElapsed;
+    return;
+  }
+
+  const expandRight = outerRight + WALL_EXPAND_DISTANCE;
+  if (expandRight < MAP_WIDTH - 10 && placeWallBlueprint(state, expandRight)) {
+    state.messages.push('Expanding defenses outward');
+    lastAutoExpandTime = state.totalElapsed;
+  }
+}
+
+function hasNearbyEnemies(state: GameState): boolean {
+  for (const greed of state.greeds) {
+    const gPos = getPosition(state.world, greed.eid);
+    if (!gPos) continue;
+    if (distance(gPos.x, CAMP_CENTER_X) < MAP_WIDTH * 0.4) return true;
+  }
+  return false;
+}
+
+function hasWallBetween(state: GameState, x1: number, x2: number): boolean {
+  const minX = Math.min(x1, x2);
+  const maxX = Math.max(x1, x2);
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+    if (struct.x > minX && struct.x < maxX) return true;
+  }
+  return false;
+}
+
+function countUnfinishedBlueprints(state: GameState): number {
+  let count = 0;
+  for (const [, struct] of state.structures) {
+    if (struct.hp === 0 && struct.type !== StructureType.Portal) count++;
+  }
+  return count;
+}
+
+// ─── Builder Priority System ──────────────────────────────────────
+
+export enum BuilderTaskType {
+  RepairTownCenter = 0,
+  RepairWall = 1,
+  BuildQueued = 2,
+  UpgradeTownCenter = 3,
+  UpgradeTower = 4,
+  UpgradeFarm = 5,
+  RestoreBoat = 6,
+  OperateCatapult = 7,
+  PushBomb = 8,
+  CutTree = 9,
+  IdleAtWall = 10,
+}
+
+/** Get the numeric priority for a builder task type (lower = higher priority). */
+export function getBuilderPriority(taskType: BuilderTaskType): number {
+  return taskType;
+}
+
+// Track how many builders are assigned to each structure x
+const builderAssignments = new Map<number, number>(); // structureX -> count
+const MAX_BUILDERS_PER_TASK = 2;
+
+function canAssignBuilder(structX: number): boolean {
+  return (builderAssignments.get(structX) ?? 0) < MAX_BUILDERS_PER_TASK;
+}
+
+function assignBuilderToTask(structX: number): void {
+  builderAssignments.set(structX, (builderAssignments.get(structX) ?? 0) + 1);
+}
+
+/** Reset builder assignments each frame (recalculated). */
+export function resetBuilderAssignments(): void {
+  builderAssignments.clear();
+}
+
+/**
+ * Find the best builder task using full priority list.
+ * Priority: repair TC > repair walls (lowest HP) > build queued > upgrades > boat > trees > idle.
+ */
+export function findBestBuilderTask(state: GameState, builderX: number): StructureData | undefined {
+  // Priority 1: Repair town center
+  const tc = findTownCenter(state);
+  if (tc && tc.hp > 0 && tc.hp < tc.maxHp && canAssignBuilder(tc.x)) {
+    assignBuilderToTask(tc.x);
+    return tc;
+  }
+
+  // Priority 2: Repair damaged walls (lowest HP first)
+  const damagedWall = findLowestHpDamagedWall(state, builderX);
+  if (damagedWall && canAssignBuilder(damagedWall.x)) {
+    assignBuilderToTask(damagedWall.x);
+    return damagedWall;
+  }
+
+  // Priority 3: Build queued structures (unfinished, hp=0)
+  const queued = findNearestQueued(state, builderX);
+  if (queued && canAssignBuilder(queued.x)) {
+    assignBuilderToTask(queued.x);
+    return queued;
+  }
+
+  // Priority 4-6: Upgrade TC, towers, farms (only if coin was dropped at them)
+  // These are initiated by dropCoin, not auto-assigned here
+
+  // Priority 7: Restore boat hull pieces
+  if (state.boatState === 'restoring') {
+    const ship = findShip(state);
+    if (ship && ship.hp < ship.maxHp && canAssignBuilder(ship.x)) {
+      assignBuilderToTask(ship.x);
+      return ship;
+    }
+  }
+
+  // Priority 8-9: Catapult and bomb are handled by other systems
+
+  return undefined; // No structure task; caller falls through to tree cutting / idle
+}
+
+function findTownCenter(state: GameState): StructureData | undefined {
+  for (const [, struct] of state.structures) {
+    if (struct.type === StructureType.Campfire) return struct;
+  }
+  return undefined;
+}
+
+function findLowestHpDamagedWall(state: GameState, fromX: number): StructureData | undefined {
+  let best: StructureData | undefined;
+  let bestHpRatio = Infinity;
+  let bestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0 || struct.hp >= struct.maxHp) continue;
+
+    const hpRatio = struct.hp / struct.maxHp;
+    const d = distance(fromX, struct.x);
+
+    // Lowest HP ratio first, then nearest
+    if (hpRatio < bestHpRatio || (hpRatio === bestHpRatio && d < bestDist)) {
+      bestHpRatio = hpRatio;
+      bestDist = d;
+      best = struct;
+    }
+  }
+
+  return best;
+}
+
+function findNearestQueued(state: GameState, fromX: number): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    if (struct.type === StructureType.Portal) continue;
+    if (struct.hp !== 0) continue; // only unfinished (hp=0)
+
+    const d = distance(fromX, struct.x);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function findShip(state: GameState): StructureData | undefined {
+  for (const [, struct] of state.structures) {
+    if (struct.type === StructureType.Ship) return struct;
+  }
+  return undefined;
+}
+
+/**
+ * Legacy find: used as fallback by existing code paths.
+ */
+function findBuildTarget(state: GameState, fromX: number): StructureData | undefined {
+  return findBestBuilderTask(state, fromX);
+}
+
+function findNearestUnfinished(state: GameState, fromX: number): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    if (struct.type === StructureType.Portal) continue;
+    if (struct.hp >= struct.maxHp) continue;
+    const d = distance(fromX, struct.x);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function findNearbyDamagedWall(
+  state: GameState,
+  fromX: number,
+  maxDist: number,
+): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0 || struct.hp >= struct.maxHp) continue;
+    const d = distance(fromX, struct.x);
+    if (d <= maxDist && d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function findOutermostWallX(state: GameState, rightSide: boolean): number | undefined {
+  let outermost: number | undefined;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== rightSide) continue;
+
+    if (outermost === undefined) {
+      outermost = struct.x;
+    } else if (rightSide && struct.x > outermost) {
+      outermost = struct.x;
+    } else if (!rightSide && struct.x < outermost) {
+      outermost = struct.x;
+    }
+  }
+
+  return outermost;
+}
+
+function findRetreatPosition(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  let bestWallX = CAMP_CENTER_X;
+  let bestDist = Infinity;
+  const towardsCamp = onRightSide ? -1 : 1;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== onRightSide) continue;
+
+    const d = distance(fromX, struct.x);
+    if (d < bestDist) {
+      bestDist = d;
+      bestWallX = struct.x + towardsCamp * 2;
+    }
+  }
+
+  return clamp(bestWallX, 0, MAP_WIDTH - 1);
+}
+
+function structureName(type: StructureType): string {
+  switch (type) {
+    case StructureType.WallWood: return 'Wood wall';
+    case StructureType.WallStone: return 'Stone wall';
+    case StructureType.WallIron: return 'Iron wall';
+    case StructureType.Farm: return 'Farm';
+    case StructureType.FarmIrrigated: return 'Irrigated farm';
+    case StructureType.FarmWindmill: return 'Windmill farm';
+    case StructureType.BowStand: return 'Bow stand';
+    case StructureType.HammerStand: return 'Hammer stand';
+    case StructureType.Shrine: return 'Shrine';
+    default: return 'Structure';
+  }
+}
+
+// ─── Tree Cutting ────────────────────────────────────────────────
+
+/**
+ * Find nearest tree outside current wall perimeter on the builder's side.
+ * Only looks at tiles at GROUND_Y (tree base row).
+ */
+export function findNearestTree(state: GameState, builderX: number): number | undefined {
+  const onRight = builderX >= CAMP_CENTER_X;
+  const outerWallX = findOutermostWallX(state, onRight);
+
+  // Only cut trees beyond the outermost wall
+  const searchStart = outerWallX !== undefined
+    ? (onRight ? outerWallX + 1 : 0)
+    : (onRight ? CAMP_CENTER_X : 0);
+  const searchEnd = outerWallX !== undefined
+    ? (onRight ? MAP_WIDTH : outerWallX - 1)
+    : (onRight ? MAP_WIDTH : CAMP_CENTER_X);
+
+  let nearest: number | undefined;
+  let nearestDist = Infinity;
+
+  const row = state.tiles[GROUND_Y];
+  if (!row) return undefined;
+
+  for (let x = Math.floor(searchStart); x < Math.ceil(searchEnd); x++) {
+    if (x < 0 || x >= MAP_WIDTH) continue;
+    if (row[x] !== TileType.Forest) continue;
+
+    const d = distance(builderX, x);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearest = x;
+    }
+  }
+
+  return nearest;
+}
+
+/**
+ * Cut a tree at the given position. Changes tile to ClearedLand.
+ * Returns 1 coin.
+ */
+export function cutTree(state: GameState, treeX: number): void {
+  const row = state.tiles[GROUND_Y];
+  if (!row) return;
+  if (treeX < 0 || treeX >= MAP_WIDTH) return;
+
+  row[treeX] = TileType.ClearedLand;
+  collectCoins(state, TREE_CHOP_REWARD);
+  state.messages.push(`Tree cleared (+${TREE_CHOP_REWARD} coin)`);
+}
+
+/**
+ * Attempt tree cutting as lowest-priority daytime task.
+ * Returns true if the builder is engaged in tree cutting.
+ */
+function tryTreeCutting(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): boolean {
+  const treeX = findNearestTree(state, pos.x);
+  if (treeX === undefined) return false;
+
+  const dist = distance(pos.x, treeX);
+
+  if (dist < 1.5) {
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+
+    const timer = (chopTimers.get(unit.eid) ?? 0) + dt;
+    if (timer >= TREE_CHOP_TIME) {
+      cutTree(state, treeX);
+      chopTimers.set(unit.eid, 0);
+    } else {
+      chopTimers.set(unit.eid, timer);
+    }
+    return true;
+  }
+
+  // Walk to tree
+  unit.aiState = AIState.MovingTo;
+  unit.targetX = treeX;
+  const dir = treeX > pos.x ? 1 : -1;
+  setVelocity(state.world, unit.eid, dir * BUILDER_SPEED, 0);
+  return true;
+}

--- a/kingdom/entities/dog.ts
+++ b/kingdom/entities/dog.ts
@@ -1,0 +1,207 @@
+/**
+ * Dog companion entity - follows monarch, barks at greed, can be kidnapped.
+ * Found on Island 2 under a fallen tree (x=200 default).
+ * 1 coin to free (coin returned immediately).
+ * Dog follows monarch within 5 tiles, barks when greed within 30 tiles.
+ * Can be kidnapped by greedlings and carried to nearest portal.
+ * Recovery: destroy portal OR lose crown (dog returns next day).
+ */
+import { addEntity, getPosition, setPosition, setVelocity, removeEntity } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  GROUND_Y,
+  CAMP_CENTER_X,
+  distance,
+  clamp,
+  MAP_WIDTH,
+} from '../types';
+
+// ─── Constants ───────────────────────────────────────────────────
+const DOG_FOLLOW_DISTANCE = 5;
+const DOG_OFFSET = 3;
+const BARK_RANGE = 30;
+const BARK_DURATION = 2; // seconds
+const DOG_DEFAULT_X = 200;
+const FREE_COST = 1;
+
+// ─── Module State ────────────────────────────────────────────────
+let dogEid: Entity | null = null;
+let dogX = DOG_DEFAULT_X;
+let dogY = GROUND_Y - 1;
+let barkTimer = 0;
+let barkDirection: -1 | 0 | 1 = 0; // -1 left, 0 none, 1 right
+let captorEntity: Entity | null = null;
+let dogFreed = false;
+
+/** Check if the dog is currently barking. */
+export function isDogBarking(): boolean {
+  return barkTimer > 0;
+}
+
+/** Get the direction the dog is barking at (-1 left, 0 none, 1 right). */
+export function getDogBarkDirection(): -1 | 0 | 1 {
+  return barkDirection;
+}
+
+/** Get the dog's current x position. */
+export function getDogX(): number {
+  return dogX;
+}
+
+/** Check if the dog has been freed yet. */
+export function isDogFreed(): boolean {
+  return dogFreed;
+}
+
+/**
+ * Free the dog from the fallen tree. Costs 1 coin but returns it immediately.
+ * Monarch must be on Island 2 near x=200.
+ */
+export function freeDog(state: GameState): boolean {
+  if (state.hasDog) return false;
+  if (state.islandIndex !== 2) return false;
+  if (state.monarchCoins < FREE_COST) return false;
+
+  // Cost is returned immediately (lore-accurate: dog brings back coin)
+  // No net cost, but monarch needs at least 1 coin
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, dogX, dogY);
+  setVelocity(state.world, eid, 0, 0);
+  dogEid = eid;
+
+  state.hasDog = true;
+  state.dogCaptured = false;
+  dogFreed = true;
+
+  state.messages.push('You freed the dog! It loyally follows you.');
+  return true;
+}
+
+/**
+ * Create the dog entity (used when loading a save or starting with dog).
+ */
+export function createDog(state: GameState): void {
+  if (dogEid !== null) return;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  const startX = monarchPos ? monarchPos.x - DOG_OFFSET : CAMP_CENTER_X - DOG_OFFSET;
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, startX, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  dogEid = eid;
+  dogX = startX;
+  dogY = GROUND_Y - 1;
+  barkTimer = 0;
+  barkDirection = 0;
+  captorEntity = null;
+
+  state.hasDog = true;
+  state.dogCaptured = false;
+}
+
+/** Capture the dog (called by greed system when greedling reaches dog). */
+export function captureDog(state: GameState, captorEid: Entity): void {
+  if (!state.hasDog || state.dogCaptured) return;
+
+  state.dogCaptured = true;
+  captorEntity = captorEid;
+  barkTimer = 0;
+  barkDirection = 0;
+
+  state.messages.push('The greed captured your dog!');
+}
+
+/** Recover the dog (called when portal is destroyed or at dawn after crown loss). */
+export function recoverDog(state: GameState): void {
+  if (!state.dogCaptured) return;
+
+  state.dogCaptured = false;
+  captorEntity = null;
+
+  // Dog returns to monarch
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (monarchPos) {
+    dogX = monarchPos.x - DOG_OFFSET;
+    if (dogEid !== null) {
+      setPosition(state.world, dogEid, dogX, dogY);
+    }
+  }
+
+  state.messages.push('Your dog has returned!');
+}
+
+/** Main update loop for the dog. */
+export function updateDog(state: GameState, dt: number): void {
+  if (!state.hasDog) return;
+  if (dogEid === null) return;
+
+  // If captured, follow captor (greed system handles movement to portal)
+  if (state.dogCaptured) {
+    if (captorEntity !== null) {
+      const captorPos = getPosition(state.world, captorEntity);
+      if (captorPos) {
+        dogX = captorPos.x;
+        dogY = captorPos.y;
+        setPosition(state.world, dogEid, dogX, dogY);
+      }
+    }
+    return;
+  }
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  // Follow monarch
+  const monarchDir = monarchPos.x > dogX ? 1 : -1;
+  const targetX = monarchPos.x - monarchDir * DOG_OFFSET;
+  const dist = distance(dogX, targetX);
+
+  if (dist > DOG_FOLLOW_DISTANCE) {
+    // Teleport if too far (e.g. monarch rode horse)
+    dogX = targetX;
+  } else if (dist > 1) {
+    // Move toward target
+    const moveDir = targetX > dogX ? 1 : -1;
+    const speed = dist > 3 ? 15 : 8; // faster if falling behind
+    dogX = clamp(dogX + moveDir * speed * dt, 0, MAP_WIDTH - 1);
+  }
+
+  setPosition(state.world, dogEid, dogX, dogY);
+
+  // Bark warning system: detect nearby greed
+  updateBark(state, dt);
+}
+
+function updateBark(state: GameState, dt: number): void {
+  if (barkTimer > 0) {
+    barkTimer -= dt;
+    if (barkTimer <= 0) {
+      barkTimer = 0;
+      barkDirection = 0;
+    }
+    return; // Don't re-trigger while barking
+  }
+
+  // Scan for greed within bark range
+  let closestGreedX: number | undefined;
+  let closestDist = Infinity;
+
+  for (const greed of state.greeds) {
+    const greedPos = getPosition(state.world, greed.eid);
+    if (!greedPos) continue;
+    const d = distance(dogX, greedPos.x);
+    if (d < BARK_RANGE && d < closestDist) {
+      closestDist = d;
+      closestGreedX = greedPos.x;
+    }
+  }
+
+  if (closestGreedX !== undefined) {
+    barkTimer = BARK_DURATION;
+    barkDirection = closestGreedX > dogX ? 1 : -1;
+  }
+}

--- a/kingdom/entities/farmer.ts
+++ b/kingdom/entities/farmer.ts
@@ -1,0 +1,398 @@
+/**
+ * Farmer entity - works farms during day, retreats at night.
+ * Irrigated farms produce 1.5x, windmill farms produce 2x.
+ * Farmers flee from nearby greed even during the day.
+ * Greed reaching a farm destroys it.
+ * Peasant-origin farmers gain +50% output bonus.
+ *
+ * Seasonal effects:
+ * - Spring/Summer: 100% production
+ * - Autumn: 75% production
+ * - Winter: no farming, forage berry bushes instead (1 coin per berry)
+ */
+import { getPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  type StructureData,
+  AIState,
+  TimeOfDay,
+  Season,
+  StructureType,
+  VILLAGER_SPEED,
+  FARM_INCOME_INTERVAL,
+  FARM_REWARD_BASE,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  clamp,
+  distance,
+} from '../types';
+import { collectCoins } from '../game/economy';
+import { getRecruitBonus, NpcOrigin } from './villager';
+import { getResourceAt, harvestResource, ResourceType } from '../structures/resources';
+
+const farmTimers = new Map<number, number>();
+
+const GREED_THREAT_RANGE = 10;
+const FARMER_FLEE_SPEED = VILLAGER_SPEED * 1.5;
+const PEASANT_OUTPUT_BONUS = 1.5;
+
+export function updateFarmer(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  // Check for nearby greed threats during any time of day
+  const nearestGreedX = findNearestGreedX(state, pos.x, GREED_THREAT_RANGE);
+  if (nearestGreedX !== undefined) {
+    updateFarmerFlee(state, unit, pos, nearestGreedX, dt);
+    return;
+  }
+
+  switch (state.timeOfDay) {
+    case TimeOfDay.Dawn:
+    case TimeOfDay.Day:
+      updateFarmerDay(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Dusk:
+    case TimeOfDay.Night:
+      updateFarmerNight(state, unit, pos, dt);
+      break;
+  }
+
+  // Check for greed reaching farms: destroy the farm
+  checkFarmDestruction(state);
+}
+
+function updateFarmerDay(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Winter: no farming, forage berries instead
+  if (state.season === Season.Winter) {
+    updateFarmerForage(state, unit, pos, dt);
+    return;
+  }
+
+  const farm = findNearestFarm(state, pos.x);
+  if (!farm) {
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dist = distance(pos.x, farm.x);
+
+  if (dist < 1.0) {
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+
+    // Farm must be built to produce
+    if (farm.hp < farm.maxHp) return;
+
+    // Production multiplier based on farm type
+    let multiplier = getFarmMultiplier(farm.type);
+
+    // Seasonal multiplier
+    if (state.season === Season.Autumn) {
+      multiplier *= 0.75;
+    }
+
+    // Peasant-origin farmers get +50% output
+    if (getRecruitBonus(unit.eid) === NpcOrigin.Peasant) {
+      multiplier *= PEASANT_OUTPUT_BONUS;
+    }
+
+    const reward = Math.max(1, Math.floor(FARM_REWARD_BASE * multiplier));
+
+    const timer = (farmTimers.get(unit.eid) ?? 0) + dt;
+    if (timer >= FARM_INCOME_INTERVAL) {
+      collectCoins(state, reward);
+      farmTimers.set(unit.eid, timer - FARM_INCOME_INTERVAL);
+      state.messages.push(`Farm produced ${reward} coins`);
+    } else {
+      farmTimers.set(unit.eid, timer);
+    }
+  } else {
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = farm.x;
+    const dir = farm.x > pos.x ? 1 : -1;
+    const vx = dir * VILLAGER_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+  }
+}
+
+/** Winter foraging: find nearest berry bush and harvest for coins. */
+function updateFarmerForage(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  const berryX = findNearestBerryBush(state, pos.x);
+  if (berryX === undefined) {
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dist = distance(pos.x, berryX);
+
+  if (dist < 2.0) {
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+
+    const timer = (farmTimers.get(unit.eid) ?? 0) + dt;
+    if (timer >= FARM_INCOME_INTERVAL) {
+      const coins = harvestResource(state, berryX);
+      if (coins > 0) {
+        collectCoins(state, coins);
+        state.messages.push(`Farmer foraged berries (+${coins} coin)`);
+      }
+      farmTimers.set(unit.eid, timer - FARM_INCOME_INTERVAL);
+    } else {
+      farmTimers.set(unit.eid, timer);
+    }
+  } else {
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = berryX;
+    const dir = berryX > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * VILLAGER_SPEED, 0);
+  }
+}
+
+/** Find the nearest non-depleted berry bush. */
+function findNearestBerryBush(state: GameState, fromX: number): number | undefined {
+  let nearest: number | undefined;
+  let nearestDist = Infinity;
+
+  // Scan the map for berry bush resources
+  for (let x = 0; x < MAP_WIDTH; x++) {
+    const res = getResourceAt(state, x);
+    if (!res) continue;
+    if (res.type !== ResourceType.BerryBush) continue;
+    if (res.depleted) continue;
+
+    const d = distance(fromX, x);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearest = x;
+    }
+  }
+
+  return nearest;
+}
+
+function updateFarmerFlee(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  greedX: number,
+  dt: number,
+): void {
+  unit.aiState = AIState.Fleeing;
+  farmTimers.delete(unit.eid);
+
+  // Flee away from greed, toward camp
+  const fleeDir = pos.x > greedX ? 1 : -1;
+  // Prefer fleeing toward camp
+  const campDir = CAMP_CENTER_X > pos.x ? 1 : -1;
+  const dir = fleeDir === campDir ? fleeDir : campDir;
+
+  const vx = dir * FARMER_FLEE_SPEED;
+  setVelocity(state.world, unit.eid, vx, 0);
+}
+
+/**
+ * Night/dusk behavior: if farm has farmhouse (level >= 2), stay at farm.
+ * Otherwise retreat to wall/camp center.
+ */
+export function updateFarmerNight(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Check if farmer has access to a farmhouse (farm level >= 2)
+  const shelterFarm = findFarmhouseFarm(state);
+  if (shelterFarm) {
+    // Stay at farm position (sheltered)
+    const dist = distance(pos.x, shelterFarm.x);
+    if (dist < 1.5) {
+      unit.aiState = AIState.Idle;
+      setVelocity(state.world, unit.eid, 0, 0);
+      return;
+    }
+    // Move to farmhouse
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = shelterFarm.x;
+    const dir = shelterFarm.x > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * VILLAGER_SPEED, 0);
+    return;
+  }
+
+  // No farmhouse: retreat to wall/camp
+  updateFarmerRetreat(state, unit, pos, dt);
+}
+
+/**
+ * Check if a farmer entity is sheltered in a farmhouse.
+ * Sheltered farmers don't lose coins to greed.
+ */
+export function isFarmerSheltered(state: GameState, farmerEid: number): boolean {
+  const pos = getPosition(state.world, farmerEid);
+  if (!pos) return false;
+
+  // Must be night/dusk
+  if (state.timeOfDay !== TimeOfDay.Night && state.timeOfDay !== TimeOfDay.Dusk) return false;
+
+  // Check if near a farmhouse (level >= 2 farm)
+  for (const [, struct] of state.structures) {
+    const isFarm = struct.type === StructureType.Farm
+      || struct.type === StructureType.FarmIrrigated
+      || struct.type === StructureType.FarmWindmill;
+    if (!isFarm) continue;
+    if (struct.level < 2) continue;
+    if (distance(pos.x, struct.x) < 2) return true;
+  }
+
+  return false;
+}
+
+function updateFarmerRetreat(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  unit.aiState = AIState.Retreating;
+  farmTimers.delete(unit.eid);
+
+  const retreatX = findRetreatPosition(state, pos.x);
+  const dist = distance(pos.x, retreatX);
+
+  if (dist < 1.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+    unit.aiState = AIState.Idle;
+    return;
+  }
+
+  const dir = retreatX > pos.x ? 1 : -1;
+  const vx = dir * VILLAGER_SPEED;
+  setVelocity(state.world, unit.eid, vx, 0);
+}
+
+/** Find a farm with level >= 2 (farmhouse). */
+function findFarmhouseFarm(state: GameState): StructureData | undefined {
+  for (const [, struct] of state.structures) {
+    const isFarm = struct.type === StructureType.Farm
+      || struct.type === StructureType.FarmIrrigated
+      || struct.type === StructureType.FarmWindmill;
+    if (!isFarm) continue;
+    if (struct.level >= 2 && struct.hp >= struct.maxHp) return struct;
+  }
+  return undefined;
+}
+
+function getFarmMultiplier(type: StructureType): number {
+  switch (type) {
+    case StructureType.FarmIrrigated: return 1.5;
+    case StructureType.FarmWindmill: return 2.0;
+    default: return 1.0;
+  }
+}
+
+function findNearestGreedX(
+  state: GameState,
+  fromX: number,
+  maxRange: number,
+): number | undefined {
+  let nearest: number | undefined;
+  let nearestDist = Infinity;
+
+  for (const greed of state.greeds) {
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    const d = distance(fromX, pos.x);
+    if (d <= maxRange && d < nearestDist) {
+      nearestDist = d;
+      nearest = pos.x;
+    }
+  }
+
+  return nearest;
+}
+
+/** Destroy farms that greed have reached. */
+function checkFarmDestruction(state: GameState): void {
+  const farmsToDestroy: number[] = [];
+
+  for (const [key, struct] of state.structures) {
+    const isFarm = struct.type === StructureType.Farm
+      || struct.type === StructureType.FarmIrrigated
+      || struct.type === StructureType.FarmWindmill;
+    if (!isFarm) continue;
+
+    for (const greed of state.greeds) {
+      const greedPos = getPosition(state.world, greed.eid);
+      if (!greedPos) continue;
+      if (distance(struct.x, greedPos.x) < 1.5) {
+        farmsToDestroy.push(key);
+        break;
+      }
+    }
+  }
+
+  for (const key of farmsToDestroy) {
+    state.structures.delete(key);
+    state.messages.push('The greed destroyed a farm!');
+  }
+}
+
+function findNearestFarm(state: GameState, fromX: number): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    if (
+      struct.type !== StructureType.Farm &&
+      struct.type !== StructureType.FarmIrrigated &&
+      struct.type !== StructureType.FarmWindmill
+    ) continue;
+
+    const d = distance(fromX, struct.x);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function findRetreatPosition(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  let bestWallX = CAMP_CENTER_X;
+  let bestDist = Infinity;
+  const towardsCamp = onRightSide ? -1 : 1;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== onRightSide) continue;
+
+    const d = distance(fromX, struct.x);
+    if (d < bestDist) {
+      bestDist = d;
+      bestWallX = struct.x + towardsCamp * 2;
+    }
+  }
+
+  return clamp(bestWallX, 0, MAP_WIDTH - 1);
+}

--- a/kingdom/entities/greed.ts
+++ b/kingdom/entities/greed.ts
@@ -1,0 +1,651 @@
+/**
+ * Greed entity spawning and AI update logic.
+ *
+ * Greed types (Kingdom Two Crowns):
+ *   Greedling (basic): 1 HP, flees at sunrise, steals tools on kill
+ *   Masked: 3 HP, front mask absorbs first frontal hit, 2x wall damage
+ *   Floater: 12 HP, ignores walls, abducts villagers, no flee
+ *   Breeder: 70 HP, punch attack stuns nearby units, spawns 2 greedlings/6s, no flee
+ *   Crown Stealer: 8 HP, 2.5x speed, bypasses walls, targets monarch only, no flee
+ *
+ * Greeds target the WEAKEST settlement (lowest defense rating).
+ * Retreat: greeds carrying 3+ stolen coins flee back to spawn portal.
+ * Island scaling: greed base hp increases by 0.5 per island.
+ * Gates block greed just like walls.
+ */
+
+import { addEntity, setPosition, getPosition, Position } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  type GreedData,
+  GreedType,
+  TimeOfDay,
+  GamePhase,
+  GROUND_Y,
+  GREED_SPEED_BASE,
+  GREED_SPEED_FAST,
+} from '../types';
+import { isDefensiveStructure, getGreedWallDamage, getWallDamageReduction } from '../structures/wall';
+import { getWeakestSettlement, getActivePortals } from '../structures/portal';
+
+interface GreedStats {
+  hp: number;
+  speed: number;
+  damage: number;
+}
+
+const GREED_STATS: Record<GreedType, GreedStats> = {
+  [GreedType.Basic]:         { hp: 1,  speed: GREED_SPEED_BASE,       damage: 1 },
+  [GreedType.Masked]:        { hp: 3,  speed: GREED_SPEED_BASE,       damage: 1 },
+  [GreedType.Floater]:       { hp: 12, speed: GREED_SPEED_FAST,       damage: 1 },
+  [GreedType.Breeder]:       { hp: 70, speed: 2,                      damage: 1 },
+  [GreedType.CrownStealer]:  { hp: 8,  speed: GREED_SPEED_BASE * 2.5, damage: 1 },
+  [GreedType.PlagueCrawler]: { hp: 4,  speed: GREED_SPEED_BASE,       damage: 1 },
+};
+
+const WALL_BREAK_PAUSE = 0.5;
+const KNOCKBACK_DISTANCE = 1.0;
+const GAP_SEARCH_RANGE = 20;
+const FLEE_COIN_THRESHOLD = 3;
+
+/** Floater constants */
+const FLOATER_GRAB_TIME = 3.0;
+const FLOATER_CARRY_SPEED_MULT = 0.5;
+
+/** Breeder constants */
+const BREEDER_PUNCH_INTERVAL = 4.0;
+const BREEDER_PUNCH_RADIUS = 2;
+const BREEDER_PUNCH_STUN = 1.5;
+const BREEDER_SPAWN_INTERVAL = 6.0;
+const BREEDER_SPAWN_COUNT = 2;
+const BREEDER_MAX_CHILDREN = 20;
+
+/** Crown stealer constants */
+const CROWN_STEAL_FLEE_SPEED = GREED_SPEED_BASE * 3;
+
+/** Plague crawler constants */
+const PLAGUE_POISON_DPS = 1;
+const PLAGUE_POISON_DURATION = 5;
+const PLAGUE_POISON_RADIUS = 2;
+const WALL_CLIMB_TIME = 2.0;
+
+/** Sunrise flee constants */
+const SUNRISE_DESPAWN_TIMEOUT = 5.0; // seconds in daylight before despawn if no portal
+const SUNRISE_DESPAWN_NO_PORTAL = 10.0; // seconds if all portals destroyed
+
+/** Per-greed pause timer (seconds remaining) */
+const pauseTimers: Map<number, number> = new Map();
+
+/** Track which wall x each greed is currently targeting */
+const greedWallTargets: Map<number, number> = new Map();
+
+/** Track which portal each greed spawned from (for retreat) */
+const greedSpawnPortals: Map<number, number> = new Map();
+
+/** Cached weakest settlement x (recalculated periodically for performance) */
+let cachedWeakestSettlement = 150;
+let weakestSettlementAge = 0;
+const WEAKNESS_CACHE_INTERVAL = 2.0;
+
+/** Spawn a greed entity at a given x position. Applies island hp scaling. */
+export function spawnGreed(state: GameState, x: number, type: GreedType): GreedData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+
+  const stats = GREED_STATS[type];
+  const islandHpBonus = (state.islandIndex - 1) * 0.5;
+
+  const greed: GreedData = {
+    eid,
+    type,
+    hp: stats.hp + Math.max(0, islandHpBonus),
+    speed: stats.speed,
+    damage: stats.damage,
+    carryingCoins: 0,
+  };
+
+  // Initialize type-specific state
+  if (type === GreedType.Masked) {
+    greed.maskBroken = false;
+  } else if (type === GreedType.Floater) {
+    greed.floaterTarget = null;
+    greed.isCarrying = false;
+    greed.grabTimer = 0;
+  } else if (type === GreedType.Breeder) {
+    greed.breederSpawnTimer = BREEDER_SPAWN_INTERVAL;
+    greed.breederPunchTimer = BREEDER_PUNCH_INTERVAL;
+    greed.breederSpawnCount = 0;
+  } else if (type === GreedType.CrownStealer) {
+    greed.hasCrown = false;
+    greed.isClimbing = false;
+    greed.climbTimer = 0;
+  } else if (type === GreedType.PlagueCrawler) {
+    greed.poisonOnDeath = true;
+    greed.isClimbing = false;
+    greed.climbTimer = 0;
+  }
+
+  greedSpawnPortals.set(eid, x);
+  state.greeds.push(greed);
+  return greed;
+}
+
+/** Spawn a mini-greed (from breeder). Fixed 1hp, no island scaling. */
+function spawnMiniGreed(state: GameState, x: number): void {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+
+  const greed: GreedData = {
+    eid,
+    type: GreedType.Basic,
+    hp: 1,
+    speed: GREED_SPEED_BASE,
+    damage: 1,
+    carryingCoins: 0,
+  };
+
+  state.greeds.push(greed);
+}
+
+/**
+ * Called by combat system when a greed takes damage.
+ * Handles masked greedling front mask logic.
+ * Returns the actual damage to apply (0 if mask absorbed).
+ */
+export function onGreedDamaged(
+  _state: GameState,
+  greed: GreedData,
+  _arrowVx: number,
+  fromTower: boolean,
+): number {
+  if (greed.type === GreedType.Masked && !greed.maskBroken) {
+    // Tower archers bypass mask
+    if (fromTower) return 1;
+
+    // Front hit absorbed by mask
+    greed.maskBroken = true;
+    return 0;
+  }
+  return 1; // full damage multiplier
+}
+
+/** Apply knockback to a greed (called by combat on arrow hit) */
+export function applyKnockback(state: GameState, greedEid: Entity, arrowVx: number): void {
+  const pos = getPosition(state.world, greedEid);
+  if (!pos) return;
+
+  const pushDir = arrowVx > 0 ? 1 : -1;
+  Position.x[greedEid] = pos.x + KNOCKBACK_DISTANCE * pushDir;
+}
+
+/** Notify greeds that a wall was destroyed. Attacking greeds get a brief pause. */
+export function onWallDestroyed(wallX: number): void {
+  const toPause: number[] = [];
+  for (const [eid, targetX] of greedWallTargets) {
+    if (targetX === wallX) {
+      toPause.push(eid);
+    }
+  }
+  for (const eid of toPause) {
+    pauseTimers.set(eid, WALL_BREAK_PAUSE);
+    greedWallTargets.delete(eid);
+  }
+}
+
+/**
+ * Trigger sunrise flee for all greedlings and masked greedlings.
+ * Breeders, floaters, and crown stealers do NOT flee.
+ */
+export function triggerSunriseFlee(state: GameState): void {
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    if (greed.type === GreedType.Basic || greed.type === GreedType.Masked) {
+      greed.isFleeing = true;
+      greed.fleeDespawnTimer = 0;
+    }
+  }
+}
+
+/** Find nearest portal position to a given x */
+function findNearestPortalX(state: GameState, x: number): number | null {
+  const portals = getActivePortals(state);
+  if (portals.length === 0) return null;
+
+  let nearest = portals[0];
+  let nearestDist = Math.abs(x - portals[0]);
+  for (let i = 1; i < portals.length; i++) {
+    const dist = Math.abs(x - portals[i]);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = portals[i];
+    }
+  }
+  return nearest;
+}
+
+/** Find nearest defensive structure in path between greed and target */
+function findNearestDefenseInPath(
+  state: GameState,
+  greedX: number,
+  targetX: number,
+): number | null {
+  const direction = greedX > targetX ? -1 : 1;
+  const startX = Math.round(greedX);
+  const endX = Math.round(targetX);
+  const scanLimit = Math.abs(endX - startX);
+
+  for (let i = 1; i <= Math.min(scanLimit, 50); i++) {
+    const checkX = startX + direction * i;
+    const structure = state.structures.get(checkX);
+    if (structure && isDefensiveStructure(structure.type)) {
+      return checkX;
+    }
+  }
+  return null;
+}
+
+/** Find a gap in a wall line that a crown stealer can pathfind through */
+function findWallGap(state: GameState, wallX: number, greedX: number): number | null {
+  let bestGap: number | null = null;
+  let bestDist = Infinity;
+
+  for (let offset = 1; offset <= GAP_SEARCH_RANGE; offset++) {
+    for (const dir of [-1, 1]) {
+      const checkX = wallX + offset * dir;
+      if (checkX < 0) continue;
+
+      const structure = state.structures.get(checkX);
+      const hasDefense = structure && isDefensiveStructure(structure.type);
+
+      if (!hasDefense) {
+        const dist = Math.abs(checkX - greedX);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestGap = checkX;
+        }
+      }
+    }
+    if (bestGap !== null) break;
+  }
+
+  return bestGap;
+}
+
+/** Update breeder-specific behavior: punch attack and continuous spawning */
+function updateBreeder(state: GameState, greed: GreedData, dt: number): void {
+  const pos = getPosition(state.world, greed.eid);
+  if (!pos) return;
+
+  // Punch attack: every 4 seconds, knocks down all units within 2 tiles
+  greed.breederPunchTimer = (greed.breederPunchTimer ?? BREEDER_PUNCH_INTERVAL) - dt;
+  if (greed.breederPunchTimer <= 0) {
+    greed.breederPunchTimer = BREEDER_PUNCH_INTERVAL;
+
+    for (const unit of state.units) {
+      if (unit.hp <= 0) continue;
+      const unitPos = getPosition(state.world, unit.eid);
+      if (!unitPos) continue;
+      if (Math.abs(unitPos.x - pos.x) <= BREEDER_PUNCH_RADIUS) {
+        // Stun unit (set to idle temporarily, use attackCooldown as stun timer)
+        unit.attackCooldown = Math.max(unit.attackCooldown, BREEDER_PUNCH_STUN);
+        // Drop coins
+        if (unit.coins > 0) {
+          unit.coins = 0;
+        }
+      }
+    }
+  }
+
+  // Continuous spawning: 2 greedlings every 6 seconds
+  greed.breederSpawnTimer = (greed.breederSpawnTimer ?? BREEDER_SPAWN_INTERVAL) - dt;
+  if (greed.breederSpawnTimer <= 0) {
+    greed.breederSpawnTimer = BREEDER_SPAWN_INTERVAL;
+
+    const currentChildren = greed.breederSpawnCount ?? 0;
+    if (currentChildren < BREEDER_MAX_CHILDREN) {
+      for (let i = 0; i < BREEDER_SPAWN_COUNT; i++) {
+        const offset = (Math.random() - 0.5) * 4;
+        spawnMiniGreed(state, pos.x + offset);
+      }
+      greed.breederSpawnCount = currentChildren + BREEDER_SPAWN_COUNT;
+    }
+  }
+}
+
+/** Update floater-specific behavior: abduct villagers */
+function updateFloater(state: GameState, greed: GreedData, dt: number): void {
+  const pos = getPosition(state.world, greed.eid);
+  if (!pos) return;
+
+  // If carrying a unit, move toward nearest portal
+  if (greed.isCarrying && greed.floaterTarget != null) {
+    const portalX = greedSpawnPortals.get(greed.eid);
+    if (portalX !== undefined) {
+      const direction = pos.x < portalX ? 1 : -1;
+      const dist = Math.abs(pos.x - portalX);
+      const moveSpeed = greed.speed * FLOATER_CARRY_SPEED_MULT;
+      const moveAmount = Math.min(moveSpeed * dt, dist);
+      Position.x[greed.eid] = pos.x + moveAmount * direction;
+
+      if (dist < 1.0) {
+        // Remove the abducted unit
+        const targetEid = greed.floaterTarget;
+        const unitIdx = state.units.findIndex(u => u.eid === targetEid);
+        if (unitIdx !== -1) {
+          state.units.splice(unitIdx, 1);
+        }
+        greed.floaterTarget = null;
+        greed.isCarrying = false;
+      }
+    }
+    return;
+  }
+
+  // Grabbing a target
+  if (greed.floaterTarget != null && !greed.isCarrying) {
+    const targetEid = greed.floaterTarget;
+    const targetUnit = state.units.find(u => u.eid === targetEid);
+    if (!targetUnit || targetUnit.hp <= 0) {
+      greed.floaterTarget = null;
+      greed.grabTimer = 0;
+      return;
+    }
+
+    const targetPos = getPosition(state.world, targetEid);
+    if (!targetPos) {
+      greed.floaterTarget = null;
+      greed.grabTimer = 0;
+      return;
+    }
+
+    // Move toward target
+    const dist = Math.abs(pos.x - targetPos.x);
+    if (dist > 1.0) {
+      const direction = pos.x < targetPos.x ? 1 : -1;
+      const moveAmount = Math.min(greed.speed * dt, dist);
+      Position.x[greed.eid] = pos.x + moveAmount * direction;
+      return;
+    }
+
+    // Within grab range: tick grab timer
+    greed.grabTimer = (greed.grabTimer ?? 0) + dt;
+    if (greed.grabTimer >= FLOATER_GRAB_TIME) {
+      greed.isCarrying = true;
+    }
+    return;
+  }
+
+  // Find a new target: nearest non-monarch unit
+  let bestUnit: Entity | null = null;
+  let bestDist = Infinity;
+
+  for (const unit of state.units) {
+    if (unit.hp <= 0) continue;
+    // Skip archers in roofed towers (towerTier >= 5)
+    // This check is simplified; we check if the unit is near a roofed tower
+    const unitPos = getPosition(state.world, unit.eid);
+    if (!unitPos) continue;
+
+    const dist = Math.abs(unitPos.x - pos.x);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestUnit = unit.eid;
+    }
+  }
+
+  if (bestUnit !== null) {
+    greed.floaterTarget = bestUnit;
+    greed.grabTimer = 0;
+  }
+}
+
+/** Update a single greed's AI */
+export function updateGreed(state: GameState, greed: GreedData, dt: number): void {
+  if (greed.hp <= 0) return;
+
+  // Periodically recalculate weakest settlement
+  weakestSettlementAge += dt;
+  if (weakestSettlementAge >= WEAKNESS_CACHE_INTERVAL) {
+    cachedWeakestSettlement = getWeakestSettlement(state);
+    weakestSettlementAge = 0;
+  }
+
+  // Check pause timer (wall-break stun)
+  const pauseRemaining = pauseTimers.get(greed.eid);
+  if (pauseRemaining !== undefined) {
+    const newPause = pauseRemaining - dt;
+    if (newPause > 0) {
+      pauseTimers.set(greed.eid, newPause);
+      return;
+    }
+    pauseTimers.delete(greed.eid);
+  }
+
+  const pos = getPosition(state.world, greed.eid);
+  if (!pos) return;
+
+  const greedX = pos.x;
+  const isFloater = greed.type === GreedType.Floater;
+  const isCrownStealer = greed.type === GreedType.CrownStealer;
+  const isBreeder = greed.type === GreedType.Breeder;
+  const isPlagueType = greed.type === GreedType.PlagueCrawler;
+
+  // Sunrise flee behavior (greedlings and masked only)
+  if (greed.isFleeing) {
+    const portalX = findNearestPortalX(state, greedX);
+    if (portalX !== null) {
+      const fleeDir = greedX < portalX ? 1 : -1;
+      const distToPortal = Math.abs(greedX - portalX);
+
+      if (distToPortal < 1.0) {
+        greed.hp = 0; // vanish at portal
+        return;
+      }
+
+      const moveAmount = Math.min(greed.speed * dt, distToPortal);
+      Position.x[greed.eid] = greedX + moveAmount * fleeDir;
+      return;
+    }
+
+    // No portal: despawn after timeout
+    greed.fleeDespawnTimer = (greed.fleeDespawnTimer ?? 0) + dt;
+    if (greed.fleeDespawnTimer >= SUNRISE_DESPAWN_NO_PORTAL) {
+      greed.hp = 0;
+      return;
+    }
+
+    // Wander while waiting to despawn
+    return;
+  }
+
+  // Daylight despawn for non-fleeing basic/masked (if sunrise flee wasn't triggered yet)
+  if ((greed.type === GreedType.Basic || greed.type === GreedType.Masked)
+      && state.timeOfDay === TimeOfDay.Day) {
+    greed.fleeDespawnTimer = (greed.fleeDespawnTimer ?? 0) + dt;
+    if (greed.fleeDespawnTimer >= SUNRISE_DESPAWN_TIMEOUT) {
+      greed.hp = 0;
+      return;
+    }
+  }
+
+  // Crown stealer with crown: flee to portal
+  if (isCrownStealer && greed.hasCrown) {
+    const portalX = greedSpawnPortals.get(greed.eid);
+    if (portalX !== undefined) {
+      const fleeDir = greedX < portalX ? 1 : -1;
+      const distToPortal = Math.abs(greedX - portalX);
+
+      if (distToPortal < 1.0) {
+        // Crown lost permanently
+        greed.hp = 0;
+        state.phase = GamePhase.GameOver;
+        state.messages.push('A Crown Stealer escaped with the crown!');
+        return;
+      }
+
+      const moveAmount = Math.min(CROWN_STEAL_FLEE_SPEED * dt, distToPortal);
+      Position.x[greed.eid] = greedX + moveAmount * fleeDir;
+    }
+    return;
+  }
+
+  // Breeder-specific updates
+  if (isBreeder) {
+    updateBreeder(state, greed, dt);
+  }
+
+  // Floater-specific updates (abduction logic)
+  if (isFloater) {
+    updateFloater(state, greed, dt);
+    // If floater has a target or is carrying, the floater update handles movement
+    if (greed.floaterTarget != null || greed.isCarrying) return;
+  }
+
+  // Retreat behavior: greeds carrying 3+ coins flee to spawn portal
+  if (greed.carryingCoins >= FLEE_COIN_THRESHOLD) {
+    const portalX = greedSpawnPortals.get(greed.eid);
+    if (portalX !== undefined) {
+      const fleeDir = greedX < portalX ? 1 : -1;
+      const distToPortal = Math.abs(greedX - portalX);
+
+      if (distToPortal < 1.0) {
+        greed.hp = 0;
+        return;
+      }
+
+      const moveAmount = Math.min(greed.speed * dt, distToPortal);
+      Position.x[greed.eid] = greedX + moveAmount * fleeDir;
+      return;
+    }
+  }
+
+  // Determine movement target: weakest settlement
+  let targetX = cachedWeakestSettlement;
+  if (isCrownStealer) {
+    const monarchPos = getPosition(state.world, state.monarch.eid);
+    if (monarchPos) {
+      targetX = monarchPos.x;
+    }
+  }
+
+  // Check for defensive structures in path
+  // Floaters fly over walls
+  const isPlagueCrawler = greed.type === GreedType.PlagueCrawler;
+  if (!isFloater) {
+    const defenseX = findNearestDefenseInPath(state, greedX, targetX);
+
+    if (defenseX !== null) {
+      const defense = state.structures.get(defenseX);
+      if (defense) {
+        // PlagueCrawler and CrownStealer climb over walls
+        if (isPlagueCrawler || isCrownStealer) {
+          if (isCrownStealer) {
+            // Crown stealers try to find a gap first
+            const gapX = findWallGap(state, defenseX, greedX);
+            if (gapX !== null) {
+              targetX = gapX;
+            } else {
+              // No gap: climb over (2 seconds, vulnerable)
+              greed.isClimbing = true;
+              greed.climbTimer = (greed.climbTimer ?? 0) + dt;
+              if (greed.climbTimer >= WALL_CLIMB_TIME) {
+                greed.isClimbing = false;
+                greed.climbTimer = 0;
+                // Jump past the wall
+                const dir = greedX > defenseX ? -1 : 1;
+                Position.x[greed.eid] = defenseX + dir * 2;
+              }
+              return;
+            }
+          } else {
+            // PlagueCrawler always climbs
+            greed.isClimbing = true;
+            greed.climbTimer = (greed.climbTimer ?? 0) + dt;
+            if (greed.climbTimer >= WALL_CLIMB_TIME) {
+              greed.isClimbing = false;
+              greed.climbTimer = 0;
+              const dir = greedX > defenseX ? -1 : 1;
+              Position.x[greed.eid] = defenseX + dir * 2;
+            }
+            return;
+          }
+        } else {
+          // Normal greed attacks wall with per-type damage
+          greedWallTargets.set(greed.eid, defenseX);
+          const wallDps = getGreedWallDamage(greed.type);
+          const reduction = getWallDamageReduction(state, defenseX);
+          defense.hp -= wallDps * reduction * dt;
+          if (defense.hp <= 0) {
+            defense.hp = 0;
+            state.structures.delete(defenseX);
+            onWallDestroyed(defenseX);
+          }
+          return;
+        }
+      }
+    } else {
+      greedWallTargets.delete(greed.eid);
+      // Reset climbing state if no wall in path
+      if (greed.isClimbing) {
+        greed.isClimbing = false;
+        greed.climbTimer = 0;
+      }
+    }
+  }
+
+  // Move toward target
+  const direction = greedX > targetX ? -1 : 1;
+  const distToTarget = Math.abs(greedX - targetX);
+  if (distToTarget < 0.1) return;
+
+  const moveAmount = Math.min(greed.speed * dt, distToTarget);
+  const newX = greedX + moveAmount * direction;
+  Position.x[greed.eid] = newX;
+
+  // Check collision with monarch
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  const distToMonarch = Math.abs(newX - monarchPos.x);
+  if (distToMonarch < 1.0) {
+    if (isCrownStealer) {
+      // Instantly knock crown off
+      greed.hasCrown = true;
+      state.crownDropped = true;
+      state.crownX = monarchPos.x;
+      state.crownY = GROUND_Y - 1;
+      state.messages.push('A Crown Stealer snatched the crown!');
+      return;
+    }
+
+    if (state.monarchCoins > 0) {
+      const stolen = Math.min(1, state.monarchCoins);
+      state.monarchCoins -= stolen;
+      greed.carryingCoins += stolen;
+    } else if (!state.crownDropped) {
+      state.phase = GamePhase.GameOver;
+      state.messages.push('The Greed has taken your crown!');
+    }
+  }
+}
+
+/** Apply plague crawler death poison to nearby units */
+export function applyPlagueCrawlerDeathPoison(state: GameState, deathX: number): void {
+  for (const unit of state.units) {
+    if (unit.hp <= 0) continue;
+    const unitPos = getPosition(state.world, unit.eid);
+    if (!unitPos) continue;
+    if (Math.abs(unitPos.x - deathX) <= PLAGUE_POISON_RADIUS) {
+      unit.poisonTimer = PLAGUE_POISON_DURATION;
+      unit.poisonDps = PLAGUE_POISON_DPS;
+    }
+  }
+}
+
+/** Clean up module state for a removed greed */
+export function cleanupGreedState(eid: Entity): void {
+  pauseTimers.delete(eid);
+  greedWallTargets.delete(eid);
+  greedSpawnPortals.delete(eid);
+}

--- a/kingdom/entities/hermit.ts
+++ b/kingdom/entities/hermit.ts
@@ -1,0 +1,231 @@
+/**
+ * Hermit system - 7 hermit types that unlock tower conversions and abilities.
+ * Each hermit lives in a cottage on a specific island.
+ * Monarch pays gems to coax hermit, then drops at target tower to convert it.
+ * Hermits can be kidnapped by greed and must be rescued by destroying portals.
+ */
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  GROUND_Y,
+  distance,
+} from '../types';
+
+// ─── Hermit Types ────────────────────────────────────────────────
+export enum HermitType {
+  Ballista = 'ballista',
+  Stable = 'stable',
+  Bakery = 'bakery',
+  Knight = 'knight',
+  Horn = 'horn',
+  FireTower = 'fireTower',
+  Berserker = 'berserker',
+}
+
+export interface HermitData {
+  type: HermitType;
+  islandIndex: number;
+  x: number;
+  coaxed: boolean;
+  riding: boolean;
+  kidnapped: boolean;
+  rescuable: boolean;
+}
+
+// ─── Hermit Config ───────────────────────────────────────────────
+interface HermitConfig {
+  type: HermitType;
+  island: number;
+  gemCost: number;
+  coinCost: number;
+  x: number;
+  description: string;
+}
+
+const HERMIT_CONFIGS: HermitConfig[] = [
+  { type: HermitType.Ballista, island: 1, gemCost: 3, coinCost: 1, x: 150, description: 'Ballista towers' },
+  { type: HermitType.Stable, island: 2, gemCost: 1, coinCost: 1, x: 180, description: 'Farmhouse & mount horn' },
+  { type: HermitType.Bakery, island: 3, gemCost: 4, coinCost: 1, x: 200, description: 'Bakery towers' },
+  { type: HermitType.Knight, island: 4, gemCost: 2, coinCost: 1, x: 160, description: 'Squire towers' },
+  { type: HermitType.Horn, island: 5, gemCost: 3, coinCost: 1, x: 140, description: 'Horn walls' },
+  { type: HermitType.FireTower, island: 1, gemCost: 2, coinCost: 1, x: 900, description: 'Fire towers' },
+  { type: HermitType.Berserker, island: 2, gemCost: 2, coinCost: 1, x: 950, description: 'Berserker towers' },
+];
+
+const HERMIT_WALK_SPEED = 2;
+const COAX_RANGE = 3;
+const KIDNAP_RANGE = 2;
+
+// ─── Module State ────────────────────────────────────────────────
+const hermits: HermitData[] = [];
+let ridingHermitIndex = -1;
+
+/** Initialize hermits for the current island. */
+export function createHermits(state: GameState): void {
+  hermits.length = 0;
+  ridingHermitIndex = -1;
+
+  for (const config of HERMIT_CONFIGS) {
+    if (config.island === state.islandIndex) {
+      hermits.push({
+        type: config.type,
+        islandIndex: config.island,
+        x: config.x,
+        coaxed: false,
+        riding: false,
+        kidnapped: false,
+        rescuable: false,
+      });
+    }
+  }
+}
+
+/** Get all hermits (read-only view). */
+export function getAvailableHermits(): readonly HermitData[] {
+  return hermits;
+}
+
+/** Get config for a hermit type. */
+export function getHermitConfig(type: HermitType): HermitConfig | undefined {
+  return HERMIT_CONFIGS.find(c => c.type === type);
+}
+
+/** Get the currently riding hermit type, or null. */
+export function getRidingHermit(): HermitType | null {
+  if (ridingHermitIndex < 0) return null;
+  return hermits[ridingHermitIndex]?.type ?? null;
+}
+
+/**
+ * Coax a hermit out of their cottage.
+ * Monarch must be near cottage, pay gem cost.
+ */
+export function coaxHermit(state: GameState, hermitIndex: number): boolean {
+  if (hermitIndex < 0 || hermitIndex >= hermits.length) return false;
+  const hermit = hermits[hermitIndex];
+  if (hermit.coaxed || hermit.kidnapped) return false;
+
+  const config = getHermitConfig(hermit.type);
+  if (!config) return false;
+
+  // Check monarch near cottage
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return false;
+  if (distance(monarchPos.x, hermit.x) > COAX_RANGE) return false;
+
+  // Check gem cost
+  if (state.gems < config.gemCost) return false;
+
+  // Check no other hermit riding
+  if (ridingHermitIndex >= 0) return false;
+
+  state.gems -= config.gemCost;
+  hermit.coaxed = true;
+  hermit.riding = true;
+  ridingHermitIndex = hermitIndex;
+
+  state.messages.push(`${config.description} hermit coaxed! (${config.gemCost} gems)`);
+  return true;
+}
+
+/**
+ * Drop the riding hermit at current monarch position.
+ * The hermit converts the nearest tower if applicable, then walks home.
+ */
+export function dropHermit(state: GameState): boolean {
+  if (ridingHermitIndex < 0) return false;
+  const hermit = hermits[ridingHermitIndex];
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return false;
+
+  // Pay coin cost
+  const config = getHermitConfig(hermit.type);
+  if (!config) return false;
+  if (state.monarchCoins < config.coinCost) {
+    state.messages.push(`Need ${config.coinCost} coin to place hermit`);
+    return false;
+  }
+  state.monarchCoins -= config.coinCost;
+
+  hermit.riding = false;
+  hermit.x = monarchPos.x;
+  ridingHermitIndex = -1;
+
+  state.messages.push(`${config.description} hermit placed! Unlocked: ${config.description}`);
+  return true;
+}
+
+/** Update hermit positions and kidnap checks. */
+export function updateHermits(state: GameState, dt: number): void {
+  for (let i = 0; i < hermits.length; i++) {
+    const hermit = hermits[i];
+
+    // Riding hermit follows monarch
+    if (hermit.riding) {
+      const monarchPos = getPosition(state.world, state.monarch.eid);
+      if (monarchPos) {
+        hermit.x = monarchPos.x;
+      }
+      continue;
+    }
+
+    // Kidnapped hermits don't move
+    if (hermit.kidnapped) continue;
+
+    // Coaxed but not riding: walk back to cottage
+    if (hermit.coaxed) {
+      const config = getHermitConfig(hermit.type);
+      if (config) {
+        const homeX = config.x;
+        const dist = distance(hermit.x, homeX);
+        if (dist > 1) {
+          const dir = homeX > hermit.x ? 1 : -1;
+          hermit.x += dir * HERMIT_WALK_SPEED * dt;
+        } else {
+          hermit.coaxed = false; // Back home, can be coaxed again for another tower
+        }
+      }
+    }
+
+    // Check for greed kidnapping
+    if (!hermit.kidnapped && !hermit.riding) {
+      for (const greed of state.greeds) {
+        const greedPos = getPosition(state.world, greed.eid);
+        if (!greedPos) continue;
+        if (distance(hermit.x, greedPos.x) < KIDNAP_RANGE) {
+          hermit.kidnapped = true;
+          hermit.rescuable = true;
+          state.messages.push('A hermit has been kidnapped!');
+          break;
+        }
+      }
+    }
+  }
+}
+
+/** Rescue a hermit when a portal is destroyed. */
+export function rescueHermitFromPortal(state: GameState): void {
+  for (const hermit of hermits) {
+    if (hermit.kidnapped && hermit.rescuable) {
+      hermit.kidnapped = false;
+      hermit.rescuable = false;
+      hermit.coaxed = false;
+      const config = getHermitConfig(hermit.type);
+      hermit.x = config?.x ?? 200;
+      state.messages.push('A hermit has been rescued!');
+      return;
+    }
+  }
+}
+
+/** Check if a specific hermit type has been unlocked (coaxed and dropped at least once). */
+const unlockedHermitTypes = new Set<HermitType>();
+
+export function markHermitUnlocked(type: HermitType): void {
+  unlockedHermitTypes.add(type);
+}
+
+export function isHermitUnlocked(type: HermitType): boolean {
+  return unlockedHermitTypes.has(type);
+}

--- a/kingdom/entities/knight.ts
+++ b/kingdom/entities/knight.ts
@@ -1,0 +1,715 @@
+/**
+ * Knight and Squire entities.
+ * Squire: 4 coins for shield (TownCenterTier >= 6, Castle). 3 HP, 5 coin cap.
+ *   Commands up to 4 archers. Can do everything knights do but weaker.
+ * Knight: promoted from Squire with iron sword (12 coins at forge, future phase).
+ *   5 HP, 11 coin cap. Enhanced combat.
+ * Both lead squads of archers toward portals and can damage them.
+ */
+import { addEntity, getPosition, setPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  UnitRole,
+  AIState,
+  TimeOfDay,
+  StructureType,
+  ARCHER_SPEED,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  GROUND_Y,
+  clamp,
+  distance,
+} from '../types';
+
+const KNIGHT_SPEED = ARCHER_SPEED + 1;
+const SQUIRE_SPEED = ARCHER_SPEED;
+const PORTAL_ATTACK_COOLDOWN = 2.0;
+const PORTAL_ATTACK_DAMAGE = 2;
+const SQUIRE_PORTAL_ATTACK_DAMAGE = 1;
+const SQUAD_SIZE = 2;
+const SQUIRE_SQUAD_SIZE = 4;
+const PORTAL_GUARD_RANGE = 15;
+const KNIGHT_SHIELD_MAX = 3;
+const CROWN_DEFENSE_ATTACK_RANGE = 5;
+
+// ─── Knight Mode & Shield ────────────────────────────────────────
+export type KnightMode = 'defensive' | 'offensive' | 'crownDefense';
+
+// Per-knight shield HP (regenerates 1 per day at dawn)
+const knightShields = new Map<number, number>();
+
+/** Get the current mode for a knight. */
+export function getKnightMode(state: GameState, knightEid: number): KnightMode {
+  if (state.crownDropped) return 'crownDefense';
+  if (activeAssault?.active && activeAssault.knightEid === knightEid) return 'offensive';
+  return 'defensive';
+}
+
+/** Get knight shield HP. */
+export function getKnightShieldHp(knightEid: number): number {
+  return knightShields.get(knightEid) ?? KNIGHT_SHIELD_MAX;
+}
+
+/** Initialize shield for a new knight. */
+function initKnightShield(knightEid: number): void {
+  if (!knightShields.has(knightEid)) {
+    knightShields.set(knightEid, KNIGHT_SHIELD_MAX);
+  }
+}
+
+/** Take a hit on the knight's personal shield. Returns true if absorbed. */
+export function absorbKnightShieldHit(knightEid: number): boolean {
+  const hp = knightShields.get(knightEid) ?? 0;
+  if (hp <= 0) return false;
+  knightShields.set(knightEid, hp - 1);
+  return true;
+}
+
+/** Regenerate 1 shield HP for all knights at dawn. */
+export function regenerateKnightShields(state: GameState): void {
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Knight) continue;
+    const current = knightShields.get(unit.eid) ?? 0;
+    if (current < KNIGHT_SHIELD_MAX) {
+      knightShields.set(unit.eid, current + 1);
+    }
+  }
+}
+
+export function createKnight(state: GameState, x: number): UnitData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  const unit: UnitData = {
+    eid,
+    role: UnitRole.Knight,
+    aiState: AIState.Idle,
+    targetX: x,
+    hp: 5,
+    maxHp: 5,
+    attackCooldown: 0,
+    coins: 0,
+  };
+
+  state.units.push(unit);
+  initKnightShield(unit.eid);
+  return unit;
+}
+
+export function updateKnight(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  if (unit.attackCooldown > 0) {
+    unit.attackCooldown = Math.max(0, unit.attackCooldown - dt);
+  }
+
+  // Crown defense overrides all other modes
+  const mode = getKnightMode(state, unit.eid);
+  if (mode === 'crownDefense') {
+    updateKnightCrownDefense(state, unit, pos, dt);
+    return;
+  }
+
+  switch (state.timeOfDay) {
+    case TimeOfDay.Dawn:
+    case TimeOfDay.Day:
+      updateKnightDay(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Dusk:
+      updateKnightDusk(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Night:
+      updateKnightNight(state, unit, pos, dt);
+      break;
+  }
+}
+
+/**
+ * Crown defense: rush to crown, attack greed within 5 tiles of crown.
+ */
+function updateKnightCrownDefense(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  const crownDist = distance(pos.x, state.crownX);
+
+  if (crownDist > 3.0) {
+    // Rush to crown
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = state.crownX;
+    const dir = state.crownX > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * KNIGHT_SPEED * 1.5, 0);
+    return;
+  }
+
+  // At crown position: attack any greed within range
+  unit.aiState = AIState.Defending;
+  setVelocity(state.world, unit.eid, 0, 0);
+
+  if (unit.attackCooldown > 0) return;
+
+  for (const greed of state.greeds) {
+    const gPos = getPosition(state.world, greed.eid);
+    if (!gPos) continue;
+    if (distance(state.crownX, gPos.x) <= CROWN_DEFENSE_ATTACK_RANGE) {
+      greed.hp -= PORTAL_ATTACK_DAMAGE;
+      unit.attackCooldown = PORTAL_ATTACK_COOLDOWN;
+      return;
+    }
+  }
+}
+
+function updateKnightDay(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Prioritize unguarded portals, then any portal
+  const portalX = findBestPortalTarget(state, pos.x);
+
+  if (portalX === undefined) {
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Attacking;
+  const dist = distance(pos.x, portalX);
+
+  if (dist < 2.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+
+    if (unit.attackCooldown <= 0) {
+      attackPortal(state, portalX);
+      unit.attackCooldown = PORTAL_ATTACK_COOLDOWN;
+    }
+  } else {
+    unit.targetX = portalX;
+    const dir = portalX > pos.x ? 1 : -1;
+    const vx = dir * KNIGHT_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+  }
+
+  // Rally nearby archers
+  rallySquad(state, unit, pos.x);
+}
+
+function updateKnightDusk(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  unit.aiState = AIState.Retreating;
+
+  const retreatX = findRetreatPosition(state, pos.x);
+  const dist = distance(pos.x, retreatX);
+
+  if (dist < 1.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dir = retreatX > pos.x ? 1 : -1;
+  const vx = dir * KNIGHT_SPEED;
+  setVelocity(state.world, unit.eid, vx, 0);
+}
+
+function updateKnightNight(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  const wallX = findOutermostWallOnSide(state, pos.x);
+  const dist = distance(pos.x, wallX);
+
+  if (dist > 1.0) {
+    unit.aiState = AIState.MovingTo;
+    const dir = wallX > pos.x ? 1 : -1;
+    const vx = dir * KNIGHT_SPEED;
+    setVelocity(state.world, unit.eid, vx, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Defending;
+  setVelocity(state.world, unit.eid, 0, 0);
+}
+
+/** Prefer unguarded portals over guarded ones. */
+function findBestPortalTarget(state: GameState, fromX: number): number | undefined {
+  let bestUnguarded: number | undefined;
+  let bestUnguardedDist = Infinity;
+  let bestAny: number | undefined;
+  let bestAnyDist = Infinity;
+
+  const portalXs = collectPortalPositions(state);
+
+  for (const px of portalXs) {
+    const d = distance(fromX, px);
+    const guarded = isPortalGuarded(state, px);
+
+    if (!guarded && d < bestUnguardedDist) {
+      bestUnguardedDist = d;
+      bestUnguarded = px;
+    }
+    if (d < bestAnyDist) {
+      bestAnyDist = d;
+      bestAny = px;
+    }
+  }
+
+  return bestUnguarded ?? bestAny;
+}
+
+function collectPortalPositions(state: GameState): number[] {
+  const positions: number[] = [];
+
+  for (const [, struct] of state.structures) {
+    if (struct.type === StructureType.Portal && struct.hp > 0) {
+      positions.push(struct.x);
+    }
+  }
+
+  for (const px of state.portalPositions) {
+    if (!positions.includes(px)) positions.push(px);
+  }
+
+  return positions;
+}
+
+function isPortalGuarded(state: GameState, portalX: number): boolean {
+  for (const greed of state.greeds) {
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (distance(portalX, pos.x) <= PORTAL_GUARD_RANGE) return true;
+  }
+  return false;
+}
+
+function attackPortal(state: GameState, portalX: number): void {
+  const roundedX = Math.round(portalX);
+  for (const [key, struct] of state.structures) {
+    if (struct.type !== StructureType.Portal) continue;
+    if (distance(struct.x, roundedX) > 2) continue;
+
+    struct.hp = Math.max(0, struct.hp - PORTAL_ATTACK_DAMAGE);
+    if (struct.hp <= 0) {
+      state.messages.push('Portal destroyed!');
+      state.structures.delete(key);
+      const idx = state.portalPositions.indexOf(struct.x);
+      if (idx >= 0) state.portalPositions.splice(idx, 1);
+    } else {
+      state.messages.push('Knight attacks portal');
+    }
+    return;
+  }
+}
+
+function rallySquad(state: GameState, knight: UnitData, knightX: number): void {
+  let rallied = 0;
+  const rallyRange = 20;
+
+  for (const unit of state.units) {
+    if (rallied >= SQUAD_SIZE) break;
+    if (unit.role !== UnitRole.Archer) continue;
+    if (unit.aiState === AIState.Retreating || unit.aiState === AIState.Defending) continue;
+
+    const archerPos = getPosition(state.world, unit.eid);
+    if (!archerPos) continue;
+
+    const d = distance(knightX, archerPos.x);
+    if (d <= rallyRange) {
+      unit.targetX = knight.targetX;
+      unit.aiState = AIState.Attacking;
+      rallied++;
+    }
+  }
+}
+
+function findRetreatPosition(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  let bestWallX = CAMP_CENTER_X;
+  let bestDist = Infinity;
+  const towardsCamp = onRightSide ? -1 : 1;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== onRightSide) continue;
+
+    const d = distance(fromX, struct.x);
+    if (d < bestDist) {
+      bestDist = d;
+      bestWallX = struct.x + towardsCamp * 2;
+    }
+  }
+
+  return clamp(bestWallX, 0, MAP_WIDTH - 1);
+}
+
+function findOutermostWallOnSide(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  let outermostX = CAMP_CENTER_X;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== onRightSide) continue;
+
+    if (onRightSide) {
+      if (struct.x > outermostX) outermostX = struct.x;
+    } else {
+      if (struct.x < outermostX) outermostX = struct.x;
+    }
+  }
+
+  return outermostX;
+}
+
+// ─── Portal Assault ──────────────────────────────────────────────
+
+export interface AssaultSquad {
+  knightEid: number;
+  archerEids: number[];
+  targetPortalX: number;
+  active: boolean;
+  knightShieldHp: number;
+}
+
+const ASSAULT_SQUAD_SIZE = 4;
+const ASSAULT_FORMATION_SPACING = 2;
+const KNIGHT_SHIELD_HP = 3;
+const ASSAULT_PORTAL_DPS = 2;
+
+let activeAssault: AssaultSquad | null = null;
+
+/** Get the current assault squad (read-only). */
+export function getAssaultSquad(): AssaultSquad | null {
+  return activeAssault;
+}
+
+/**
+ * Dispatch an assault squad toward a portal.
+ * Knight leads, 4 archers follow in formation.
+ */
+export function dispatchAssault(
+  state: GameState,
+  knightUnit: UnitData,
+  targetPortalX: number,
+): boolean {
+  if (activeAssault?.active) return false;
+
+  // Find 4 nearest available archers
+  const archerEids: number[] = [];
+  const knightPos = getPosition(state.world, knightUnit.eid);
+  if (!knightPos) return false;
+
+  const candidates: { eid: number; dist: number }[] = [];
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Archer) continue;
+    if (unit.aiState === AIState.Retreating || unit.aiState === AIState.Fleeing) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    candidates.push({ eid: unit.eid, dist: distance(knightPos.x, pos.x) });
+  }
+
+  candidates.sort((a, b) => a.dist - b.dist);
+  for (let i = 0; i < Math.min(ASSAULT_SQUAD_SIZE, candidates.length); i++) {
+    archerEids.push(candidates[i].eid);
+  }
+
+  activeAssault = {
+    knightEid: knightUnit.eid,
+    archerEids,
+    targetPortalX,
+    active: true,
+    knightShieldHp: KNIGHT_SHIELD_HP,
+  };
+
+  knightUnit.aiState = AIState.Attacking;
+  knightUnit.targetX = targetPortalX;
+
+  // Set archers to assault mode
+  for (const archerEid of archerEids) {
+    const unit = state.units.find(u => u.eid === archerEid);
+    if (unit) {
+      unit.aiState = AIState.Attacking;
+      unit.targetX = targetPortalX;
+    }
+  }
+
+  state.messages.push('Portal assault dispatched!');
+  return true;
+}
+
+/** Update the active assault squad. */
+export function updateAssault(state: GameState, dt: number): void {
+  if (!activeAssault || !activeAssault.active) return;
+
+  const knight = state.units.find(u => u.eid === activeAssault!.knightEid);
+  if (!knight) {
+    recallSquad(state);
+    return;
+  }
+
+  const knightPos = getPosition(state.world, knight.eid);
+  if (!knightPos) return;
+
+  // Check retreat conditions
+  if (activeAssault.knightShieldHp <= 0) {
+    state.messages.push('Knight shield broken! Squad retreating!');
+    recallSquad(state);
+    return;
+  }
+  if (knight.hp <= 1) {
+    state.messages.push('Knight critically wounded! Squad retreating!');
+    recallSquad(state);
+    return;
+  }
+
+  // Check if archers are all dead
+  const livingArchers = activeAssault.archerEids.filter(eid =>
+    state.units.some(u => u.eid === eid && u.hp > 0)
+  );
+  if (livingArchers.length === 0) {
+    state.messages.push('All archers fallen! Squad retreating!');
+    recallSquad(state);
+    return;
+  }
+  activeAssault.archerEids = livingArchers;
+
+  const portalDist = distance(knightPos.x, activeAssault.targetPortalX);
+
+  // Knight moves to portal
+  if (portalDist > 2.0) {
+    knight.aiState = AIState.Attacking;
+    const dir = activeAssault.targetPortalX > knightPos.x ? 1 : -1;
+    setVelocity(state.world, knight.eid, dir * KNIGHT_SPEED, 0);
+  } else {
+    // Knight attacking portal
+    setVelocity(state.world, knight.eid, 0, 0);
+    if (knight.attackCooldown <= 0) {
+      attackPortal(state, activeAssault.targetPortalX);
+      knight.attackCooldown = PORTAL_ATTACK_COOLDOWN;
+
+      // Check if portal destroyed
+      const portalStillExists = state.portalPositions.includes(
+        Math.round(activeAssault.targetPortalX)
+      ) || [...state.structures.values()].some(
+        s => s.type === StructureType.Portal && distance(s.x, activeAssault!.targetPortalX) < 3
+      );
+
+      if (!portalStillExists) {
+        state.messages.push('Portal destroyed! Squad returning victorious!');
+        recallSquad(state);
+        return;
+      }
+    }
+  }
+
+  // Archers follow in formation behind knight
+  for (let i = 0; i < activeAssault.archerEids.length; i++) {
+    const archer = state.units.find(u => u.eid === activeAssault!.archerEids[i]);
+    if (!archer) continue;
+    const archerPos = getPosition(state.world, archer.eid);
+    if (!archerPos) continue;
+
+    // Formation position: behind knight
+    const dir = activeAssault.targetPortalX > knightPos.x ? -1 : 1;
+    const formationX = knightPos.x + dir * (ASSAULT_FORMATION_SPACING * (i + 1));
+    const formDist = distance(archerPos.x, formationX);
+
+    if (formDist > 1.5) {
+      const moveDir = formationX > archerPos.x ? 1 : -1;
+      setVelocity(state.world, archer.eid, moveDir * ARCHER_SPEED, 0);
+    } else {
+      setVelocity(state.world, archer.eid, 0, 0);
+    }
+  }
+}
+
+/** Recall the assault squad. All units return to idle. */
+export function recallSquad(state: GameState): void {
+  if (!activeAssault) return;
+
+  const knight = state.units.find(u => u.eid === activeAssault!.knightEid);
+  if (knight) {
+    knight.aiState = AIState.Idle;
+    setVelocity(state.world, knight.eid, 0, 0);
+  }
+
+  for (const archerEid of activeAssault.archerEids) {
+    const archer = state.units.find(u => u.eid === archerEid);
+    if (archer) {
+      archer.aiState = AIState.Idle;
+      setVelocity(state.world, archer.eid, 0, 0);
+    }
+  }
+
+  activeAssault.active = false;
+  activeAssault = null;
+}
+
+/** Absorb a hit on the assault knight's shield. Returns true if absorbed. */
+export function absorbAssaultHit(): boolean {
+  if (!activeAssault || !activeAssault.active) return false;
+  if (activeAssault.knightShieldHp <= 0) return false;
+
+  activeAssault.knightShieldHp--;
+  return true;
+}
+
+// ─── Squire ───────────────────────────────────────────────────────
+
+export function createSquire(state: GameState, x: number): UnitData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  const unit: UnitData = {
+    eid,
+    role: UnitRole.Squire,
+    aiState: AIState.Idle,
+    targetX: x,
+    hp: 3,
+    maxHp: 3,
+    attackCooldown: 0,
+    coins: 0,
+  };
+
+  state.units.push(unit);
+  return unit;
+}
+
+/** Squire update: same behavior as knight but with weaker stats and larger squad. */
+export function updateSquire(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  if (unit.attackCooldown > 0) {
+    unit.attackCooldown = Math.max(0, unit.attackCooldown - dt);
+  }
+
+  switch (state.timeOfDay) {
+    case TimeOfDay.Dawn:
+    case TimeOfDay.Day:
+      updateSquireDay(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Dusk:
+      updateSquireDusk(state, unit, pos);
+      break;
+    case TimeOfDay.Night:
+      updateSquireNight(state, unit, pos);
+      break;
+  }
+}
+
+function updateSquireDay(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  _dt: number,
+): void {
+  const portalX = findBestPortalTarget(state, pos.x);
+
+  if (portalX === undefined) {
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Attacking;
+  const dist = distance(pos.x, portalX);
+
+  if (dist < 2.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+
+    if (unit.attackCooldown <= 0) {
+      attackPortal(state, portalX);
+      unit.attackCooldown = PORTAL_ATTACK_COOLDOWN;
+    }
+  } else {
+    unit.targetX = portalX;
+    const dir = portalX > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * SQUIRE_SPEED, 0);
+  }
+
+  // Squires rally a larger squad (4 archers)
+  rallySquireSquad(state, unit, pos.x);
+}
+
+function updateSquireDusk(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+): void {
+  unit.aiState = AIState.Retreating;
+
+  const retreatX = findRetreatPosition(state, pos.x);
+  const dist = distance(pos.x, retreatX);
+
+  if (dist < 1.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dir = retreatX > pos.x ? 1 : -1;
+  setVelocity(state.world, unit.eid, dir * SQUIRE_SPEED, 0);
+}
+
+function updateSquireNight(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+): void {
+  const wallX = findOutermostWallOnSide(state, pos.x);
+  const dist = distance(pos.x, wallX);
+
+  if (dist > 1.0) {
+    unit.aiState = AIState.MovingTo;
+    const dir = wallX > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * SQUIRE_SPEED, 0);
+    return;
+  }
+
+  unit.aiState = AIState.Defending;
+  setVelocity(state.world, unit.eid, 0, 0);
+}
+
+function rallySquireSquad(state: GameState, squire: UnitData, squireX: number): void {
+  let rallied = 0;
+  const rallyRange = 20;
+
+  for (const unit of state.units) {
+    if (rallied >= SQUIRE_SQUAD_SIZE) break;
+    if (unit.role !== UnitRole.Archer) continue;
+    if (unit.aiState === AIState.Retreating || unit.aiState === AIState.Defending) continue;
+
+    const archerPos = getPosition(state.world, unit.eid);
+    if (!archerPos) continue;
+
+    const d = distance(squireX, archerPos.x);
+    if (d <= rallyRange) {
+      unit.targetX = squire.targetX;
+      unit.aiState = AIState.Attacking;
+      rallied++;
+    }
+  }
+}

--- a/kingdom/entities/merchant.ts
+++ b/kingdom/entities/merchant.ts
@@ -1,0 +1,109 @@
+/**
+ * Merchant NPC - appears on islands 1-2 only (state.islandIndex <= 2).
+ * Has a camp in the forest at a fixed x position.
+ * Mechanic: monarch drops 1 coin near merchant -> merchant returns 8 coins next dawn.
+ * Only accepts during daytime, not during danger (no active greed nearby).
+ */
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  TimeOfDay,
+  CAMP_CENTER_X,
+  distance,
+} from '../types';
+import { collectCoins } from '../game/economy';
+
+// ─── Module State ─────────────────────────────────────────────────
+let pendingPayout = 0;
+let merchantX = 100; // fixed position on the map
+let lastPayoutDay = -1;
+
+const MERCHANT_PAYOUT = 8;
+const MERCHANT_ACCEPT_RANGE = 3;
+const GREED_DANGER_RANGE = 20;
+
+// ─── Public API ───────────────────────────────────────────────────
+
+/** Create/initialize merchant for the current island. */
+export function createMerchant(state: GameState): void {
+  if (state.islandIndex > 2) return; // islands 1-2 only (0-indexed: 0,1,2)
+
+  // Place merchant on opposite side from town center on island 1, nearby on island 2
+  merchantX = state.islandIndex <= 1 ? 100 : 200;
+  pendingPayout = 0;
+  lastPayoutDay = -1;
+}
+
+/** Merchant accepts a coin from the monarch. Returns true if accepted. */
+export function merchantAcceptCoin(state: GameState): boolean {
+  if (state.islandIndex > 2) return false;
+
+  // Only during daytime
+  if (state.timeOfDay !== TimeOfDay.Day && state.timeOfDay !== TimeOfDay.Dawn) {
+    state.messages.push('Merchant only trades during the day');
+    return false;
+  }
+
+  // Check for danger (greed nearby)
+  if (hasNearbyGreed(state, merchantX, GREED_DANGER_RANGE)) {
+    state.messages.push('Merchant refuses to trade during danger!');
+    return false;
+  }
+
+  // Check monarch is near merchant
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos || distance(monarchPos.x, merchantX) > MERCHANT_ACCEPT_RANGE) {
+    return false;
+  }
+
+  if (state.monarchCoins < 1) {
+    state.messages.push('No coins to pay merchant!');
+    return false;
+  }
+
+  state.monarchCoins -= 1;
+  pendingPayout += MERCHANT_PAYOUT;
+  state.messages.push(`Paid merchant 1 coin (${MERCHANT_PAYOUT} coins at dawn)`);
+  return true;
+}
+
+/** Update merchant each frame. At dawn, pay out pending coins. */
+export function updateMerchant(state: GameState, _dt: number): void {
+  if (state.islandIndex > 2) return;
+
+  // Pay out at dawn
+  if (state.timeOfDay === TimeOfDay.Dawn && pendingPayout > 0 && state.dayCount !== lastPayoutDay) {
+    lastPayoutDay = state.dayCount;
+    const payout = pendingPayout;
+    pendingPayout = 0;
+    collectCoins(state, payout);
+    state.messages.push(`Merchant delivered ${payout} coins!`);
+  }
+}
+
+/** Check if merchant is available for interaction. */
+export function isMerchantAvailable(state: GameState): boolean {
+  if (state.islandIndex > 2) return false;
+  if (state.timeOfDay !== TimeOfDay.Day && state.timeOfDay !== TimeOfDay.Dawn) return false;
+  if (hasNearbyGreed(state, merchantX, GREED_DANGER_RANGE)) return false;
+  return true;
+}
+
+/** Get merchant's x position. */
+export function getMerchantX(): number {
+  return merchantX;
+}
+
+/** Get pending payout amount. */
+export function getPendingPayout(): number {
+  return pendingPayout;
+}
+
+function hasNearbyGreed(state: GameState, x: number, range: number): boolean {
+  for (const greed of state.greeds) {
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (distance(x, pos.x) <= range) return true;
+  }
+  return false;
+}

--- a/kingdom/entities/monarch.ts
+++ b/kingdom/entities/monarch.ts
@@ -1,0 +1,197 @@
+/**
+ * Monarch entity - the player character.
+ * One-shot coin drop (fires once per space press, not continuous).
+ * Updates nearby interactable indicator for HUD each frame.
+ *
+ * Crown mechanic:
+ * - Crown drops when monarch has 0 coins and takes a hit from greed
+ * - 10 second recovery window to walk over crown position
+ * - Crown stealer can grab dropped crown and carry to portal
+ * - If timer expires or crown reaches portal: game over
+ */
+import { addEntity, setPosition, getPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  UnitRole,
+  AIState,
+  GamePhase,
+  MountType,
+  CAMP_CENTER_X,
+  GROUND_Y,
+  STARTING_COINS,
+  distance,
+} from '../types';
+import { dropCoin, updateNearbyInteractable } from '../game/economy';
+import { getMountSpeed } from './mount';
+
+let previousInputDrop = false;
+
+const CROWN_RECOVERY_TIME = 10; // seconds
+const CROWN_PICKUP_RANGE = 2; // tiles
+
+export function createMonarch(state: GameState): UnitData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, CAMP_CENTER_X, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  const unit: UnitData = {
+    eid,
+    role: UnitRole.Monarch,
+    aiState: AIState.Idle,
+    targetX: CAMP_CENTER_X,
+    hp: 1,
+    maxHp: 1,
+    attackCooldown: 0,
+    coins: 0,
+  };
+
+  return unit;
+}
+
+export function updateMonarch(state: GameState, dt: number): void {
+  const monarch = state.monarch;
+  const pos = getPosition(state.world, monarch.eid);
+  if (!pos) return;
+
+  // Determine movement velocity from input
+  let vx = 0;
+  let speed = getMountSpeed(state);
+  if (state.speedBoostTimer > 0) speed *= 1.5;
+
+  if (state.inputLeft) vx = -speed;
+  if (state.inputRight) vx = speed;
+
+  setVelocity(state.world, monarch.eid, vx, 0);
+
+  // Update nearby interactable indicator for HUD
+  updateNearbyInteractable(state);
+
+  // Handle crown drop recovery
+  if (state.crownDropped) {
+    updateCrownRecovery(state, pos, dt);
+  }
+
+  // Handle coin drop: one-shot on rising edge of inputDrop
+  if (state.inputDrop && !previousInputDrop) {
+    dropCoin(state);
+    state.lastCoinDrop = Date.now();
+  }
+  previousInputDrop = state.inputDrop;
+}
+
+/**
+ * Drop the crown when monarch has 0 coins and takes a hit.
+ * Called by combat/greed system when monarch is hit.
+ */
+export function dropCrown(state: GameState): void {
+  if (state.crownDropped) return; // already dropped
+
+  const pos = getPosition(state.world, state.monarch.eid);
+  if (!pos) return;
+
+  state.crownDropped = true;
+  state.crownX = pos.x;
+  state.crownY = pos.y;
+  state.crownTimer = CROWN_RECOVERY_TIME;
+
+  state.messages.push('The crown has fallen! Recover it quickly!');
+}
+
+/**
+ * Recover the crown by walking over it.
+ */
+export function recoverCrown(state: GameState): void {
+  if (!state.crownDropped) return;
+
+  state.crownDropped = false;
+  state.crownTimer = 0;
+
+  state.messages.push('Crown recovered!');
+}
+
+/**
+ * Check if monarch is vulnerable (0 coins, crown not already dropped).
+ * Used by combat system to determine if a hit should drop the crown.
+ */
+export function isMonarchVulnerable(state: GameState): boolean {
+  return state.monarchCoins <= 0 && !state.crownDropped;
+}
+
+function updateCrownRecovery(
+  state: GameState,
+  monarchPos: { x: number; y: number },
+  dt: number,
+): void {
+  // Count down timer
+  state.crownTimer -= dt;
+
+  // Check if monarch walks over crown
+  if (distance(monarchPos.x, state.crownX) <= CROWN_PICKUP_RANGE) {
+    recoverCrown(state);
+    return;
+  }
+
+  // Check if timer expired
+  if (state.crownTimer <= 0) {
+    triggerHeirSuccession(state);
+  }
+}
+
+// ─── Heir Succession ──────────────────────────────────────────────
+
+const HEIR_STARTING_COINS = 8;
+const DOCK_X = 50; // spawn at dock on same island
+
+/**
+ * Trigger heir succession when crown is permanently lost.
+ * Instead of game over, a new heir takes the throne.
+ * Preserves: banker coins, gems, unlocks.
+ * Decays: all subjects revert to vagrants, structures decay.
+ */
+export function triggerHeirSuccession(state: GameState): void {
+  state.totalHeirs++;
+  state.messages.push('The crown has been lost...');
+  state.messages.push('A new heir approaches the kingdom.');
+
+  // Revert all units to vagrants (lose their tools)
+  for (const unit of state.units) {
+    if (unit.role === UnitRole.Monarch) continue;
+    if (unit.role !== UnitRole.Vagrant) {
+      unit.role = UnitRole.Vagrant;
+      unit.aiState = AIState.Idle;
+      unit.hp = 1;
+      unit.maxHp = 1;
+      unit.coins = 0;
+    }
+  }
+
+  // Spawn new heir
+  spawnHeir(state);
+}
+
+/**
+ * Spawn the heir monarch at the dock position.
+ * Starts with 8 coins, no mount.
+ */
+export function spawnHeir(state: GameState): void {
+  // Reset crown state
+  state.crownDropped = false;
+  state.crownTimer = 0;
+
+  // Reset monarch position to dock
+  setPosition(state.world, state.monarch.eid, DOCK_X, GROUND_Y - 1);
+  setVelocity(state.world, state.monarch.eid, 0, 0);
+
+  // Heir starts with limited resources
+  state.monarchCoins = HEIR_STARTING_COINS;
+
+  // No mount
+  state.mountType = MountType.None;
+  state.stamina = 0;
+
+  // Gems and banker coins are preserved (inheritance)
+  // Unlocks (mounts, hermits, statues) are preserved
+
+  state.messages.push(`Heir #${state.totalHeirs} has arrived at the dock with ${HEIR_STARTING_COINS} coins.`);
+}

--- a/kingdom/entities/mount.ts
+++ b/kingdom/entities/mount.ts
@@ -1,0 +1,385 @@
+/**
+ * Kingdom - Mount system with 7 mount types.
+ * Each mount has unique speed, stamina, and ability.
+ * Mounts found at stables on specific islands, unlocked with gems, ridden for coins.
+ * Mount loss on hit: returns to stable.
+ * Abilities activated with 'e' key.
+ *
+ * | Mount    | Speed | Stamina | Ability                                |
+ * |----------|-------|---------|----------------------------------------|
+ * | Horse    | 1.5x  | 100     | None (baseline)                        |
+ * | Stag     | 1.3x  | 80      | Attracts deer within 20 tiles          |
+ * | Griffin  | 1.8x  | 60      | Wing flap knockback (5 tiles AoE)      |
+ * | Warhorse | 1.5x  | 120     | Charge: 10s invincibility nearby allies |
+ * | Bear     | 1.0x  | 150     | Pounce: instakill 1 greed, 8s cd       |
+ * | Lizard   | 1.3x  | 70      | Fire breath: 3-tile cone, 3 DPS, 6s cd |
+ * | Unicorn  | 1.4x  | 90      | Grass eating: +3 coins, 15s cd         |
+ */
+
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  MountType,
+  TileType,
+  GROUND_Y,
+  MONARCH_SPEED,
+  MONARCH_SPRINT,
+  distance,
+} from '../types';
+import { collectCoins } from '../game/economy';
+
+export { MountType } from '../types';
+
+// ─── Mount Stats ──────────────────────────────────────────────────
+interface MountStats {
+  speedMult: number;
+  sprintMult: number;
+  maxStamina: number;
+  island: number;
+  gemCost: number;
+  coinCost: number;
+  abilityCooldown: number; // seconds; 0 = no ability
+}
+
+const MOUNT_STATS: Record<string, MountStats> = {
+  [MountType.Horse]:    { speedMult: 1.5, sprintMult: 2.0, maxStamina: 100, island: 1, gemCost: 0, coinCost: 3, abilityCooldown: 0 },
+  [MountType.Stag]:     { speedMult: 1.3, sprintMult: 1.8, maxStamina: 80,  island: 2, gemCost: 1, coinCost: 3, abilityCooldown: 0 },
+  [MountType.Griffin]:  { speedMult: 1.8, sprintMult: 2.5, maxStamina: 60,  island: 1, gemCost: 2, coinCost: 8, abilityCooldown: 10 },
+  [MountType.Warhorse]: { speedMult: 1.5, sprintMult: 2.0, maxStamina: 120, island: 3, gemCost: 2, coinCost: 8, abilityCooldown: 20 },
+  [MountType.Bear]:     { speedMult: 1.0, sprintMult: 1.5, maxStamina: 150, island: 4, gemCost: 3, coinCost: 11, abilityCooldown: 8 },
+  [MountType.Lizard]:   { speedMult: 1.3, sprintMult: 1.8, maxStamina: 70,  island: 4, gemCost: 3, coinCost: 10, abilityCooldown: 6 },
+  [MountType.Unicorn]:  { speedMult: 1.4, sprintMult: 2.0, maxStamina: 90,  island: 5, gemCost: 4, coinCost: 12, abilityCooldown: 15 },
+};
+
+const STAMINA_DEPLETE_RATE = 20;
+const STAMINA_RECHARGE_RATE = 10;
+const STAMINA_GRASS_BONUS = 5;
+const STAMINA_IDLE_BONUS = 3; // extra recharge when idle (no movement input)
+const MOUNT_SWITCH_COST = 3;
+
+// ─── Module State ────────────────────────────────────────────────
+const mountsUnlocked = new Set<MountType>();
+let mountAbilityCooldown = 0;
+let chargeTimer = 0; // warhorse charge duration
+
+// ─── Mount Fear ──────────────────────────────────────────────────
+const FEAR_RANGE = 8;
+const FEAR_DURATION_DEFAULT = 2;
+const FEAR_DURATION_WARHORSE = 1;
+const FEAR_COOLDOWN = 3; // seconds after panic before normal control
+const FEAR_SPEED_MULT = 2;
+
+let mountPanicTimer = 0;
+let mountPanicCooldown = 0;
+let panicDirection = 0; // -1 or 1, direction to flee
+
+/** Get stats for a mount type. */
+export function getMountStatsForType(type: MountType): MountStats | undefined {
+  return MOUNT_STATS[type];
+}
+
+/** Get all mount stats (for UI). */
+export function getAllMountStats(): Record<string, MountStats> {
+  return MOUNT_STATS;
+}
+
+/** Check if a mount type is unlocked. */
+export function isMountUnlocked(type: MountType): boolean {
+  return mountsUnlocked.has(type);
+}
+
+/** Unlock a mount type. */
+export function unlockMount(state: GameState, type: MountType): boolean {
+  if (mountsUnlocked.has(type)) return false;
+  const stats = MOUNT_STATS[type];
+  if (!stats) return false;
+
+  if (state.gems < stats.gemCost) return false;
+  state.gems -= stats.gemCost;
+  mountsUnlocked.add(type);
+  state.messages.push(`${type} mount unlocked! (${stats.gemCost} gems)`);
+  return true;
+}
+
+/** Give the monarch a mount. */
+export function createMount(state: GameState): void {
+  state.mountType = MountType.Horse;
+  state.stamina = state.maxStamina;
+  mountsUnlocked.add(MountType.Horse);
+}
+
+/**
+ * Switch mount at stable. Costs 3 coins.
+ */
+export function switchMount(state: GameState, newType: MountType): boolean {
+  if (newType === state.mountType) return false;
+  if (!mountsUnlocked.has(newType)) return false;
+
+  if (state.monarchCoins < MOUNT_SWITCH_COST) {
+    state.messages.push(`Need ${MOUNT_SWITCH_COST} coins to switch mounts`);
+    return false;
+  }
+
+  state.monarchCoins -= MOUNT_SWITCH_COST;
+
+  const stats = MOUNT_STATS[newType];
+  if (stats) {
+    state.mountType = newType;
+    state.maxStamina = stats.maxStamina;
+    state.stamina = stats.maxStamina;
+  }
+
+  mountAbilityCooldown = 0;
+  state.messages.push(`Switched to ${newType} mount!`);
+  return true;
+}
+
+/**
+ * Lose mount (monarch takes hit). Mount returns to stable.
+ */
+export function loseMount(state: GameState): void {
+  if (state.mountType === MountType.None) return;
+
+  state.messages.push('Your mount fled!');
+  state.mountType = MountType.None;
+  state.stamina = 0;
+  mountAbilityCooldown = 0;
+  chargeTimer = 0;
+}
+
+/**
+ * Update mount stamina each frame.
+ */
+export function updateMount(state: GameState, dt: number): void {
+  if (state.mountType === MountType.None) return;
+
+  // Update ability cooldown
+  if (mountAbilityCooldown > 0) {
+    mountAbilityCooldown = Math.max(0, mountAbilityCooldown - dt);
+  }
+
+  // Warhorse charge timer
+  if (chargeTimer > 0) {
+    chargeTimer = Math.max(0, chargeTimer - dt);
+  }
+
+  if (state.inputSprint && state.stamina > 0) {
+    state.stamina = Math.max(0, state.stamina - STAMINA_DEPLETE_RATE * dt);
+  } else {
+    let rechargeRate = STAMINA_RECHARGE_RATE;
+
+    // Grass bonus for any mount
+    const monarchPos = getPosition(state.world, state.monarch.eid);
+    if (monarchPos) {
+      const tileX = Math.floor(monarchPos.x);
+      const tile = state.tiles[GROUND_Y]?.[tileX];
+      if (tile === TileType.Grass || tile === TileType.Forest) {
+        rechargeRate += STAMINA_GRASS_BONUS;
+      }
+    }
+
+    // Idle bonus (not moving)
+    if (!state.inputLeft && !state.inputRight) {
+      rechargeRate += STAMINA_IDLE_BONUS;
+    }
+
+    state.stamina = Math.min(state.maxStamina, state.stamina + rechargeRate * dt);
+  }
+}
+
+/** Get effective movement speed based on mount type and stamina. */
+export function getMountSpeed(state: GameState): number {
+  if (state.mountType === MountType.None) {
+    return state.inputSprint ? MONARCH_SPRINT : MONARCH_SPEED;
+  }
+
+  const stats = MOUNT_STATS[state.mountType];
+  if (!stats) {
+    return state.inputSprint ? MONARCH_SPRINT : MONARCH_SPEED;
+  }
+
+  const canSprint = state.inputSprint && state.stamina > 0;
+  return canSprint
+    ? MONARCH_SPEED * stats.sprintMult
+    : MONARCH_SPEED * stats.speedMult;
+}
+
+/** Get current and max stamina values. */
+export function getStamina(state: GameState): { current: number; max: number } {
+  return { current: state.stamina, max: state.maxStamina };
+}
+
+/** Get mount ability cooldown. */
+export function getMountAbilityCooldown(): number {
+  return mountAbilityCooldown;
+}
+
+/** Check if stag mount is active (for deer attraction in animals.ts). */
+export function isStagMounted(state: GameState): boolean {
+  return state.mountType === MountType.Stag;
+}
+
+/** Check if warhorse charge is active (allies invincible). */
+export function isWarhorseChargeActive(): boolean {
+  return chargeTimer > 0;
+}
+
+/**
+ * Activate the current mount's ability.
+ * Called when player presses 'e'.
+ */
+export function activateMountAbility(state: GameState): boolean {
+  if (state.mountType === MountType.None) return false;
+
+  const stats = MOUNT_STATS[state.mountType];
+  if (!stats || stats.abilityCooldown === 0) return false;
+  if (mountAbilityCooldown > 0) return false;
+
+  mountAbilityCooldown = stats.abilityCooldown;
+
+  switch (state.mountType) {
+    case MountType.Griffin: {
+      // Wing flap knockback: push greed 5 tiles away
+      const monarchPos = getPosition(state.world, state.monarch.eid);
+      if (monarchPos) {
+        let knocked = 0;
+        for (const greed of state.greeds) {
+          const gPos = getPosition(state.world, greed.eid);
+          if (!gPos) continue;
+          if (distance(monarchPos.x, gPos.x) <= 5) {
+            // Push greed away (handled by greed system checking knockback flag)
+            knocked++;
+          }
+        }
+        state.messages.push(`Griffin flap knocked back ${knocked} greed!`);
+      }
+      return true;
+    }
+
+    case MountType.Warhorse: {
+      // Charge: 10s invincibility to nearby allies
+      chargeTimer = 10;
+      state.messages.push('Warhorse charge! Allies are invincible for 10 seconds!');
+      return true;
+    }
+
+    case MountType.Bear: {
+      // Pounce: instakill 1 nearest greed
+      const monarchPos = getPosition(state.world, state.monarch.eid);
+      if (monarchPos) {
+        let closest = -1;
+        let closestDist = 10; // max pounce range
+        for (let i = 0; i < state.greeds.length; i++) {
+          const gPos = getPosition(state.world, state.greeds[i].eid);
+          if (!gPos) continue;
+          const d = distance(monarchPos.x, gPos.x);
+          if (d < closestDist) {
+            closestDist = d;
+            closest = i;
+          }
+        }
+        if (closest >= 0) {
+          state.greeds[closest].hp = 0;
+          state.messages.push('Bear pounce! Greed destroyed!');
+        } else {
+          state.messages.push('No greed in range for bear pounce');
+          mountAbilityCooldown = 1; // short cooldown on miss
+        }
+      }
+      return true;
+    }
+
+    case MountType.Lizard: {
+      // Fire breath: damage greed in 3-tile cone
+      const monarchPos = getPosition(state.world, state.monarch.eid);
+      if (monarchPos) {
+        const facingDir = state.inputRight ? 1 : -1;
+        let hit = 0;
+        for (const greed of state.greeds) {
+          const gPos = getPosition(state.world, greed.eid);
+          if (!gPos) continue;
+          const dx = gPos.x - monarchPos.x;
+          if (Math.abs(dx) <= 3 && Math.sign(dx) === facingDir) {
+            greed.hp -= 3;
+            hit++;
+          }
+        }
+        state.messages.push(`Lizard fire breath hit ${hit} greed!`);
+      }
+      return true;
+    }
+
+    case MountType.Unicorn: {
+      // Grass eating: generate 3 coins
+      collectCoins(state, 3);
+      state.messages.push('Unicorn grazes. +3 coins!');
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Update mount abilities (cooldown timers handled in updateMount).
+ */
+export function updateMountAbility(state: GameState, dt: number): void {
+  // Stag attraction handled in animals.ts via isStagMounted check
+  // Warhorse charge timer handled in updateMount
+  // All other abilities are instant on activation
+
+  // Update panic timers
+  if (mountPanicTimer > 0) {
+    mountPanicTimer = Math.max(0, mountPanicTimer - dt);
+    if (mountPanicTimer <= 0) {
+      mountPanicCooldown = FEAR_COOLDOWN;
+    }
+  }
+  if (mountPanicCooldown > 0) {
+    mountPanicCooldown = Math.max(0, mountPanicCooldown - dt);
+  }
+}
+
+// ─── Mount Fear Exports ──────────────────────────────────────────
+
+/**
+ * Trigger mount panic from a breeder greed at the given position.
+ * Bear is immune (too brave). Griffin is immune (flies over).
+ */
+export function triggerMountPanic(state: GameState, breederX: number): void {
+  if (state.mountType === MountType.None) return;
+  if (state.mountType === MountType.Bear) return; // immune
+  if (state.mountType === MountType.Griffin) return; // immune
+
+  // Don't re-trigger if already panicking or in cooldown
+  if (mountPanicTimer > 0 || mountPanicCooldown > 0) return;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  if (distance(monarchPos.x, breederX) > FEAR_RANGE) return;
+
+  // Warhorse has reduced fear duration
+  mountPanicTimer = state.mountType === MountType.Warhorse
+    ? FEAR_DURATION_WARHORSE
+    : FEAR_DURATION_DEFAULT;
+
+  // Flee away from breeder
+  panicDirection = monarchPos.x > breederX ? 1 : -1;
+
+  state.messages.push('Your mount panics!');
+}
+
+/** Check if the mount is currently panicking. */
+export function isMountPanicking(): boolean {
+  return mountPanicTimer > 0;
+}
+
+/** Get the panic flee velocity (used by monarch movement). */
+export function getMountPanicVelocity(state: GameState): number {
+  if (mountPanicTimer <= 0) return 0;
+  const stats = MOUNT_STATS[state.mountType];
+  if (!stats) return 0;
+  return panicDirection * MONARCH_SPEED * stats.speedMult * FEAR_SPEED_MULT;
+}

--- a/kingdom/entities/pikeman.ts
+++ b/kingdom/entities/pikeman.ts
@@ -1,0 +1,224 @@
+/**
+ * Pikeman entity - recruited at pike vendor (TownCenterTier >= 5, Stone Fort).
+ * Day: fish at nearest water tile, earning 1 coin per fish every 8 seconds.
+ * Night: defend outermost wall with AoE pike thrust (1.5 tile range).
+ * Carries 0 coins (drops immediately).
+ */
+import { addEntity, getPosition, setPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  UnitRole,
+  AIState,
+  TimeOfDay,
+  TileType,
+  StructureType,
+  GROUND_Y,
+  VILLAGER_SPEED,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  clamp,
+  distance,
+} from '../types';
+import { collectCoins } from '../game/economy';
+
+const PIKE_THRUST_RANGE = 1.5;
+const PIKE_THRUST_COOLDOWN = 2.0;
+const FISH_INTERVAL = 8; // seconds between fish catches
+const FISH_REWARD = 1;
+const PIKEMAN_SPEED = VILLAGER_SPEED;
+
+// Per-pikeman fishing timer
+const fishTimers = new Map<number, number>();
+
+export function createPikeman(state: GameState, x: number): UnitData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  const unit: UnitData = {
+    eid,
+    role: UnitRole.Pikeman,
+    aiState: AIState.Idle,
+    targetX: x,
+    hp: 2,
+    maxHp: 2,
+    attackCooldown: 0,
+    coins: 0,
+  };
+
+  state.units.push(unit);
+  return unit;
+}
+
+export function updatePikeman(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  if (unit.attackCooldown > 0) {
+    unit.attackCooldown = Math.max(0, unit.attackCooldown - dt);
+  }
+
+  // Pikeman always drops coins immediately
+  unit.coins = 0;
+
+  switch (state.timeOfDay) {
+    case TimeOfDay.Dawn:
+    case TimeOfDay.Day:
+      updatePikemanDay(state, unit, pos, dt);
+      break;
+    case TimeOfDay.Dusk:
+      updatePikemanDusk(state, unit, pos);
+      break;
+    case TimeOfDay.Night:
+      updatePikemanNight(state, unit, pos, dt);
+      break;
+  }
+}
+
+function updatePikemanDay(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  // Find nearest water tile for fishing
+  const waterX = findNearestWaterTile(state, pos.x);
+  if (waterX === undefined) {
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dist = distance(pos.x, waterX);
+
+  if (dist < 2.0) {
+    // At the fishing spot
+    unit.aiState = AIState.Working;
+    setVelocity(state.world, unit.eid, 0, 0);
+
+    const timer = (fishTimers.get(unit.eid) ?? 0) + dt;
+    if (timer >= FISH_INTERVAL) {
+      collectCoins(state, FISH_REWARD);
+      fishTimers.set(unit.eid, timer - FISH_INTERVAL);
+      state.messages.push(`Pikeman caught a fish (+${FISH_REWARD} coin)`);
+    } else {
+      fishTimers.set(unit.eid, timer);
+    }
+  } else {
+    // Walk to water
+    unit.aiState = AIState.MovingTo;
+    unit.targetX = waterX;
+    const dir = waterX > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * PIKEMAN_SPEED, 0);
+  }
+}
+
+function updatePikemanDusk(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+): void {
+  unit.aiState = AIState.Retreating;
+  fishTimers.delete(unit.eid);
+
+  const wallX = findOutermostWallOnSide(state, pos.x);
+  const dist = distance(pos.x, wallX);
+
+  if (dist < 1.0) {
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  const dir = wallX > pos.x ? 1 : -1;
+  setVelocity(state.world, unit.eid, dir * PIKEMAN_SPEED, 0);
+}
+
+function updatePikemanNight(
+  state: GameState,
+  unit: UnitData,
+  pos: { x: number; y: number },
+  dt: number,
+): void {
+  const wallX = findOutermostWallOnSide(state, pos.x);
+  const dist = distance(pos.x, wallX);
+
+  if (dist > 1.5) {
+    unit.aiState = AIState.MovingTo;
+    const dir = wallX > pos.x ? 1 : -1;
+    setVelocity(state.world, unit.eid, dir * PIKEMAN_SPEED, 0);
+    return;
+  }
+
+  // At wall: defend with pike thrust
+  unit.aiState = AIState.Defending;
+  setVelocity(state.world, unit.eid, 0, 0);
+
+  if (unit.attackCooldown > 0) return;
+
+  // Pike thrust: kill all greed within PIKE_THRUST_RANGE (AoE melee)
+  let killed = false;
+  for (let i = state.greeds.length - 1; i >= 0; i--) {
+    const greed = state.greeds[i];
+    const greedPos = getPosition(state.world, greed.eid);
+    if (!greedPos) continue;
+
+    if (distance(pos.x, greedPos.x) <= PIKE_THRUST_RANGE) {
+      greed.hp = 0;
+      killed = true;
+    }
+  }
+
+  if (killed) {
+    unit.attackCooldown = PIKE_THRUST_COOLDOWN;
+    state.messages.push('Pikeman thrusts pike!');
+  }
+}
+
+function findNearestWaterTile(state: GameState, fromX: number): number | undefined {
+  let nearest: number | undefined;
+  let nearestDist = Infinity;
+
+  // Scan tiles row at water level and ground level for Water type
+  const yChecks = [GROUND_Y, GROUND_Y + 1, GROUND_Y + 2];
+  for (const y of yChecks) {
+    if (y < 0 || y >= state.tiles.length) continue;
+    const row = state.tiles[y];
+    if (!row) continue;
+    for (let x = 0; x < row.length; x++) {
+      if (row[x] === TileType.Water) {
+        const d = distance(fromX, x);
+        if (d < nearestDist) {
+          nearestDist = d;
+          nearest = x;
+        }
+      }
+    }
+  }
+
+  return nearest;
+}
+
+function findOutermostWallOnSide(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  let outermostX = CAMP_CENTER_X;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== onRightSide) continue;
+
+    if (onRightSide) {
+      if (struct.x > outermostX) outermostX = struct.x;
+    } else {
+      if (struct.x < outermostX) outermostX = struct.x;
+    }
+  }
+
+  return outermostX;
+}

--- a/kingdom/entities/statue.ts
+++ b/kingdom/entities/statue.ts
@@ -1,0 +1,184 @@
+/**
+ * Statue blessing system - 4 statues on specific islands.
+ * Each can be unlocked with gems (one-time), then activated with coins (repeatable).
+ * Only one blessing active at a time. Blessings have timed durations.
+ *
+ * - Archer Statue (Island 1): perfect accuracy for 1 day
+ * - Farmer Statue (Island 2): +2 farmers/farm, 50% more output for 2 days
+ * - Builder Statue (Island 3): +50% wall HP for 2 days
+ * - Knight Statue (Island 5): jump-slash (2x damage) for 1 day
+ */
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  distance,
+} from '../types';
+
+// ─── Blessing Types ──────────────────────────────────────────────
+export enum BlessingType {
+  Archer = 'archer',
+  Farmer = 'farmer',
+  Builder = 'builder',
+  Knight = 'knight',
+}
+
+export interface StatueData {
+  type: BlessingType;
+  islandIndex: number;
+  x: number;
+  unlocked: boolean;
+  blessingActive: boolean;
+  blessingTimer: number; // seconds remaining
+}
+
+// ─── Statue Config ───────────────────────────────────────────────
+interface StatueConfig {
+  type: BlessingType;
+  island: number;
+  gemCost: number;
+  coinCost: number;
+  x: number;
+  durationDays: number;
+  description: string;
+}
+
+const DAY_LENGTH = 180; // match types.ts DAY_LENGTH
+
+const STATUE_CONFIGS: StatueConfig[] = [
+  { type: BlessingType.Archer, island: 1, gemCost: 4, coinCost: 10, x: 300, durationDays: 1, description: 'Archer precision' },
+  { type: BlessingType.Farmer, island: 2, gemCost: 1, coinCost: 7, x: 350, durationDays: 2, description: 'Farm prosperity' },
+  { type: BlessingType.Builder, island: 3, gemCost: 3, coinCost: 9, x: 280, durationDays: 2, description: 'Fortification' },
+  { type: BlessingType.Knight, island: 5, gemCost: 2, coinCost: 9, x: 320, durationDays: 1, description: 'Knight fury' },
+];
+
+const STATUE_INTERACT_RANGE = 3;
+
+// ─── Module State ────────────────────────────────────────────────
+const statues: StatueData[] = [];
+let activeBlessingType: BlessingType | null = null;
+
+/** Initialize statues for the current island. */
+export function createStatues(state: GameState): void {
+  statues.length = 0;
+  activeBlessingType = null;
+
+  for (const config of STATUE_CONFIGS) {
+    if (config.island === state.islandIndex) {
+      statues.push({
+        type: config.type,
+        islandIndex: config.island,
+        x: config.x,
+        unlocked: false,
+        blessingActive: false,
+        blessingTimer: 0,
+      });
+    }
+  }
+}
+
+/** Get all statues (read-only). */
+export function getStatues(): readonly StatueData[] {
+  return statues;
+}
+
+/** Get config for a statue type. */
+export function getStatueConfig(type: BlessingType): StatueConfig | undefined {
+  return STATUE_CONFIGS.find(c => c.type === type);
+}
+
+/**
+ * Unlock a statue with gems (one-time).
+ */
+export function unlockStatue(state: GameState, statueIndex: number): boolean {
+  if (statueIndex < 0 || statueIndex >= statues.length) return false;
+  const statue = statues[statueIndex];
+  if (statue.unlocked) return false;
+
+  const config = getStatueConfig(statue.type);
+  if (!config) return false;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return false;
+  if (distance(monarchPos.x, statue.x) > STATUE_INTERACT_RANGE) return false;
+
+  if (state.gems < config.gemCost) return false;
+
+  state.gems -= config.gemCost;
+  statue.unlocked = true;
+  state.messages.push(`${config.description} statue unlocked! (${config.gemCost} gems)`);
+  return true;
+}
+
+/**
+ * Activate a statue's blessing with coins (repeatable).
+ * Replaces any active blessing.
+ */
+export function activateStatue(state: GameState, statueIndex: number): boolean {
+  if (statueIndex < 0 || statueIndex >= statues.length) return false;
+  const statue = statues[statueIndex];
+  if (!statue.unlocked) return false;
+
+  const config = getStatueConfig(statue.type);
+  if (!config) return false;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return false;
+  if (distance(monarchPos.x, statue.x) > STATUE_INTERACT_RANGE) return false;
+
+  if (state.monarchCoins < config.coinCost) return false;
+
+  // Deactivate any existing blessing
+  for (const s of statues) {
+    if (s.blessingActive) {
+      s.blessingActive = false;
+      s.blessingTimer = 0;
+    }
+  }
+
+  state.monarchCoins -= config.coinCost;
+  statue.blessingActive = true;
+  statue.blessingTimer = config.durationDays * DAY_LENGTH;
+  activeBlessingType = statue.type;
+
+  state.messages.push(`${config.description} blessing activated! (${config.coinCost} coins)`);
+  return true;
+}
+
+/** Update blessing timers. */
+export function updateStatueBlessings(dt: number): void {
+  for (const statue of statues) {
+    if (!statue.blessingActive) continue;
+
+    statue.blessingTimer -= dt;
+    if (statue.blessingTimer <= 0) {
+      statue.blessingActive = false;
+      statue.blessingTimer = 0;
+      if (activeBlessingType === statue.type) {
+        activeBlessingType = null;
+      }
+    }
+  }
+}
+
+/** Check if a specific blessing type is currently active. */
+export function isBlessed(type: BlessingType): boolean {
+  return activeBlessingType === type;
+}
+
+/** Get the current active blessing type, or null. */
+export function getBlessingType(): BlessingType | null {
+  return activeBlessingType;
+}
+
+/** Find a statue near the monarch. Returns index or -1. */
+export function findNearbyStatue(state: GameState): number {
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return -1;
+
+  for (let i = 0; i < statues.length; i++) {
+    if (distance(monarchPos.x, statues[i].x) <= STATUE_INTERACT_RANGE) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/kingdom/entities/villager.ts
+++ b/kingdom/entities/villager.ts
@@ -1,0 +1,376 @@
+/**
+ * Vagrant / villager entity with NPC subtypes.
+ *
+ * NPC Types and their spawn locations:
+ * - Standard vagrant: near camp, becomes any role via tool stands
+ * - Warrior (red): outer settlements, becomes knight directly (3 coins)
+ * - Scout (green): near forests, becomes archer with +3 range (2 coins)
+ * - Craftsman (blue): central settlements, becomes builder 1.5x faster (2 coins)
+ * - Peasant (yellow): everywhere, becomes farmer +50% output (1 coin)
+ */
+import { addEntity, setPosition, getPosition, setVelocity } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  UnitRole,
+  AIState,
+  StructureType,
+  GROUND_Y,
+  VILLAGER_SPEED,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  clamp,
+  distance,
+} from '../types';
+
+// ─── NPC Origin System ──────────────────────────────────────────────
+
+export enum NpcOrigin {
+  Standard = 'standard',
+  Warrior = 'warrior',
+  Scout = 'scout',
+  Craftsman = 'craftsman',
+  Peasant = 'peasant',
+}
+
+// Track NPC origin per entity (while still a vagrant)
+const npcOrigins = new Map<number, NpcOrigin>();
+
+// Track recruited bonuses (persists after recruitment for archer/builder/farmer bonuses)
+const recruitBonuses = new Map<number, NpcOrigin>();
+
+export function getNpcOrigin(eid: number): NpcOrigin {
+  return npcOrigins.get(eid) ?? NpcOrigin.Standard;
+}
+
+/** Get the bonus origin for a recruited unit (for archer/builder/farmer bonuses). */
+export function getRecruitBonus(eid: number): NpcOrigin {
+  return recruitBonuses.get(eid) ?? NpcOrigin.Standard;
+}
+
+/** Called when a unit is recruited: transfers origin to bonus map. */
+export function markRecruited(eid: number): void {
+  const origin = npcOrigins.get(eid);
+  if (origin && origin !== NpcOrigin.Standard) {
+    recruitBonuses.set(eid, origin);
+  }
+  npcOrigins.delete(eid);
+}
+
+// ─── Vagrant Camp System ──────────────────────────────────────────
+
+export interface VagrantCamp {
+  x: number;
+  vagrantsAlive: number;
+  spawnTimer: number;
+}
+
+const CAMP_SPAWN_INTERVAL = 120; // 2 minutes per vagrant per camp
+const MAX_VAGRANTS_PER_CAMP = 3;
+const MAX_TOTAL_VAGRANTS = 15;
+const VAGRANT_CAMP_WANDER_RADIUS = 10;
+const GREED_CROUCH_RANGE = 10;
+const CROUCH_RECOVERY_TIME = 3; // seconds after greed passes
+
+// Fixed camp positions in forest areas (per island, same for all)
+const CAMP_POSITIONS = [45, 190, 540, 880, 1150];
+
+const vagrantCamps: VagrantCamp[] = [];
+let campsInitialized = false;
+
+// Track crouch state per vagrant
+const crouchTimers = new Map<number, number>(); // eid -> recovery timer
+
+function initializeCamps(): void {
+  if (campsInitialized) return;
+  campsInitialized = true;
+  vagrantCamps.length = 0;
+  for (const x of CAMP_POSITIONS) {
+    vagrantCamps.push({ x, vagrantsAlive: 0, spawnTimer: 0 });
+  }
+}
+
+/** Get vagrant camps (read-only). */
+export function getVagrantCamps(): readonly VagrantCamp[] {
+  initializeCamps();
+  return vagrantCamps;
+}
+
+/** Update camp-based vagrant spawning. */
+export function updateVagrantSpawning(state: GameState, dt: number): void {
+  initializeCamps();
+
+  const totalVagrants = countVagrants(state);
+  if (totalVagrants >= MAX_TOTAL_VAGRANTS) return;
+
+  for (const camp of vagrantCamps) {
+    if (camp.vagrantsAlive >= MAX_VAGRANTS_PER_CAMP) continue;
+
+    camp.spawnTimer += dt;
+    if (camp.spawnTimer >= CAMP_SPAWN_INTERVAL) {
+      camp.spawnTimer -= CAMP_SPAWN_INTERVAL;
+      if (totalVagrants + camp.vagrantsAlive < MAX_TOTAL_VAGRANTS) {
+        const offset = (Math.random() - 0.5) * 6;
+        spawnVagrant(state, camp.x + offset, NpcOrigin.Standard);
+        camp.vagrantsAlive++;
+      }
+    }
+  }
+}
+
+/** Check if a vagrant should crouch (greed nearby). Returns true if crouching. */
+export function isVagrantCrouching(eid: number): boolean {
+  return crouchTimers.has(eid);
+}
+
+// ─── Spawn Configuration ────────────────────────────────────────────
+
+const MAX_VAGRANTS = 8;
+const VAGRANT_SPAWN_INTERVAL = 45;
+const VAGRANT_WALK_SPEED = 2;
+const CAMPFIRE_WANDER_RADIUS = 6;
+
+// Settlement zones
+const OUTER_LEFT_SETTLEMENT = 40;
+const OUTER_RIGHT_SETTLEMENT = MAP_WIDTH - 40;
+const FOREST_LEFT_ZONE = 70;
+const FOREST_RIGHT_ZONE = MAP_WIDTH - 70;
+const CENTRAL_LEFT_SETTLEMENT = CAMP_CENTER_X - 30;
+const CENTRAL_RIGHT_SETTLEMENT = CAMP_CENTER_X + 30;
+
+let vagrantSpawnTimer = 0;
+
+// Spawn rotation: cycle through NPC types
+const SPAWN_ROTATION: NpcOrigin[] = [
+  NpcOrigin.Standard,
+  NpcOrigin.Peasant,
+  NpcOrigin.Standard,
+  NpcOrigin.Scout,
+  NpcOrigin.Standard,
+  NpcOrigin.Craftsman,
+  NpcOrigin.Standard,
+  NpcOrigin.Warrior,
+];
+let spawnRotationIndex = 0;
+
+export function spawnVagrant(
+  state: GameState,
+  x: number,
+  origin: NpcOrigin = NpcOrigin.Standard,
+): UnitData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y - 1);
+  setVelocity(state.world, eid, 0, 0);
+
+  if (origin !== NpcOrigin.Standard) {
+    npcOrigins.set(eid, origin);
+  }
+
+  const unit: UnitData = {
+    eid,
+    role: UnitRole.Vagrant,
+    aiState: AIState.MovingTo,
+    targetX: getTargetForOrigin(origin, x),
+    hp: 1,
+    maxHp: 1,
+    attackCooldown: 0,
+    coins: 0,
+  };
+
+  state.units.push(unit);
+  return unit;
+}
+
+function getTargetForOrigin(origin: NpcOrigin, spawnX: number): number {
+  const onLeft = spawnX < CAMP_CENTER_X;
+  switch (origin) {
+    case NpcOrigin.Warrior:
+      return onLeft ? OUTER_LEFT_SETTLEMENT : OUTER_RIGHT_SETTLEMENT;
+    case NpcOrigin.Scout:
+      return onLeft ? FOREST_LEFT_ZONE : FOREST_RIGHT_ZONE;
+    case NpcOrigin.Craftsman:
+      return onLeft ? CENTRAL_LEFT_SETTLEMENT : CENTRAL_RIGHT_SETTLEMENT;
+    case NpcOrigin.Peasant:
+    case NpcOrigin.Standard:
+    default:
+      return CAMP_CENTER_X;
+  }
+}
+
+function getSpawnX(origin: NpcOrigin): number {
+  switch (origin) {
+    case NpcOrigin.Warrior: {
+      const fromLeft = Math.random() < 0.5;
+      return fromLeft
+        ? 5 + Math.random() * 10
+        : MAP_WIDTH - 15 + Math.random() * 10;
+    }
+    case NpcOrigin.Scout: {
+      const fromLeft = Math.random() < 0.5;
+      return fromLeft
+        ? 50 + Math.random() * 20
+        : MAP_WIDTH - 70 + Math.random() * 20;
+    }
+    case NpcOrigin.Craftsman:
+      return CAMP_CENTER_X + (Math.random() - 0.5) * 40;
+    case NpcOrigin.Peasant: {
+      const fromLeft = Math.random() < 0.5;
+      return fromLeft
+        ? 20 + Math.random() * 30
+        : MAP_WIDTH - 50 + Math.random() * 30;
+    }
+    default: {
+      const fromLeft = Math.random() < 0.5;
+      return fromLeft
+        ? 5 + Math.random() * 20
+        : MAP_WIDTH - 25 + Math.random() * 20;
+    }
+  }
+}
+
+/** Tick the vagrant spawn timer. Spawns new vagrants from various locations. */
+export function tickVagrantSpawns(state: GameState, dt: number): void {
+  vagrantSpawnTimer += dt;
+  if (vagrantSpawnTimer < VAGRANT_SPAWN_INTERVAL) return;
+  vagrantSpawnTimer -= VAGRANT_SPAWN_INTERVAL;
+
+  const vagrantCount = countVagrants(state);
+  if (vagrantCount >= MAX_VAGRANTS) return;
+
+  const origin = SPAWN_ROTATION[spawnRotationIndex % SPAWN_ROTATION.length];
+  spawnRotationIndex++;
+
+  const x = getSpawnX(origin);
+  spawnVagrant(state, x, origin);
+
+  const label = origin === NpcOrigin.Standard ? 'vagrant' : origin;
+  state.messages.push(`A ${label} wanders in from the wilderness`);
+}
+
+export function updateVagrant(state: GameState, unit: UnitData, dt: number): void {
+  const pos = getPosition(state.world, unit.eid);
+  if (!pos) return;
+
+  // Check for nearby greed: crouch and freeze
+  const nearGreed = hasGreedNearby(state, pos.x, GREED_CROUCH_RANGE);
+  if (nearGreed) {
+    crouchTimers.set(unit.eid, CROUCH_RECOVERY_TIME);
+    unit.aiState = AIState.Idle;
+    setVelocity(state.world, unit.eid, 0, 0);
+    return;
+  }
+
+  // Crouch recovery timer
+  const crouchTimer = crouchTimers.get(unit.eid);
+  if (crouchTimer !== undefined) {
+    const remaining = crouchTimer - dt;
+    if (remaining > 0) {
+      crouchTimers.set(unit.eid, remaining);
+      setVelocity(state.world, unit.eid, 0, 0);
+      return;
+    }
+    crouchTimers.delete(unit.eid);
+  }
+
+  const origin = getNpcOrigin(unit.eid);
+  const homeX = getWanderTarget(state, origin, pos.x);
+  const wanderRadius = origin === NpcOrigin.Standard ? CAMPFIRE_WANDER_RADIUS : 8;
+  const nearHome = distance(pos.x, homeX) < wanderRadius;
+
+  if (unit.aiState === AIState.Idle) {
+    if (nearHome) {
+      if (Math.random() < 0.015) {
+        unit.aiState = AIState.MovingTo;
+        const offset = (Math.random() - 0.5) * 2 * wanderRadius;
+        unit.targetX = clamp(homeX + offset, 0, MAP_WIDTH - 1);
+      }
+      setVelocity(state.world, unit.eid, 0, 0);
+    } else {
+      unit.aiState = AIState.MovingTo;
+      unit.targetX = homeX;
+    }
+    return;
+  }
+
+  if (unit.aiState === AIState.MovingTo) {
+    const dx = unit.targetX - pos.x;
+    const absDx = Math.abs(dx);
+
+    if (absDx < 0.5) {
+      unit.aiState = AIState.Idle;
+      setVelocity(state.world, unit.eid, 0, 0);
+      return;
+    }
+
+    const speed = nearHome ? VILLAGER_SPEED : VAGRANT_WALK_SPEED;
+    const dir = dx > 0 ? 1 : -1;
+    const vx = dir * speed;
+    setVelocity(state.world, unit.eid, vx, 0);
+  }
+}
+
+function hasGreedNearby(state: GameState, x: number, range: number): boolean {
+  for (const greed of state.greeds) {
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (distance(x, pos.x) <= range) return true;
+  }
+  return false;
+}
+
+function getWanderTarget(state: GameState, origin: NpcOrigin, currentX: number): number {
+  switch (origin) {
+    case NpcOrigin.Warrior:
+      return currentX < CAMP_CENTER_X ? OUTER_LEFT_SETTLEMENT : OUTER_RIGHT_SETTLEMENT;
+    case NpcOrigin.Scout:
+      return currentX < CAMP_CENTER_X ? FOREST_LEFT_ZONE : FOREST_RIGHT_ZONE;
+    case NpcOrigin.Craftsman:
+      return currentX < CAMP_CENTER_X ? CENTRAL_LEFT_SETTLEMENT : CENTRAL_RIGHT_SETTLEMENT;
+    case NpcOrigin.Peasant:
+    case NpcOrigin.Standard:
+    default:
+      return findCampfireX(state);
+  }
+}
+
+export function recruitVagrant(state: GameState, unit: UnitData, newRole: UnitRole): void {
+  markRecruited(unit.eid);
+  unit.role = newRole;
+  unit.aiState = AIState.Idle;
+
+  switch (newRole) {
+    case UnitRole.Builder:
+      unit.hp = 3;
+      unit.maxHp = 3;
+      break;
+    case UnitRole.Archer:
+      unit.hp = 2;
+      unit.maxHp = 2;
+      break;
+    case UnitRole.Farmer:
+      unit.hp = 2;
+      unit.maxHp = 2;
+      break;
+    case UnitRole.Knight:
+      unit.hp = 5;
+      unit.maxHp = 5;
+      break;
+    default:
+      break;
+  }
+}
+
+function countVagrants(state: GameState): number {
+  let count = 0;
+  for (const unit of state.units) {
+    if (unit.role === UnitRole.Vagrant) count++;
+  }
+  return count;
+}
+
+function findCampfireX(state: GameState): number {
+  for (const [, struct] of state.structures) {
+    if (struct.type === StructureType.Campfire) return struct.x;
+  }
+  return CAMP_CENTER_X;
+}

--- a/kingdom/game/dayNight.ts
+++ b/kingdom/game/dayNight.ts
@@ -1,0 +1,42 @@
+/**
+ * Kingdom - Day/night cycle
+ * Advances day time and computes the current time of day phase.
+ */
+
+import {
+  type GameState,
+  TimeOfDay,
+  DAY_LENGTH,
+  DAWN_START,
+  DAY_START,
+  DUSK_START,
+  NIGHT_START,
+} from '../types';
+
+/**
+ * Advance the day/night cycle by dt seconds.
+ * Wraps dayTime at 1.0 and increments dayCount.
+ * Sets state.timeOfDay based on threshold constants.
+ */
+export function updateDayNight(state: GameState, dt: number): void {
+  state.dayTime += dt / DAY_LENGTH;
+
+  // Wrap day cycle
+  while (state.dayTime >= 1.0) {
+    state.dayTime -= 1.0;
+    state.dayCount++;
+  }
+
+  // Determine time of day from thresholds
+  if (state.dayTime >= NIGHT_START) {
+    state.timeOfDay = TimeOfDay.Night;
+  } else if (state.dayTime >= DUSK_START) {
+    state.timeOfDay = TimeOfDay.Dusk;
+  } else if (state.dayTime >= DAY_START) {
+    state.timeOfDay = TimeOfDay.Day;
+  } else if (state.dayTime >= DAWN_START) {
+    state.timeOfDay = TimeOfDay.Dawn;
+  } else {
+    state.timeOfDay = TimeOfDay.Night;
+  }
+}

--- a/kingdom/game/economy.ts
+++ b/kingdom/game/economy.ts
@@ -1,0 +1,917 @@
+/**
+ * Economy system - coin dropping, recruiting, purchasing.
+ * Handles proximity-based interactions with structures and NPCs.
+ * Supports NPC subtypes (warrior, scout, craftsman, peasant) and
+ * standard vagrant recruiting via tool stands.
+ */
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  type UnitData,
+  type StructureData,
+  UnitRole,
+  AIState,
+  StructureType,
+  TownCenterTier,
+  MAX_COINS,
+  RECRUIT_COST,
+  BOW_COST,
+  HAMMER_COST,
+  WALL_COST_WOOD,
+  WALL_COST_STONE,
+  WALL_COST_IRON,
+  FARM_BUILD_COST,
+  SHRINE_COST,
+  WALL_HP_WOOD,
+  WALL_HP_STONE,
+  WALL_HP_IRON,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  distance,
+} from '../types';
+import { getNpcOrigin, NpcOrigin, markRecruited } from '../entities/villager';
+import { isBankerAvailable, depositCoins, withdrawCoins } from '../entities/banker';
+import { isMerchantAvailable, merchantAcceptCoin, getMerchantX } from '../entities/merchant';
+import { getAvailableHermits, getHermitConfig, getRidingHermit } from '../entities/hermit';
+import { getStatues, getStatueConfig, findNearbyStatue } from '../entities/statue';
+import { isMountUnlocked, getMountStatsForType } from '../entities/mount';
+import { MountType } from '../types';
+
+// ─── Unit Caps ──────────────────────────────────────────────────────
+const MAX_ARCHERS = 10;
+const MAX_BUILDERS = 8;
+const MAX_FARMERS = 6;
+const MAX_KNIGHTS = 4;
+const MAX_PIKEMEN = 6;
+const MAX_SQUIRES = 4;
+export const KNIGHT_COST = 5;
+export const KNIGHT_UNLOCK_DAY = 5;
+export const PIKE_COST = 2;
+export const SQUIRE_COST = 4;
+const FARM_UNLOCK_DAY = 3;
+
+// ─── Unit Coin Capacities ────────────────────────────────────────
+const UNIT_COIN_CAPACITY: Record<string, number> = {
+  [UnitRole.Vagrant]: 0,
+  [UnitRole.Builder]: 2,
+  [UnitRole.Archer]: 11,
+  [UnitRole.Farmer]: 14,
+  [UnitRole.Knight]: 11,
+  [UnitRole.Squire]: 5,
+  [UnitRole.Pikeman]: 0,
+  [UnitRole.Monarch]: 40,
+};
+
+/** Get the max coin capacity for a given role. */
+export function getUnitCoinCapacity(role: UnitRole): number {
+  return UNIT_COIN_CAPACITY[role] ?? 0;
+}
+
+/** Enforce coin capacity on a unit. Returns overflow coins (dropped on ground). */
+export function enforceUnitCoinCap(unit: UnitData): number {
+  const cap = getUnitCoinCapacity(unit.role);
+  if (unit.coins <= cap) return 0;
+  const overflow = unit.coins - cap;
+  unit.coins = cap;
+  return overflow;
+}
+
+// ─── NPC Direct Recruit Costs ──────────────────────────────────────
+const WARRIOR_RECRUIT_COST = 3;
+const SCOUT_RECRUIT_COST = 2;
+const CRAFTSMAN_RECRUIT_COST = 2;
+const PEASANT_RECRUIT_COST = 1;
+
+// ─── Inflation Tracking ─────────────────────────────────────────────
+let wallsBuiltLeft = 0;
+let wallsBuiltRight = 0;
+let shrineUses = 0;
+
+// ─── Nearby Interactable (for HUD) ─────────────────────────────────
+let nearbyInteractableDesc: string | null = null;
+
+/** HUD can call this to display what the player can interact with. */
+export function getNearbyInteractable(): string | null {
+  return nearbyInteractableDesc;
+}
+
+export function canAfford(state: GameState, cost: number): boolean {
+  return state.monarchCoins >= cost;
+}
+
+export function collectCoins(state: GameState, amount: number): void {
+  state.monarchCoins = Math.min(state.monarchCoins + amount, MAX_COINS);
+}
+
+export function resetInflation(): void {
+  wallsBuiltLeft = 0;
+  wallsBuiltRight = 0;
+  shrineUses = 0;
+}
+
+function countUnitsByRole(state: GameState, role: UnitRole): number {
+  let count = 0;
+  for (const unit of state.units) {
+    if (unit.role === role) count++;
+  }
+  return count;
+}
+
+function getUnitCap(role: UnitRole): number {
+  switch (role) {
+    case UnitRole.Archer: return MAX_ARCHERS;
+    case UnitRole.Builder: return MAX_BUILDERS;
+    case UnitRole.Farmer: return MAX_FARMERS;
+    case UnitRole.Knight: return MAX_KNIGHTS;
+    case UnitRole.Pikeman: return MAX_PIKEMEN;
+    case UnitRole.Squire: return MAX_SQUIRES;
+    default: return Infinity;
+  }
+}
+
+function scaledCost(baseCost: number, state: GameState, role: UnitRole): number {
+  const existing = countUnitsByRole(state, role);
+  return baseCost + existing;
+}
+
+function isAtCap(state: GameState, role: UnitRole): boolean {
+  return countUnitsByRole(state, role) >= getUnitCap(role);
+}
+
+function inflatedWallCost(x: number): number {
+  const onRight = x >= CAMP_CENTER_X;
+  const builtOnSide = onRight ? wallsBuiltRight : wallsBuiltLeft;
+  return WALL_COST_WOOD + builtOnSide;
+}
+
+function inflatedShrineCost(): number {
+  return SHRINE_COST + shrineUses * 2;
+}
+
+// ─── Nearby Interactable Update ─────────────────────────────────────
+
+/** Called each frame to update the nearby interactable description. */
+export function updateNearbyInteractable(state: GameState): void {
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) {
+    nearbyInteractableDesc = null;
+    return;
+  }
+
+  const mx = monarchPos.x;
+  const range = 3;
+
+  // Check for banker (near town center)
+  if (isBankerAvailable(state) && distance(mx, CAMP_CENTER_X) <= range) {
+    nearbyInteractableDesc = '[SPACE] Deposit coins with Banker';
+    return;
+  }
+
+  // Check for merchant
+  if (isMerchantAvailable(state) && distance(mx, getMerchantX()) <= range) {
+    nearbyInteractableDesc = '[SPACE] Pay merchant (1 coin -> 8 coins at dawn)';
+    return;
+  }
+
+  // Check for hermit cottage
+  const hermits = getAvailableHermits();
+  for (let i = 0; i < hermits.length; i++) {
+    const hermit = hermits[i];
+    if (hermit.kidnapped || hermit.riding || hermit.coaxed) continue;
+    if (distance(mx, hermit.x) > range) continue;
+    const config = getHermitConfig(hermit.type);
+    if (!config) continue;
+    nearbyInteractableDesc = `[SPACE] Coax ${config.description} hermit (${config.gemCost} gems)`;
+    return;
+  }
+
+  // Check for riding hermit (can drop)
+  if (getRidingHermit() !== null) {
+    nearbyInteractableDesc = '[SPACE] Drop hermit at current location';
+    return;
+  }
+
+  // Check for nearby statue
+  const statueIdx = findNearbyStatue(state);
+  if (statueIdx >= 0) {
+    const statues = getStatues();
+    const statue = statues[statueIdx];
+    const config = getStatueConfig(statue.type);
+    if (config) {
+      if (!statue.unlocked) {
+        nearbyInteractableDesc = `[SPACE] Unlock ${config.description} statue (${config.gemCost} gems)`;
+        return;
+      }
+      if (!statue.blessingActive) {
+        nearbyInteractableDesc = `[SPACE] Activate ${config.description} blessing (${config.coinCost} coins)`;
+        return;
+      }
+    }
+  }
+
+  // Check for special NPCs
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Vagrant) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (distance(mx, pos.x) > range) continue;
+
+    const origin = getNpcOrigin(unit.eid);
+    switch (origin) {
+      case NpcOrigin.Warrior:
+        nearbyInteractableDesc = `[SPACE] Recruit Knight (${WARRIOR_RECRUIT_COST})`;
+        return;
+      case NpcOrigin.Scout:
+        nearbyInteractableDesc = `[SPACE] Recruit Archer +range (${SCOUT_RECRUIT_COST})`;
+        return;
+      case NpcOrigin.Craftsman:
+        nearbyInteractableDesc = `[SPACE] Recruit Builder +speed (${CRAFTSMAN_RECRUIT_COST})`;
+        return;
+      case NpcOrigin.Peasant:
+        nearbyInteractableDesc = `[SPACE] Recruit Farmer +yield (${PEASANT_RECRUIT_COST})`;
+        return;
+      default:
+        break;
+    }
+  }
+
+  // Check for standard vagrant near tool stand
+  const vagrant = findNearestStandardVagrant(state, mx, range);
+  if (vagrant) {
+    const bowStand = findNearestStructureByType(state, mx, StructureType.BowStand, range);
+    if (bowStand) {
+      const cost = scaledCost(BOW_COST, state, UnitRole.Archer);
+      nearbyInteractableDesc = `[SPACE] Recruit Archer (${cost})`;
+      return;
+    }
+    const hammerStand = findNearestStructureByType(state, mx, StructureType.HammerStand, range);
+    if (hammerStand) {
+      const cost = scaledCost(HAMMER_COST, state, UnitRole.Builder);
+      nearbyInteractableDesc = `[SPACE] Recruit Builder (${cost})`;
+      return;
+    }
+  }
+
+  // Check for wall nearby
+  const wall = findNearestWall(state, mx, range);
+  if (wall && wall.hp >= wall.maxHp) {
+    if (wall.type === StructureType.WallWood) {
+      nearbyInteractableDesc = `[SPACE] Upgrade to Stone (${WALL_COST_STONE})`;
+      return;
+    }
+    if (wall.type === StructureType.WallStone) {
+      nearbyInteractableDesc = `[SPACE] Upgrade to Iron (${WALL_COST_IRON})`;
+      return;
+    }
+  }
+
+  // Check for shrine
+  const shrine = findNearestStructureByType(state, mx, StructureType.Shrine, range);
+  if (shrine) {
+    const cost = inflatedShrineCost();
+    nearbyInteractableDesc = `[SPACE] Activate Shrine (${cost})`;
+    return;
+  }
+
+  // Open ground: wall blueprint
+  const roundedX = Math.round(mx);
+  if (!state.structures.has(roundedX)) {
+    const cost = inflatedWallCost(roundedX);
+    nearbyInteractableDesc = `[SPACE] Place wall (${cost})`;
+    return;
+  }
+
+  nearbyInteractableDesc = null;
+}
+
+// ─── Drop Coin (Main Interaction) ──────────────────────────────────
+
+export function dropCoin(state: GameState): void {
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+  if (state.monarchCoins <= 0) {
+    state.messages.push('No coins!');
+    return;
+  }
+
+  const mx = monarchPos.x;
+  const range = 3;
+
+  // ─── Priority 0a: Banker deposit (near town center) ───
+  if (isBankerAvailable(state) && distance(mx, CAMP_CENTER_X) <= range) {
+    depositCoins(state, 1);
+    return;
+  }
+
+  // ─── Priority 0b: Merchant payment (near merchant) ───
+  if (isMerchantAvailable(state) && distance(mx, getMerchantX()) <= range) {
+    merchantAcceptCoin(state);
+    return;
+  }
+
+  // ─── Priority 1: Recruit special NPC (warrior/scout/craftsman/peasant) ───
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Vagrant) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (distance(mx, pos.x) > range) continue;
+
+    const origin = getNpcOrigin(unit.eid);
+
+    if (origin === NpcOrigin.Warrior) {
+      if (isAtCap(state, UnitRole.Knight)) {
+        state.messages.push('No room for more knights!');
+        return;
+      }
+      if (!canAfford(state, WARRIOR_RECRUIT_COST)) {
+        state.messages.push(`Not enough coins! (need ${WARRIOR_RECRUIT_COST})`);
+        return;
+      }
+      state.monarchCoins -= WARRIOR_RECRUIT_COST;
+      recruitUnit(unit, UnitRole.Knight);
+      state.messages.push(`Recruited Knight! (${WARRIOR_RECRUIT_COST} coins)`);
+      return;
+    }
+
+    if (origin === NpcOrigin.Scout) {
+      if (isAtCap(state, UnitRole.Archer)) {
+        state.messages.push('No room for more archers!');
+        return;
+      }
+      if (!canAfford(state, SCOUT_RECRUIT_COST)) {
+        state.messages.push(`Not enough coins! (need ${SCOUT_RECRUIT_COST})`);
+        return;
+      }
+      state.monarchCoins -= SCOUT_RECRUIT_COST;
+      recruitUnit(unit, UnitRole.Archer);
+      state.messages.push(`Recruited Scout Archer! (${SCOUT_RECRUIT_COST} coins, +3 range)`);
+      return;
+    }
+
+    if (origin === NpcOrigin.Craftsman) {
+      if (isAtCap(state, UnitRole.Builder)) {
+        state.messages.push('No room for more builders!');
+        return;
+      }
+      if (!canAfford(state, CRAFTSMAN_RECRUIT_COST)) {
+        state.messages.push(`Not enough coins! (need ${CRAFTSMAN_RECRUIT_COST})`);
+        return;
+      }
+      state.monarchCoins -= CRAFTSMAN_RECRUIT_COST;
+      recruitUnit(unit, UnitRole.Builder);
+      state.messages.push(`Recruited Master Builder! (${CRAFTSMAN_RECRUIT_COST} coins, 1.5x speed)`);
+      return;
+    }
+
+    if (origin === NpcOrigin.Peasant) {
+      if (isAtCap(state, UnitRole.Farmer)) {
+        state.messages.push('No room for more farmers!');
+        return;
+      }
+      if (!canAfford(state, PEASANT_RECRUIT_COST)) {
+        state.messages.push(`Not enough coins! (need ${PEASANT_RECRUIT_COST})`);
+        return;
+      }
+      state.monarchCoins -= PEASANT_RECRUIT_COST;
+      recruitUnit(unit, UnitRole.Farmer);
+      state.messages.push(`Recruited Expert Farmer! (${PEASANT_RECRUIT_COST} coins, +50% output)`);
+      return;
+    }
+  }
+
+  // ─── Priority 2: Standard vagrant near tool stand ───
+  const vagrant = findNearestStandardVagrant(state, mx, range);
+  if (vagrant) {
+    const bowStand = findNearestStructureByType(state, mx, StructureType.BowStand, range);
+    if (bowStand) {
+      if (isAtCap(state, UnitRole.Archer)) {
+        state.messages.push('No room for more archers!');
+        return;
+      }
+      const cost = scaledCost(BOW_COST, state, UnitRole.Archer);
+      if (!canAfford(state, cost)) {
+        state.messages.push(`Not enough coins! (need ${cost})`);
+        return;
+      }
+      state.monarchCoins -= cost;
+      recruitUnit(vagrant, UnitRole.Archer);
+      state.messages.push(`Recruited Archer! (${cost} coins)`);
+      return;
+    }
+
+    const hammerStand = findNearestStructureByType(state, mx, StructureType.HammerStand, range);
+    if (hammerStand) {
+      if (isAtCap(state, UnitRole.Builder)) {
+        state.messages.push('No room for more builders!');
+        return;
+      }
+      const cost = scaledCost(HAMMER_COST, state, UnitRole.Builder);
+      if (!canAfford(state, cost)) {
+        state.messages.push(`Not enough coins! (need ${cost})`);
+        return;
+      }
+      state.monarchCoins -= cost;
+      recruitUnit(vagrant, UnitRole.Builder);
+      state.messages.push(`Recruited Builder! (${cost} coins)`);
+      return;
+    }
+
+    if (state.dayCount >= FARM_UNLOCK_DAY) {
+      const farm = findNearestFarmStructure(state, mx, range);
+      if (farm) {
+        if (isAtCap(state, UnitRole.Farmer)) {
+          state.messages.push('No room for more farmers!');
+          return;
+        }
+        const cost = scaledCost(RECRUIT_COST, state, UnitRole.Farmer);
+        if (!canAfford(state, cost)) {
+          state.messages.push(`Not enough coins! (need ${cost})`);
+          return;
+        }
+        state.monarchCoins -= cost;
+        recruitUnit(vagrant, UnitRole.Farmer);
+        state.messages.push(`Recruited Farmer! (${cost} coins)`);
+        return;
+      }
+    }
+
+    if (state.dayCount >= KNIGHT_UNLOCK_DAY) {
+      const shrineOrCamp = findNearestStructureByType(state, mx, StructureType.Shrine, range)
+        ?? findNearestStructureByType(state, mx, StructureType.Campfire, range);
+      if (shrineOrCamp) {
+        if (isAtCap(state, UnitRole.Knight)) {
+          state.messages.push('No room for more knights!');
+          return;
+        }
+        const cost = scaledCost(KNIGHT_COST, state, UnitRole.Knight);
+        if (!canAfford(state, cost)) {
+          state.messages.push(`Not enough coins! (need ${cost})`);
+          return;
+        }
+        state.monarchCoins -= cost;
+        recruitUnit(vagrant, UnitRole.Knight);
+        state.messages.push(`Recruited Knight! (${cost} coins)`);
+        return;
+      }
+    }
+
+    // Pikeman: requires TownCenterTier >= 5 (Stone Fort)
+    if (state.townCenterTier >= TownCenterTier.StoneFort) {
+      if (!isAtCap(state, UnitRole.Pikeman)) {
+        const cost = PIKE_COST;
+        if (canAfford(state, cost)) {
+          state.monarchCoins -= cost;
+          recruitUnit(vagrant, UnitRole.Pikeman);
+          state.messages.push(`Recruited Pikeman! (${cost} coins)`);
+          return;
+        }
+      }
+    }
+
+    // Squire: requires TownCenterTier >= 6 (Castle)
+    if (state.townCenterTier >= TownCenterTier.Castle) {
+      if (!isAtCap(state, UnitRole.Squire)) {
+        const cost = SQUIRE_COST;
+        if (canAfford(state, cost)) {
+          state.monarchCoins -= cost;
+          recruitUnit(vagrant, UnitRole.Squire);
+          state.messages.push(`Recruited Squire! (${cost} coins)`);
+          return;
+        }
+      }
+    }
+  }
+
+  // ─── Priority 3: Wall upgrade (only fully-built, upgradeable walls) ───
+  const wall = findNearestWall(state, mx, range);
+  if (wall && wall.hp >= wall.maxHp) {
+    if (tryUpgradeWall(state, wall)) return;
+  }
+
+  // ─── Priority 4: Shrine activation ───
+  const shrine = findNearestStructureByType(state, mx, StructureType.Shrine, range);
+  if (shrine) {
+    const cost = inflatedShrineCost();
+    if (canAfford(state, cost)) {
+      state.monarchCoins -= cost;
+      shrineUses++;
+      state.messages.push(`Shrine activated! (${cost} coins)`);
+      return;
+    }
+    state.messages.push(`Not enough coins for shrine! (need ${cost})`);
+    return;
+  }
+
+  // ─── Priority 5: Place wall blueprint on open ground ───
+  const roundedX = Math.round(mx);
+  if (!state.structures.has(roundedX)) {
+    const cost = inflatedWallCost(roundedX);
+    if (canAfford(state, cost)) {
+      state.monarchCoins -= cost;
+      const onRight = roundedX >= CAMP_CENTER_X;
+      if (onRight) wallsBuiltRight++; else wallsBuiltLeft++;
+
+      const wallData: StructureData = {
+        eid: 0 as any,
+        type: StructureType.WallWood,
+        x: roundedX,
+        hp: 0,
+        maxHp: WALL_HP_WOOD,
+        level: 1,
+        assignedWorkers: [],
+      };
+      state.structures.set(roundedX, wallData);
+      state.messages.push(`Wall blueprint placed! (${cost} coins)`);
+      return;
+    }
+    state.messages.push(`Not enough coins! (need ${cost})`);
+    return;
+  }
+
+  // ─── Priority 6: Build farm (day 3+) ───
+  if (state.dayCount >= FARM_UNLOCK_DAY) {
+    for (const offset of [0, -1, 1, -2, 2]) {
+      const farmX = Math.round(mx) + offset;
+      if (farmX < 0 || farmX >= MAP_WIDTH) continue;
+      if (state.structures.has(farmX)) continue;
+
+      if (canAfford(state, FARM_BUILD_COST)) {
+        state.monarchCoins -= FARM_BUILD_COST;
+        const farm: StructureData = {
+          eid: 0 as any,
+          type: StructureType.Farm,
+          x: farmX,
+          hp: 0,
+          maxHp: 5,
+          level: 1,
+          assignedWorkers: [],
+        };
+        state.structures.set(farmX, farm);
+        state.messages.push(`Farm plot placed! (${FARM_BUILD_COST} coins)`);
+        return;
+      }
+      state.messages.push(`Not enough coins! (need ${FARM_BUILD_COST})`);
+      return;
+    }
+  }
+
+  state.messages.push('Nothing nearby to interact with');
+}
+
+// ─── Auto-Builder Wall Blueprint ───────────────────────────────────
+
+/** Place a wall blueprint at given x (used by auto-builder AI). No coin cost. */
+export function placeWallBlueprint(state: GameState, x: number): boolean {
+  const roundedX = Math.round(x);
+  if (roundedX < 0 || roundedX >= MAP_WIDTH) return false;
+  if (state.structures.has(roundedX)) return false;
+
+  const wallData: StructureData = {
+    eid: 0 as any,
+    type: StructureType.WallWood,
+    x: roundedX,
+    hp: 0,
+    maxHp: WALL_HP_WOOD,
+    level: 1,
+    assignedWorkers: [],
+  };
+  state.structures.set(roundedX, wallData);
+  return true;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function recruitUnit(unit: UnitData, newRole: UnitRole): void {
+  markRecruited(unit.eid);
+  unit.role = newRole;
+  unit.aiState = AIState.Idle;
+
+  switch (newRole) {
+    case UnitRole.Builder:
+      unit.hp = 3;
+      unit.maxHp = 3;
+      break;
+    case UnitRole.Archer:
+      unit.hp = 2;
+      unit.maxHp = 2;
+      break;
+    case UnitRole.Farmer:
+      unit.hp = 2;
+      unit.maxHp = 2;
+      break;
+    case UnitRole.Knight:
+      unit.hp = 5;
+      unit.maxHp = 5;
+      break;
+    case UnitRole.Pikeman:
+      unit.hp = 2;
+      unit.maxHp = 2;
+      unit.coins = 0;
+      break;
+    case UnitRole.Squire:
+      unit.hp = 3;
+      unit.maxHp = 3;
+      break;
+    default:
+      break;
+  }
+}
+
+/** Find nearest standard vagrant (no special NPC origin). */
+function findNearestStandardVagrant(
+  state: GameState,
+  x: number,
+  maxDist: number,
+): UnitData | undefined {
+  let nearest: UnitData | undefined;
+  let nearestDist = Infinity;
+
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Vagrant) continue;
+    if (getNpcOrigin(unit.eid) !== NpcOrigin.Standard) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    const d = distance(x, pos.x);
+    if (d <= maxDist && d < nearestDist) {
+      nearestDist = d;
+      nearest = unit;
+    }
+  }
+
+  return nearest;
+}
+
+function findNearestStructureByType(
+  state: GameState,
+  x: number,
+  type: StructureType,
+  maxDist: number,
+): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    if (struct.type !== type) continue;
+    const d = distance(x, struct.x);
+    if (d <= maxDist && d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function findNearestFarmStructure(
+  state: GameState,
+  x: number,
+  maxDist: number,
+): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    if (
+      struct.type !== StructureType.Farm &&
+      struct.type !== StructureType.FarmIrrigated &&
+      struct.type !== StructureType.FarmWindmill
+    ) continue;
+    const d = distance(x, struct.x);
+    if (d <= maxDist && d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function findNearestWall(
+  state: GameState,
+  x: number,
+  maxDist: number,
+): StructureData | undefined {
+  let nearest: StructureData | undefined;
+  let nearestDist = Infinity;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    const d = distance(x, struct.x);
+    if (d <= maxDist && d < nearestDist) {
+      nearestDist = d;
+      nearest = struct;
+    }
+  }
+
+  return nearest;
+}
+
+function tryUpgradeWall(state: GameState, wall: StructureData): boolean {
+  switch (wall.type) {
+    case StructureType.WallWood:
+      if (canAfford(state, WALL_COST_STONE)) {
+        state.monarchCoins -= WALL_COST_STONE;
+        wall.type = StructureType.WallStone;
+        wall.hp = WALL_HP_STONE;
+        wall.maxHp = WALL_HP_STONE;
+        state.messages.push(`Wall upgraded to Stone! (${WALL_COST_STONE} coins)`);
+        return true;
+      }
+      state.messages.push(`Not enough coins to upgrade! (need ${WALL_COST_STONE})`);
+      return true;
+    case StructureType.WallStone:
+      if (canAfford(state, WALL_COST_IRON)) {
+        state.monarchCoins -= WALL_COST_IRON;
+        wall.type = StructureType.WallIron;
+        wall.hp = WALL_HP_IRON;
+        wall.maxHp = WALL_HP_IRON;
+        state.messages.push(`Wall upgraded to Iron! (${WALL_COST_IRON} coins)`);
+        return true;
+      }
+      state.messages.push(`Not enough coins to upgrade! (need ${WALL_COST_IRON})`);
+      return true;
+    default:
+      // Iron or unknown: can't upgrade, fall through to next priority
+      return false;
+  }
+}
+
+// ─── Bread System (Bakery Tower) ──────────────────────────────────
+
+const BREAD_PER_DAY = 7;
+const BREAD_SPOIL_TIME = 360; // 2 in-game days (180s each)
+
+interface BreadLoaf {
+  x: number;
+  age: number; // seconds since produced
+}
+
+const breadLoaves: BreadLoaf[] = [];
+
+/** Get current bread count. */
+export function getBreadCount(): number {
+  return breadLoaves.length;
+}
+
+/**
+ * Produce bread at a bakery position.
+ * Called once per day per bakery tower.
+ */
+export function produceBread(bakeryX: number): void {
+  for (let i = 0; i < BREAD_PER_DAY; i++) {
+    breadLoaves.push({ x: bakeryX, age: 0 });
+  }
+}
+
+/**
+ * Update bread: age all loaves, spoil expired ones.
+ */
+export function updateBread(dt: number): void {
+  for (let i = breadLoaves.length - 1; i >= 0; i--) {
+    breadLoaves[i].age += dt;
+    if (breadLoaves[i].age >= BREAD_SPOIL_TIME) {
+      breadLoaves.splice(i, 1);
+    }
+  }
+}
+
+/**
+ * Use bread to recruit a vagrant. Consumes 1 bread loaf.
+ * Returns true if bread was available and used.
+ */
+export function useBreadForRecruitment(state: GameState, vagrant: UnitData, role: UnitRole): boolean {
+  if (breadLoaves.length === 0) return false;
+
+  // Use the oldest loaf first
+  breadLoaves.shift();
+
+  recruitUnit(vagrant, role);
+  state.messages.push(`Bread recruited a ${role}!`);
+  return true;
+}
+
+// ─── Dawn Bonus ──────────────────────────────────────────────────
+
+/**
+ * Apply dawn coin bonus based on town center tier.
+ * Tier 1-2: 2 coins, Tier 3-4: 3 coins, Tier 5-7: 4 coins.
+ * Called by ai.ts when time transitions to Dawn.
+ */
+export function applyDawnBonus(state: GameState): void {
+  const tier = state.townCenterTier;
+  let bonus: number;
+
+  if (tier >= TownCenterTier.StoneFort) {
+    bonus = 4;
+  } else if (tier >= TownCenterTier.Village) {
+    bonus = 3;
+  } else {
+    bonus = 2;
+  }
+
+  collectCoins(state, bonus);
+  state.messages.push(`Dawn breaks. +${bonus} coins`);
+}
+
+// ─── Tool Theft System ──────────────────────────────────────────
+
+export type ToolType = 'bow' | 'hammer' | 'scythe' | 'pike' | 'shield' | 'sword';
+
+interface DroppedTool {
+  x: number;
+  toolType: ToolType;
+  timer: number; // seconds remaining before despawn
+}
+
+const TOOL_DESPAWN_TIME = 60; // seconds
+const droppedTools: DroppedTool[] = [];
+
+/** Map tool types to unit roles. */
+function toolToRole(tool: ToolType): UnitRole {
+  switch (tool) {
+    case 'bow': return UnitRole.Archer;
+    case 'hammer': return UnitRole.Builder;
+    case 'scythe': return UnitRole.Farmer;
+    case 'pike': return UnitRole.Pikeman;
+    case 'shield': return UnitRole.Squire;
+    case 'sword': return UnitRole.Knight;
+  }
+}
+
+/** Map unit roles to tool types. */
+function roleToTool(role: UnitRole): ToolType | undefined {
+  switch (role) {
+    case UnitRole.Archer: return 'bow';
+    case UnitRole.Builder: return 'hammer';
+    case UnitRole.Farmer: return 'scythe';
+    case UnitRole.Pikeman: return 'pike';
+    case UnitRole.Squire: return 'shield';
+    case UnitRole.Knight: return 'sword';
+    default: return undefined;
+  }
+}
+
+/**
+ * Drop a tool at a position (when a unit dies).
+ * Called by combat system.
+ */
+export function dropTool(x: number, toolType: ToolType): void {
+  droppedTools.push({ x, toolType, timer: TOOL_DESPAWN_TIME });
+}
+
+/**
+ * Drop a tool for a specific unit role at its death position.
+ */
+export function dropToolForRole(x: number, role: UnitRole): void {
+  const tool = roleToTool(role);
+  if (tool) {
+    dropTool(x, tool);
+  }
+}
+
+/**
+ * Pick up a dropped tool. Vagrant becomes the tool's unit role.
+ * Returns true if successful.
+ */
+export function pickUpTool(state: GameState, vagrant: UnitData, toolIndex: number): boolean {
+  if (toolIndex < 0 || toolIndex >= droppedTools.length) return false;
+  if (vagrant.role !== UnitRole.Vagrant) return false;
+
+  const tool = droppedTools[toolIndex];
+  const role = toolToRole(tool.toolType);
+  recruitUnit(vagrant, role);
+  droppedTools.splice(toolIndex, 1);
+
+  state.messages.push(`Vagrant picked up ${tool.toolType} and became ${role}!`);
+  return true;
+}
+
+/**
+ * Update dropped tools: age timers, remove expired.
+ */
+export function updateDroppedTools(dt: number): void {
+  for (let i = droppedTools.length - 1; i >= 0; i--) {
+    droppedTools[i].timer -= dt;
+    if (droppedTools[i].timer <= 0) {
+      droppedTools.splice(i, 1);
+    }
+  }
+}
+
+/** Get all dropped tools (read-only). */
+export function getDroppedTools(): readonly DroppedTool[] {
+  return droppedTools;
+}
+
+/** Find a dropped tool near a position. Returns index or -1. */
+export function findNearbyDroppedTool(x: number, range: number): number {
+  for (let i = 0; i < droppedTools.length; i++) {
+    if (distance(x, droppedTools[i].x) <= range) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/kingdom/game/input.ts
+++ b/kingdom/game/input.ts
@@ -1,0 +1,288 @@
+/**
+ * Kingdom - Input handling
+ * Proper key-down/key-up tracking using timestamp expiry.
+ * Left/right are held states, space is a one-shot trigger.
+ * Handles Title/GameOver phase inputs (Enter, R).
+ */
+
+import { type GameState, GamePhase } from '../types';
+
+const KEY_HOLD_EXPIRY_MS = 200; // ms before a held key is considered released
+
+let stdinListener: ((data: Buffer) => void) | null = null;
+
+// Timestamp tracking for held keys
+let leftPressedAt = 0;
+let rightPressedAt = 0;
+let sprintPressedAt = 0;
+
+// One-shot flags (set on press, consumed by game systems)
+let dropQueued = false;
+let enterQueued = false;
+let restartQueued = false;
+let newGameQueued = false;
+let continueGameQueued = false;
+let interactQueued = false;
+let pauseQueued = false;
+let tabQueued = false;
+let quitMenuQueued = false;
+let numberKeyQueued: number | null = null;
+
+/**
+ * Set up raw mode input handling.
+ * Phase-aware: Title expects Enter, GameOver expects R, Playing expects movement.
+ */
+export function setupInput(state: GameState): void {
+  const stdin = process.stdin;
+  stdin.setRawMode?.(true);
+  stdin.resume();
+  stdin.setEncoding('utf8');
+
+  stdinListener = (data: Buffer) => {
+    const str = String(data);
+    const now = Date.now();
+
+    for (let i = 0; i < str.length; i++) {
+      // Escape sequences (arrow keys)
+      if (str[i] === '\x1b' && str[i + 1] === '[') {
+        // Check for shift+arrow first (CSI 1;2 X)
+        if (str[i + 2] === '1' && str[i + 3] === ';' && str[i + 4] === '2') {
+          sprintPressedAt = now;
+          const shiftCode = str[i + 5];
+          if (shiftCode === 'D') {
+            leftPressedAt = now;
+            rightPressedAt = 0;
+          } else if (shiftCode === 'C') {
+            rightPressedAt = now;
+            leftPressedAt = 0;
+          }
+          i += 5;
+          continue;
+        }
+
+        const code = str[i + 2];
+        if (code === 'D') {
+          leftPressedAt = now;
+          rightPressedAt = 0;
+        } else if (code === 'C') {
+          rightPressedAt = now;
+          leftPressedAt = 0;
+        }
+        i += 2;
+        continue;
+      }
+
+      const ch = str[i];
+
+      // Ctrl+C: always quit immediately
+      if (ch === '\x03') {
+        state.running = false;
+        return;
+      }
+
+      // WASD movement: handle before phase checks (like arrow keys)
+      if (ch === 'a' || ch === 'A') {
+        leftPressedAt = now;
+        rightPressedAt = 0;
+        if (ch === 'A') sprintPressedAt = now;
+      }
+      if (ch === 'd' || ch === 'D') {
+        rightPressedAt = now;
+        leftPressedAt = 0;
+        if (ch === 'D') sprintPressedAt = now;
+      }
+
+      // Q: quit on non-playing screens, open quit menu during play
+      if (ch === 'q' || ch === 'Q') {
+        if (state.phase === GamePhase.Title || state.phase === GamePhase.GameOver || state.phase === GamePhase.Victory) {
+          state.running = false;
+          return;
+        }
+        quitMenuQueued = true;
+        continue;
+      }
+
+      // Phase-specific keys
+      if (state.phase === GamePhase.Title) {
+        if (ch === '\r' || ch === '\n' || ch === 'n' || ch === 'N') {
+          newGameQueued = true;
+          enterQueued = true;
+        }
+        if (ch === 'c' || ch === 'C') {
+          continueGameQueued = true;
+        }
+        continue;
+      }
+
+      if (state.phase === GamePhase.IslandSelect) {
+        // Arrow keys handled above (leftPressedAt/rightPressedAt)
+        if (ch === '\r' || ch === '\n') {
+          enterQueued = true;
+        }
+        continue;
+      }
+
+      if (state.phase === GamePhase.GameOver || state.phase === GamePhase.Victory) {
+        if (ch === 'r' || ch === 'R') {
+          restartQueued = true;
+        }
+        continue;
+      }
+
+      // Playing phase keys
+      if (ch === ' ') {
+        dropQueued = true;
+      }
+
+      // Interact: e or Enter
+      if (ch === 'e' || ch === 'E' || ch === '\r' || ch === '\n') {
+        interactQueued = true;
+      }
+
+      // Pause: p
+      if (ch === 'p' || ch === 'P') {
+        pauseQueued = true;
+      }
+
+      // Tab: toggle minimap
+      if (ch === '\t') {
+        tabQueued = true;
+      }
+
+      // Number keys 1-9: quick action slots
+      if (ch && ch >= '1' && ch <= '9') {
+        numberKeyQueued = parseInt(ch, 10);
+      }
+
+      // 'a'/'d' and sprint handled above, before phase checks
+    }
+  };
+
+  stdin.on('data', stdinListener as (data: any) => void);
+}
+
+/**
+ * Poll input state each frame. Updates held key flags based on timestamp expiry.
+ * Call this at the start of each game loop iteration.
+ */
+export function pollInput(state: GameState): void {
+  const now = Date.now();
+
+  // Held keys: true if pressed recently (within expiry window)
+  state.inputLeft = (now - leftPressedAt) < KEY_HOLD_EXPIRY_MS;
+  state.inputRight = (now - rightPressedAt) < KEY_HOLD_EXPIRY_MS;
+  state.inputSprint = (now - sprintPressedAt) < KEY_HOLD_EXPIRY_MS;
+
+  // One-shot: consume drop flag
+  state.inputDrop = dropQueued;
+  dropQueued = false;
+}
+
+/**
+ * Check and consume the Enter key (for title screen).
+ */
+export function consumeEnter(): boolean {
+  if (enterQueued) {
+    enterQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the Restart key (for game over/victory screen).
+ */
+export function consumeRestart(): boolean {
+  if (restartQueued) {
+    restartQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the New Game key (for title screen).
+ */
+export function consumeNewGame(): boolean {
+  if (newGameQueued) {
+    newGameQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the Continue Game key (for title screen).
+ */
+export function consumeContinue(): boolean {
+  if (continueGameQueued) {
+    continueGameQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the Interact key (e or Enter during play).
+ */
+export function consumeInteract(): boolean {
+  if (interactQueued) {
+    interactQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the Pause key (p).
+ */
+export function consumePause(): boolean {
+  if (pauseQueued) {
+    pauseQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the Tab key (minimap toggle).
+ */
+export function consumeTab(): boolean {
+  if (tabQueued) {
+    tabQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume the Quit menu key (q during play).
+ */
+export function consumeQuit(): boolean {
+  if (quitMenuQueued) {
+    quitMenuQueued = false;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check and consume a number key press (1-9).
+ */
+export function consumeNumberKey(): number | null {
+  const val = numberKeyQueued;
+  numberKeyQueued = null;
+  return val;
+}
+
+/**
+ * Clean up input handling and restore terminal.
+ */
+export function cleanupInput(): void {
+  if (stdinListener) {
+    process.stdin.removeListener('data', stdinListener as (data: any) => void);
+    stdinListener = null;
+  }
+  process.stdin.setRawMode?.(false);
+  process.stdin.pause();
+}

--- a/kingdom/game/persistence.ts
+++ b/kingdom/game/persistence.ts
@@ -1,0 +1,140 @@
+/**
+ * Kingdom - Save/Load persistence
+ * Saves game state to ~/.kingdom-save.json.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  UnitRole,
+  MountType,
+} from '../types';
+
+const SAVE_PATH = join(homedir(), '.kingdom-save.json');
+
+interface SavedStructure {
+  type: StructureType;
+  x: number;
+  hp: number;
+  maxHp: number;
+  level: number;
+}
+
+interface SavedUnit {
+  role: UnitRole;
+  x: number;
+  y: number;
+  hp: number;
+  maxHp: number;
+  coins: number;
+}
+
+interface SaveData {
+  version: 1;
+  islandIndex: number;
+  dayCount: number;
+  monarchCoins: number;
+  mountType: MountType;
+  stamina: number;
+  structures: SavedStructure[];
+  units: SavedUnit[];
+  portalPositions: number[];
+  monarchX: number;
+}
+
+/**
+ * Save game state to ~/.kingdom-save.json.
+ */
+export function saveGame(state: GameState): void {
+  try {
+    const monarchPos = getPosition(state.world, state.monarch.eid);
+
+    const structures: SavedStructure[] = [];
+    for (const [, s] of state.structures) {
+      structures.push({
+        type: s.type,
+        x: s.x,
+        hp: s.hp,
+        maxHp: s.maxHp,
+        level: s.level,
+      });
+    }
+
+    const units: SavedUnit[] = [];
+    for (const u of state.units) {
+      const pos = getPosition(state.world, u.eid);
+      if (pos) {
+        units.push({
+          role: u.role,
+          x: pos.x,
+          y: pos.y,
+          hp: u.hp,
+          maxHp: u.maxHp,
+          coins: u.coins,
+        });
+      }
+    }
+
+    const save: SaveData = {
+      version: 1,
+      islandIndex: state.islandIndex,
+      dayCount: state.dayCount,
+      monarchCoins: state.monarchCoins,
+      mountType: state.mountType,
+      stamina: state.stamina,
+      structures,
+      units,
+      portalPositions: [...state.portalPositions],
+      monarchX: monarchPos?.x ?? 200,
+    };
+
+    writeFileSync(SAVE_PATH, JSON.stringify(save), 'utf8');
+  } catch {
+    // Silently fail on save error
+  }
+}
+
+/**
+ * Load game state from ~/.kingdom-save.json.
+ * Returns partial state with restorable fields, or null if no save exists.
+ */
+export function loadGame(): Partial<GameState> | null {
+  try {
+    if (!existsSync(SAVE_PATH)) return null;
+
+    const raw = readFileSync(SAVE_PATH, 'utf8');
+    const save: SaveData = JSON.parse(raw);
+    if (save.version !== 1) return null;
+
+    // Reconstruct structures Map
+    const structures = new Map<number, StructureData>();
+    for (const s of save.structures) {
+      structures.set(s.x, {
+        eid: 0 as any,
+        type: s.type,
+        x: s.x,
+        hp: s.hp,
+        maxHp: s.maxHp,
+        level: s.level,
+        assignedWorkers: [],
+      });
+    }
+
+    return {
+      islandIndex: save.islandIndex,
+      dayCount: save.dayCount,
+      monarchCoins: save.monarchCoins,
+      mountType: save.mountType,
+      stamina: save.stamina,
+      portalPositions: save.portalPositions,
+      structures,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/kingdom/index.ts
+++ b/kingdom/index.ts
@@ -1,0 +1,630 @@
+#!/usr/bin/env node
+/**
+ * Kingdom - A side-scrolling TUI strategy game inspired by Kingdom: Two Crowns
+ *
+ * Built with blECSd 0.2.0 ECS framework.
+ * Defend your kingdom, recruit villagers, and survive the nightly greed attacks.
+ *
+ * Controls: Arrow keys to move, Shift+Arrow to sprint, Space to drop coin, Q to quit.
+ */
+
+import { createWorld, getPosition } from 'blecsd';
+import {
+  type GameState,
+  type IslandSaveState,
+  type MultiIslandSave,
+  type IslandStats,
+  GamePhase,
+  TimeOfDay,
+  Season,
+  TownCenterTier,
+  WeatherType,
+  MountType,
+  StructureType,
+  ConsumableType,
+  CAMP_CENTER_X,
+  STARTING_COINS,
+  FRAME_TIME,
+  NIGHT_START,
+  GROUND_Y,
+  ISLAND_MAP_WIDTHS,
+  MAP_WIDTH,
+} from './types';
+
+// Core systems
+import { generateMap } from './world/map';
+import { updateCamera } from './world/camera';
+import { updateDayNight } from './game/dayNight';
+import { setupInput, cleanupInput, pollInput, consumeEnter, consumeRestart, consumeNewGame, consumeContinue, consumePause, consumeQuit, consumeTab } from './game/input';
+import { render } from './render/renderer';
+import { triggerWaveFlash } from './render/effects';
+import { playBell, playAlert, playBloodMoonWarning, setSoundEnabled } from './render/sound';
+import { saveGame, loadGame } from './game/persistence';
+import { collectCoins } from './game/economy';
+
+// Entities + Economy (Agent 2)
+import { createMonarch } from './entities/monarch';
+import { spawnVagrant } from './entities/villager';
+import { createMount, updateMount } from './entities/mount';
+import { updateMovement } from './systems/movement';
+import { updateAI } from './systems/ai';
+
+// Combat + Structures + Spawning (Agent 3)
+import { updateCombat } from './systems/combat';
+import { updateSpawning } from './systems/spawn';
+import { updateConstruction } from './systems/construction';
+import { updateShrineBuff } from './structures/shrine';
+
+function createInitialState(): GameState {
+  const world = createWorld();
+  const stdout = process.stdout;
+
+  const state: GameState = {
+    world,
+    phase: GamePhase.Title,
+    running: true,
+
+    // Time
+    dayTime: 0.2, // Start at early morning
+    dayCount: 1,
+    timeOfDay: TimeOfDay.Day,
+    totalElapsed: 0,
+    season: Season.Spring,
+    seasonDay: 0,
+
+    // Economy
+    monarchCoins: STARTING_COINS,
+
+    // Map (populated by generateMap)
+    tiles: [],
+    structures: new Map(),
+
+    // Entities
+    monarch: null as any,
+    units: [],
+    greeds: [],
+    projectiles: [],
+
+    // Portals
+    portalPositions: [],
+
+    // Camera
+    cameraX: 0,
+    viewWidth: stdout.columns ?? 80,
+    viewHeight: stdout.rows ?? 24,
+
+    // Island
+    islandIndex: 0,
+    difficultyMultiplier: 1.0,
+
+    // Input
+    inputLeft: false,
+    inputRight: false,
+    inputSprint: false,
+    inputDrop: false,
+    lastCoinDrop: 0,
+
+    // Rendering
+    needsFullRedraw: true,
+
+    // Messages
+    messages: [],
+
+    // Mount
+    mountType: MountType.None,
+    stamina: 100,
+    maxStamina: 100,
+
+    // Consumables
+    consumedSpots: new Set(),
+    consumableSpots: new Map(),
+    speedBoostTimer: 0,
+
+    // Town Center
+    townCenterTier: TownCenterTier.Campfire,
+    townCenterCooldown: 0,
+    gems: 0,
+    gemCapacity: 10,
+
+    // Blood Moon
+    isBloodMoon: false,
+
+    // Weather
+    weather: WeatherType.Clear,
+
+    // Crown
+    crownDropped: false,
+    crownX: CAMP_CENTER_X,
+    crownY: GROUND_Y,
+    crownTimer: 0,
+
+    // Dog companion
+    hasDog: false,
+    dogCaptured: false,
+
+    // Portal Assault
+    portalAssaultActive: false,
+    assaultTargetPortal: -1,
+
+    // Pause
+    isPaused: false,
+
+    // Boat
+    boatState: 'wreck',
+    hullPieces: 0,
+
+    // Bear combat
+    bearAttackCooldown: 0,
+
+    // Effects / Timers
+    screenShakeTimer: 0,
+    gameOverTimer: 0,
+    lastSaveTime: 0,
+
+    // Island system
+    islandUnlocked: [true, false, false, false, false],
+    islandStats: Array.from({ length: 5 }, () => ({ portalsDestroyed: 0, daysVisited: 0, structuresBuilt: 0 })),
+    selectedIsland: 0,
+    bankedCoins: 0,
+    globalDayCount: 0,
+    mapWidth: ISLAND_MAP_WIDTHS[0] ?? MAP_WIDTH,
+
+    // Minimap
+    showMinimap: false,
+
+    // Sound
+    soundEnabled: true,
+
+    // Heir succession
+    totalHeirs: 0,
+
+    // Challenge islands
+    challengeNightsSurvived: 0,
+    hourglassFreezeTimer: 0,
+  };
+
+  // Generate world
+  generateMap(state);
+
+  // Create monarch
+  state.monarch = createMonarch(state);
+
+  // Give monarch a horse
+  createMount(state);
+
+  // Spawn initial vagrants near the camp
+  const vagrantOffsets = [-15, -10, 10, 15, 20];
+  for (const offset of vagrantOffsets) {
+    state.units.push(spawnVagrant(state, CAMP_CENTER_X + offset));
+  }
+
+  return state;
+}
+
+function resetState(state: GameState): void {
+  const fresh = createInitialState();
+  fresh.phase = GamePhase.Playing;
+  fresh.needsFullRedraw = true;
+
+  // Copy all properties from fresh state onto existing state object
+  // so the input system's reference remains valid
+  Object.assign(state, fresh);
+}
+
+// ─── Per-Island Save/Load ─────────────────────────────────────────
+
+const islandSaves: (IslandSaveState | null)[] = [null, null, null, null, null];
+
+function saveIslandState(state: GameState, islandIndex: number): void {
+  const structures: IslandSaveState['structures'] = [];
+  for (const [, s] of state.structures) {
+    structures.push({ type: s.type, x: s.x, hp: s.hp, maxHp: s.maxHp, level: s.level });
+  }
+
+  islandSaves[islandIndex] = {
+    dayCount: state.dayCount,
+    dayTime: state.dayTime,
+    monarchCoins: state.monarchCoins,
+    mountType: state.mountType,
+    stamina: state.stamina,
+    portalPositions: [...state.portalPositions],
+    structures,
+    townCenterTier: state.townCenterTier,
+    boatState: state.boatState,
+    hullPieces: state.hullPieces,
+    hasDog: state.hasDog,
+  };
+
+  // Update island stats
+  if (state.islandStats[islandIndex]) {
+    state.islandStats[islandIndex].daysVisited = state.dayCount;
+  }
+}
+
+function loadIslandState(state: GameState, islandIndex: number): boolean {
+  const saved = islandSaves[islandIndex];
+  if (!saved) return false;
+
+  state.islandIndex = islandIndex;
+  state.mapWidth = ISLAND_MAP_WIDTHS[islandIndex] ?? MAP_WIDTH;
+  state.dayCount = saved.dayCount;
+  state.dayTime = saved.dayTime;
+  state.monarchCoins = saved.monarchCoins;
+  state.mountType = saved.mountType;
+  state.stamina = saved.stamina;
+  state.portalPositions = [...saved.portalPositions];
+  state.townCenterTier = saved.townCenterTier;
+  state.boatState = saved.boatState;
+  state.hullPieces = saved.hullPieces;
+  state.hasDog = saved.hasDog;
+
+  // Regenerate map tiles for the island
+  generateMap(state);
+
+  // Restore structures from save over the generated ones
+  for (const s of saved.structures) {
+    const existing = state.structures.get(s.x);
+    if (existing) {
+      existing.type = s.type;
+      existing.hp = s.hp;
+      existing.maxHp = s.maxHp;
+      existing.level = s.level;
+    } else {
+      state.structures.set(s.x, {
+        eid: 0 as any,
+        type: s.type,
+        x: s.x,
+        hp: s.hp,
+        maxHp: s.maxHp,
+        level: s.level,
+        assignedWorkers: [],
+      });
+    }
+  }
+
+  // Recreate monarch and units
+  state.monarch = createMonarch(state);
+  createMount(state);
+  state.units = [];
+  state.greeds = [];
+  state.projectiles = [];
+
+  return true;
+}
+
+function main(): void {
+  const stdout = process.stdout;
+
+  // Terminal setup
+  stdout.write('\x1b[?1049h'); // Alt screen
+  stdout.write('\x1b[?25l');   // Hide cursor
+
+  const state = createInitialState();
+
+  // Try loading a saved game
+  const saved = loadGame();
+  if (saved) {
+    Object.assign(state, saved);
+    state.messages.push(`Loaded save: Day ${state.dayCount}, Isle ${state.islandIndex + 1}`);
+  }
+
+  // Set up input
+  setupInput(state);
+
+  // Handle resize
+  stdout.on('resize', () => {
+    state.viewWidth = stdout.columns ?? 80;
+    state.viewHeight = stdout.rows ?? 24;
+    state.needsFullRedraw = true;
+  });
+
+  // Cleanup handler
+  const cleanup = (): void => {
+    saveGame(state);
+    cleanupInput();
+    stdout.write('\x1b[?25h');   // Show cursor
+    stdout.write('\x1b[?1049l'); // Exit alt screen
+    stdout.write('\x1b[0m');     // Reset attributes
+  };
+
+  process.on('SIGINT', () => { cleanup(); process.exit(0); });
+  process.on('SIGTERM', () => { cleanup(); process.exit(0); });
+
+  // Track previous state for transition detection
+  let prevTimeOfDay = state.timeOfDay;
+  let prevPhase = state.phase;
+
+  // Game loop
+  let lastTime = Date.now();
+
+  const loop = (): void => {
+    if (!state.running) {
+      cleanup();
+      process.exit(0);
+      return;
+    }
+
+    const now = Date.now();
+    const dtMs = now - lastTime;
+    lastTime = now;
+    const dt = dtMs / 1000;
+    state.totalElapsed += dt;
+
+    // Poll input (timestamp-based held key detection)
+    pollInput(state);
+
+    // Pause toggle (works during playing phase)
+    if (state.phase === GamePhase.Playing && consumePause()) {
+      state.isPaused = !state.isPaused;
+      state.needsFullRedraw = true;
+    }
+
+    // Quit from pause: exit game
+    if (state.isPaused && consumeQuit()) {
+      state.running = false;
+    }
+
+    // When paused, skip all game updates, only render
+    if (state.isPaused) {
+      prevPhase = state.phase;
+      render(state);
+      const elapsed = Date.now() - now;
+      const delay = Math.max(0, FRAME_TIME - elapsed);
+      setTimeout(loop, delay);
+      return;
+    }
+
+    // Phase-specific logic
+    if (state.phase === GamePhase.Title) {
+      if (consumeNewGame() || consumeEnter()) {
+        state.phase = GamePhase.Playing;
+        state.needsFullRedraw = true;
+        state.messages.push('Your kingdom awaits. Ride forth and build your defenses!');
+      } else if (consumeContinue()) {
+        const savedGame = loadGame();
+        if (savedGame) {
+          Object.assign(state, savedGame);
+          state.phase = GamePhase.Playing;
+          state.needsFullRedraw = true;
+          state.messages.push(`Loaded save: Day ${state.dayCount}, Isle ${state.islandIndex + 1}`);
+        } else {
+          state.messages.push('No save found. Press N for a new game.');
+        }
+      }
+    } else if (state.phase === GamePhase.IslandSelect) {
+      // Island selection screen input handling
+      if (state.inputLeft) {
+        state.selectedIsland = Math.max(0, state.selectedIsland - 1);
+        state.inputLeft = false;
+        state.needsFullRedraw = true;
+      }
+      if (state.inputRight) {
+        state.selectedIsland = Math.min(4, state.selectedIsland + 1);
+        state.inputRight = false;
+        state.needsFullRedraw = true;
+      }
+      if (consumeEnter()) {
+        const sel = state.selectedIsland;
+        if (state.islandUnlocked[sel]) {
+          // Save current island state before switching
+          saveIslandState(state, state.islandIndex);
+          // Switch to selected island
+          const loaded = loadIslandState(state, sel);
+          if (!loaded) {
+            // Generate fresh island
+            state.islandIndex = sel;
+            state.mapWidth = ISLAND_MAP_WIDTHS[sel] ?? MAP_WIDTH;
+            generateMap(state);
+            state.monarch = createMonarch(state);
+            createMount(state);
+            const vagrantOffsets = [-15, -10, 10, 15, 20];
+            for (const offset of vagrantOffsets) {
+              state.units.push(spawnVagrant(state, (ISLAND_MAP_WIDTHS[sel] ?? MAP_WIDTH) / 2 + offset));
+            }
+          }
+          state.phase = GamePhase.Playing;
+          state.needsFullRedraw = true;
+          state.messages.push(`Arrived at Isle ${sel + 1}`);
+        } else {
+          state.messages.push('That island is locked. Build a boat to unlock the next island.');
+        }
+      }
+      if (consumeQuit()) {
+        state.phase = GamePhase.Title;
+        state.needsFullRedraw = true;
+      }
+    } else if (state.phase === GamePhase.GameOver) {
+      // 500ms pause before accepting restart input
+      if (prevPhase !== GamePhase.GameOver) {
+        state.gameOverTimer = 0.5;
+        playAlert();
+      }
+
+      state.gameOverTimer = Math.max(0, state.gameOverTimer - dt);
+
+      if (state.gameOverTimer <= 0 && consumeRestart()) {
+        resetState(state);
+        state.messages.push('A new reign begins...');
+      }
+    } else if (state.phase === GamePhase.Victory) {
+      if (prevPhase !== GamePhase.Victory) {
+        state.gameOverTimer = 0.5;
+      }
+      state.gameOverTimer = Math.max(0, state.gameOverTimer - dt);
+      if (state.gameOverTimer <= 0 && consumeRestart()) {
+        resetState(state);
+        state.messages.push('A new reign begins...');
+      }
+    } else if (state.phase === GamePhase.Playing) {
+      // Minimap toggle
+      if (consumeTab()) {
+        state.showMinimap = !state.showMinimap;
+        state.needsFullRedraw = true;
+      }
+
+      // Snapshot values for change detection
+      const prevCoins = state.monarchCoins;
+      const wallHpBefore = new Map<number, number>();
+      for (const [x, s] of state.structures) {
+        if (s.type === StructureType.WallWood || s.type === StructureType.WallStone || s.type === StructureType.WallIron) {
+          wallHpBefore.set(x, s.hp);
+        }
+      }
+
+      // Update game systems
+      updateDayNight(state, dt);
+
+      // Compute season from day count (16 days per season, 64-day full cycle)
+      state.season = Math.floor((state.dayCount % 64) / 16) as Season;
+      state.seasonDay = state.dayCount % 16;
+
+      // Blood moon: every 5th day during night
+      state.isBloodMoon = state.dayCount > 0 && state.dayCount % 5 === 0 && state.dayTime >= NIGHT_START;
+
+      // Weather: set at dawn each day based on season
+      if (state.isBloodMoon) {
+        state.weather = WeatherType.Storm;
+      } else if (state.timeOfDay === TimeOfDay.Dawn && prevTimeOfDay !== TimeOfDay.Dawn) {
+        const weatherRoll = (state.dayCount * 7 + state.seasonDay * 13) % 100;
+        switch (state.season) {
+          case Season.Spring:
+            state.weather = weatherRoll < 30 ? WeatherType.Rain : WeatherType.Clear;
+            break;
+          case Season.Summer:
+            state.weather = WeatherType.Clear;
+            break;
+          case Season.Autumn:
+            state.weather = weatherRoll < 20 ? WeatherType.Rain : WeatherType.Clear;
+            break;
+          case Season.Winter:
+            state.weather = weatherRoll < 80 ? WeatherType.Snow : WeatherType.Clear;
+            break;
+        }
+      }
+
+      // NOTE: updateMount is called inside updateAI, no separate call needed here
+
+      // Blood moon warning ~40 seconds before midnight (dayTime ~0.78 for blood moon days)
+      if (state.dayCount > 0 && state.dayCount % 5 === 0 && state.dayTime >= 0.78 && state.dayTime < 0.80 && prevTimeOfDay === TimeOfDay.Dusk) {
+        playBloodMoonWarning();
+        state.messages.push('A blood moon rises tonight...');
+      }
+
+      // Trigger wave flash + alert when night begins
+      if (state.timeOfDay === TimeOfDay.Night && prevTimeOfDay !== TimeOfDay.Night) {
+        triggerWaveFlash();
+        playAlert();
+        state.messages.push('The greed stirs in the darkness...');
+      }
+
+      // Dawn bonus: +2 coins each morning
+      if (state.timeOfDay === TimeOfDay.Dawn && prevTimeOfDay !== TimeOfDay.Dawn) {
+        collectCoins(state, 2);
+        playBell();
+        state.messages.push('Dawn bonus: +2 coins');
+      }
+
+      prevTimeOfDay = state.timeOfDay;
+
+      updateAI(state, dt);
+
+      // NOTE: double-movement issue exists: updateMonarch applies position directly,
+      // then updateMovement also applies velocity to position. Agent 3 will fix
+      // movement.ts to not double-apply. Speed boost is handled via state.speedBoostTimer
+      // which monarch.ts / getMountSpeed should read instead of scaling velocity here.
+      updateMovement(state, dt);
+      updateSpawning(state, dt);
+      updateCombat(state, dt);
+      updateConstruction(state, dt);
+      updateShrineBuff(dt);
+      updateCamera(state);
+
+      // Check consumable spot pickup
+      const monarchPos = getPosition(state.world, state.monarch.eid);
+      if (monarchPos) {
+        const mx = Math.round(monarchPos.x);
+        const consumable = state.consumableSpots.get(mx);
+        if (consumable !== undefined && !state.consumedSpots.has(mx)) {
+          state.consumedSpots.add(mx);
+          switch (consumable) {
+            case ConsumableType.FoodCache:
+              collectCoins(state, 3);
+              state.messages.push('Found food cache! (+3 coins)');
+              playBell();
+              break;
+            case ConsumableType.RestShrine:
+              state.stamina = state.maxStamina;
+              state.messages.push('Rested at shrine! (stamina restored)');
+              playBell();
+              break;
+            case ConsumableType.PowerWell:
+              state.speedBoostTimer = 15;
+              state.messages.push('Power well activated! (speed boost 15s)');
+              playBell();
+              break;
+          }
+        }
+      }
+
+      // Decrement speed boost timer
+      if (state.speedBoostTimer > 0) {
+        state.speedBoostTimer = Math.max(0, state.speedBoostTimer - dt);
+      }
+
+      // Sound cue on coin pickup
+      if (state.monarchCoins > prevCoins) {
+        playBell();
+      }
+
+      // Detect wall breaches: trigger screen shake + alert
+      for (const [x, prevHp] of wallHpBefore) {
+        const wall = state.structures.get(x);
+        if (!wall || wall.hp <= 0) {
+          if (prevHp > 0) {
+            state.screenShakeTimer = 0.2;
+            playAlert();
+            state.messages.push('A wall has been breached!');
+            break;
+          }
+        }
+      }
+
+      // Decrement screen shake timer
+      if (state.screenShakeTimer > 0) {
+        state.screenShakeTimer = Math.max(0, state.screenShakeTimer - dt);
+      }
+
+      // Boat departed: unlock next island and go to island select
+      if (state.boatState === 'departed') {
+        const nextIsland = state.islandIndex + 1;
+        if (nextIsland < 5) {
+          state.islandUnlocked[nextIsland] = true;
+        }
+        state.boatState = 'wreck'; // Reset for next use
+        state.selectedIsland = Math.min(nextIsland, 4);
+        state.phase = GamePhase.IslandSelect;
+        state.needsFullRedraw = true;
+        state.messages.push('Your boat sails to new shores...');
+      }
+
+      // Auto-save every 30 seconds
+      if (state.totalElapsed - state.lastSaveTime >= 30) {
+        saveGame(state);
+        state.lastSaveTime = state.totalElapsed;
+      }
+    }
+
+    prevPhase = state.phase;
+
+    render(state);
+
+    // Schedule next frame
+    const elapsed = Date.now() - now;
+    const delay = Math.max(0, FRAME_TIME - elapsed);
+    setTimeout(loop, delay);
+  };
+
+  loop();
+}
+
+main();

--- a/kingdom/package-lock.json
+++ b/kingdom/package-lock.json
@@ -1,0 +1,1572 @@
+{
+  "name": "kingdom",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kingdom",
+      "version": "1.0.0",
+      "dependencies": {
+        "blecsd": "^0.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.2",
+        "tsup": "^8.5.1",
+        "tsx": "^4.19.3",
+        "typescript": "^5.8.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.9.tgz",
+      "integrity": "sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bitecs": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/bitecs/-/bitecs-0.4.0.tgz",
+      "integrity": "sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/blecsd": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+      "integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bitecs": "^0.4.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "blecsd": "dist/cli/init.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/kingdom/package.json
+++ b/kingdom/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "kingdom",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Kingdom-style side-scrolling strategy game built with blECSd TUI framework",
+  "scripts": {
+    "dev": "tsx index.ts",
+    "build": "tsup index.ts --format esm --dts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "blecsd": "file:../../blECSd"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.2",
+    "tsup": "^8.5.1",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/kingdom/pnpm-lock.yaml
+++ b/kingdom/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.2
+        version: 22.19.11
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@6.21.0: {}
+
+  zod@4.3.6: {}

--- a/kingdom/render/effects.ts
+++ b/kingdom/render/effects.ts
@@ -1,0 +1,352 @@
+/**
+ * Kingdom - Visual effects
+ * Smooth night transitions, wave-incoming flash, coin sparkle, damage flash.
+ */
+
+import {
+  TimeOfDay,
+  WeatherType,
+  DUSK_START,
+  NIGHT_START,
+  DAWN_START,
+  DAY_START,
+  GROUND_Y,
+} from '../types';
+
+interface CellBufferDirect {
+  width: number;
+  height: number;
+  cells: { char: string; fg: number; bg: number }[][];
+  setCell: (x: number, y: number, char: string, fg: number, bg: number) => void;
+}
+
+function darkenColor(color: number, factor: number): number {
+  const r = Math.floor(((color >> 24) & 0xff) * factor);
+  const g = Math.floor(((color >> 16) & 0xff) * factor);
+  const b = Math.floor(((color >> 8) & 0xff) * factor);
+  const a = color & 0xff;
+  return ((r & 0xff) << 24) | ((g & 0xff) << 16) | ((b & 0xff) << 8) | a;
+}
+
+function tintColor(color: number, tintR: number, tintG: number, tintB: number, strength: number): number {
+  const r = ((color >> 24) & 0xff);
+  const g = ((color >> 16) & 0xff);
+  const b = ((color >> 8) & 0xff);
+  const a = color & 0xff;
+  const nr = Math.floor(r * (1 - strength) + tintR * strength);
+  const ng = Math.floor(g * (1 - strength) + tintG * strength);
+  const nb = Math.floor(b * (1 - strength) + tintB * strength);
+  return ((nr & 0xff) << 24) | ((ng & 0xff) << 16) | ((nb & 0xff) << 8) | a;
+}
+
+/**
+ * Compute a smooth darkening factor based on continuous dayTime.
+ * Returns a value between 0.3 (full night) and 1.0 (full day).
+ * Transitions smoothly between phases instead of discrete jumps.
+ */
+function computeDarkenFactor(dayTime: number): number {
+  // Dawn transition: DAWN_START -> DAY_START (0.0 -> 0.15), dark to light
+  if (dayTime < DAY_START) {
+    const t = dayTime / DAY_START; // 0..1 within dawn
+    return 0.3 + t * 0.45; // 0.3 -> 0.75
+  }
+  // Day: full brightness
+  if (dayTime < DUSK_START) {
+    // Ease in from dawn end
+    if (dayTime < DAY_START + 0.05) {
+      const t = (dayTime - DAY_START) / 0.05;
+      return 0.75 + t * 0.25; // 0.75 -> 1.0
+    }
+    return 1.0;
+  }
+  // Dusk transition: DUSK_START -> NIGHT_START (0.65 -> 0.8), light to dark
+  if (dayTime < NIGHT_START) {
+    const t = (dayTime - DUSK_START) / (NIGHT_START - DUSK_START); // 0..1 within dusk
+    return 1.0 - t * 0.7; // 1.0 -> 0.3
+  }
+  // Night: darkest
+  // Very slight variation for atmosphere
+  return 0.3;
+}
+
+/**
+ * Apply smooth darkening overlay to the buffer based on continuous dayTime.
+ * Also applies a red tint during blood moon nights.
+ */
+export function applyNightOverlay(buffer: CellBufferDirect, timeOfDay: TimeOfDay, dayTime: number, isBloodMoon: boolean): void {
+  const factor = computeDarkenFactor(dayTime);
+
+  if (factor >= 0.99 && !isBloodMoon) return; // Full day, no overlay needed
+
+  for (let y = 0; y < buffer.height; y++) {
+    const row = buffer.cells[y];
+    if (!row) continue;
+    for (let x = 0; x < buffer.width; x++) {
+      const cell = row[x];
+      if (!cell) continue;
+      cell.fg = darkenColor(cell.fg, factor);
+      cell.bg = darkenColor(cell.bg, factor);
+
+      // Blood moon red tint during night
+      if (isBloodMoon && timeOfDay === TimeOfDay.Night) {
+        cell.fg = tintColor(cell.fg, 180, 20, 20, 0.15);
+        cell.bg = tintColor(cell.bg, 120, 10, 10, 0.1);
+      }
+    }
+  }
+}
+
+// ─── Wave Incoming Flash ──────────────────────────────────────────
+
+let waveFlashTimer = 0;
+const WAVE_FLASH_DURATION = 0.8; // seconds
+
+/**
+ * Trigger the wave incoming flash. Call when night begins.
+ */
+export function triggerWaveFlash(): void {
+  waveFlashTimer = WAVE_FLASH_DURATION;
+}
+
+/**
+ * Update and apply wave incoming flash effect.
+ * Pulses the screen border red when a greed wave is starting.
+ */
+export function updateWaveFlash(buffer: CellBufferDirect, dt: number): void {
+  if (waveFlashTimer <= 0) return;
+  waveFlashTimer -= dt;
+
+  const intensity = Math.max(0, waveFlashTimer / WAVE_FLASH_DURATION);
+  const pulse = Math.sin(intensity * Math.PI * 4) * 0.5 + 0.5; // Pulsing effect
+  const flashColor = ((Math.floor(200 * pulse) & 0xff) << 24) | (0x10 << 16) | (0x10 << 8) | 0xff;
+
+  // Flash top and bottom borders
+  for (let x = 0; x < buffer.width; x++) {
+    const topCell = buffer.cells[0]?.[x];
+    const botCell = buffer.cells[buffer.height - 1]?.[x];
+    if (topCell) topCell.bg = flashColor;
+    if (botCell) botCell.bg = flashColor;
+  }
+  // Flash left and right borders
+  for (let y = 0; y < buffer.height; y++) {
+    const leftCell = buffer.cells[y]?.[0];
+    const rightCell = buffer.cells[y]?.[buffer.width - 1];
+    if (leftCell) leftCell.bg = flashColor;
+    if (rightCell) rightCell.bg = flashColor;
+  }
+}
+
+// ─── Coin Sparkle Effect ──────────────────────────────────────────
+
+interface Sparkle {
+  x: number;
+  y: number;
+  timer: number;
+}
+
+const sparkles: Sparkle[] = [];
+const SPARKLE_DURATION = 0.5;
+const SPARKLE_CHARS = ['\u2727', '\u2729', '\u00B7', ' ']; // star, star, dot, gone
+
+/**
+ * Queue a sparkle effect at screen coordinates.
+ */
+export function addSparkle(screenX: number, screenY: number): void {
+  sparkles.push({ x: screenX, y: screenY, timer: SPARKLE_DURATION });
+}
+
+/**
+ * Update and render sparkle effects onto the buffer.
+ */
+export function updateSparkles(buffer: CellBufferDirect, dt: number): void {
+  for (let i = sparkles.length - 1; i >= 0; i--) {
+    const s = sparkles[i]!;
+    s.timer -= dt;
+    if (s.timer <= 0) {
+      sparkles.splice(i, 1);
+      continue;
+    }
+
+    const progress = 1 - (s.timer / SPARKLE_DURATION);
+    const charIdx = Math.min(Math.floor(progress * SPARKLE_CHARS.length), SPARKLE_CHARS.length - 1);
+    const ch = SPARKLE_CHARS[charIdx]!;
+
+    // Draw sparkle at position and slightly above (floats up)
+    const drawY = s.y - Math.floor(progress * 2);
+    if (s.x >= 0 && s.x < buffer.width && drawY >= 0 && drawY < buffer.height) {
+      const brightness = Math.floor(255 * (1 - progress * 0.6));
+      const fg = ((brightness & 0xff) << 24) | ((brightness & 0xff) << 16) | (0x00 << 8) | 0xff;
+      buffer.setCell(s.x, drawY, ch, fg, buffer.cells[drawY]![s.x]!.bg);
+    }
+  }
+}
+
+/**
+ * Brief color inversion flash at a screen position for damage feedback.
+ */
+export function flashEffect(buffer: CellBufferDirect, x: number, y: number): void {
+  if (x < 0 || x >= buffer.width || y < 0 || y >= buffer.height) return;
+  const row = buffer.cells[y];
+  if (!row) return;
+  const cell = row[x];
+  if (!cell) return;
+
+  const tmpFg = cell.fg;
+  cell.fg = cell.bg;
+  cell.bg = tmpFg;
+}
+
+// ─── Weather Effects ─────────────────────────────────────────────
+
+let stormFlashFrames = 0;
+
+// Deterministic pseudo-random for weather particles
+function weatherRand(seed: number): number {
+  seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+  return (seed >> 16) / 32768.0;
+}
+
+/**
+ * Render weather overlay onto the buffer.
+ * Call after sky/terrain but before entities.
+ */
+export function renderWeather(
+  buffer: CellBufferDirect,
+  width: number,
+  height: number,
+  weather: WeatherType,
+  time: number,
+  groundScreenY?: number,
+): void {
+  if (weather === WeatherType.Clear) return;
+
+  const effectiveGroundY = groundScreenY ?? GROUND_Y;
+  const maxY = Math.min(effectiveGroundY, height);
+
+  if (weather === WeatherType.Rain || weather === WeatherType.Storm) {
+    const dropCount = weather === WeatherType.Storm ? 40 : 20;
+    const COLOR_RAIN = 0x4488bbff;
+    const rainChars = ['|', '/'];
+
+    for (let i = 0; i < dropCount; i++) {
+      // Time-based position: each drop has a unique phase offset
+      const seed = i * 997 + Math.floor(time * 15);
+      const rx = Math.floor(weatherRand(seed) * width);
+      const baseY = (Math.floor(time * 12 + i * 3.7) % maxY);
+      const ry = baseY;
+      if (rx >= 0 && rx < width && ry >= 2 && ry < maxY) {
+        const ch = rainChars[i % 2]!;
+        const cell = buffer.cells[ry]?.[rx];
+        if (cell) {
+          buffer.setCell(rx, ry, ch, COLOR_RAIN, cell.bg);
+        }
+      }
+    }
+
+    // Storm lightning flash
+    if (weather === WeatherType.Storm) {
+      // Random flash: ~5% chance per frame
+      if (stormFlashFrames > 0) {
+        stormFlashFrames--;
+        for (let y = 0; y < Math.min(effectiveGroundY - 4, height); y++) {
+          const row = buffer.cells[y];
+          if (!row) continue;
+          for (let x = 0; x < width; x++) {
+            const cell = row[x];
+            if (cell) {
+              cell.bg = 0xffffffaaff;
+            }
+          }
+        }
+      } else if (weatherRand(Math.floor(time * 30)) < 0.05) {
+        stormFlashFrames = 2;
+      }
+    }
+  }
+
+  if (weather === WeatherType.Snow) {
+    const flakeCount = 15;
+    const COLOR_SNOW = 0xddddffff;
+    const snowChars = ['*', '.', '\u00B7'];
+
+    for (let i = 0; i < flakeCount; i++) {
+      const seed = i * 1013;
+      const baseX = Math.floor(weatherRand(seed) * width);
+      // Slow drift down, slight sinusoidal x wobble
+      const fy = (Math.floor(time * 3 + i * 4.1) % maxY);
+      const xWobble = Math.floor(Math.sin(time * 0.8 + i * 1.3) * 2);
+      const fx = ((baseX + xWobble) % width + width) % width;
+      if (fx >= 0 && fx < width && fy >= 2 && fy < maxY) {
+        const ch = snowChars[i % 3]!;
+        const cell = buffer.cells[fy]?.[fx];
+        if (cell) {
+          buffer.setCell(fx, fy, ch, COLOR_SNOW, cell.bg);
+        }
+      }
+    }
+  }
+}
+
+// ─── Coin Burst Sparkle ────────────────────────────────────────
+
+interface CoinSpark {
+  originX: number;
+  originY: number;
+  dx: number;
+  dy: number;
+  timer: number;
+}
+
+const coinSparks: CoinSpark[] = [];
+const COIN_SPARK_DURATION = 0.3;
+
+/**
+ * Create a coin pickup/drop burst of 3-5 sparks radiating outward.
+ */
+export function createCoinSparkle(screenX: number, screenY: number): void {
+  const count = 3 + Math.floor(Math.random() * 3);
+  for (let i = 0; i < count; i++) {
+    const angle = (Math.PI * 2 * i) / count + (Math.random() - 0.5) * 0.5;
+    coinSparks.push({
+      originX: screenX,
+      originY: screenY,
+      dx: Math.round(Math.cos(angle)),
+      dy: Math.round(Math.sin(angle)),
+      timer: COIN_SPARK_DURATION,
+    });
+  }
+}
+
+/**
+ * Update coin sparkle timers. Call once per frame.
+ */
+export function updateCoinSparkles(dt: number): void {
+  for (let i = coinSparks.length - 1; i >= 0; i--) {
+    const s = coinSparks[i]!;
+    s.timer -= dt;
+    if (s.timer <= 0) {
+      coinSparks.splice(i, 1);
+    }
+  }
+}
+
+/**
+ * Render coin sparkles onto the buffer. Gold stars radiating outward.
+ */
+export function renderCoinSparkles(buffer: CellBufferDirect): void {
+  for (const s of coinSparks) {
+    const elapsed = COIN_SPARK_DURATION - s.timer;
+    const step = Math.floor(elapsed / 0.1);
+    const x = s.originX + s.dx * step;
+    const y = s.originY + s.dy * step;
+    if (x < 0 || x >= buffer.width || y < 0 || y >= buffer.height) continue;
+    const fade = s.timer / COIN_SPARK_DURATION;
+    const r = Math.floor(0xff * fade);
+    const g = Math.floor(0xcc * fade);
+    const fg = ((r & 0xff) << 24) | ((g & 0xff) << 16) | (0x00 << 8) | 0xff;
+    const cell = buffer.cells[y]?.[x];
+    if (cell) {
+      buffer.setCell(x, y, '*', fg, cell.bg);
+    }
+  }
+}

--- a/kingdom/render/hud.ts
+++ b/kingdom/render/hud.ts
@@ -1,0 +1,492 @@
+/**
+ * Kingdom - HUD rendering
+ * Top status bar, secondary bar (stamina/mount/wave), unit counts,
+ * wall health, blood moon warning, message log.
+ */
+
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  TimeOfDay,
+  Season,
+  TownCenterTier,
+  TowerTier,
+  WeatherType,
+  UnitRole,
+  StructureType,
+  MountType,
+  TileType,
+  MAP_WIDTH,
+  GROUND_Y,
+  COLOR_HUD_BG,
+  COLOR_HUD_TEXT,
+  COLOR_COIN,
+  COLOR_GREED,
+  COLOR_BUILDER,
+  COLOR_ARCHER,
+  COLOR_FARMER,
+  COLOR_WALL_WOOD,
+  CHAR_COIN,
+  NIGHT_START,
+  DUSK_START,
+  CAMP_CENTER_X,
+  TOWN_CENTER_COSTS,
+  TOWN_CENTER_NAMES,
+} from '../types';
+import { getNearbyInteractable } from '../game/economy';
+
+interface CellBufferDirect {
+  width: number;
+  height: number;
+  cells: { char: string; fg: number; bg: number }[][];
+  setCell: (x: number, y: number, char: string, fg: number, bg: number) => void;
+}
+
+const COLOR_MSG_FG = 0xcccc88ff;
+const COLOR_MSG_BG = 0x111111ff;
+const COLOR_WARN_FG = 0xff4444ff;
+const COLOR_HP_FULL = 0x44cc44ff;
+const COLOR_HP_MED = 0xcccc44ff;
+const COLOR_HP_LOW = 0xff4444ff;
+const COLOR_STAMINA = 0x44ccccff;
+
+const SEASON_NAMES: Record<Season, string> = {
+  [Season.Spring]: 'Spring',
+  [Season.Summer]: 'Summer',
+  [Season.Autumn]: 'Autumn',
+  [Season.Winter]: 'Winter',
+};
+
+const SEASON_COLORS: Record<Season, number> = {
+  [Season.Spring]: 0x44cc44ff,
+  [Season.Summer]: 0xffcc44ff,
+  [Season.Autumn]: 0xcc8833ff,
+  [Season.Winter]: 0x99bbddff,
+};
+
+function weatherIcon(w: WeatherType): string {
+  switch (w) {
+    case WeatherType.Rain: return '~';
+    case WeatherType.Snow: return '*';
+    case WeatherType.Storm: return '!';
+    default: return ' ';
+  }
+}
+
+const WEATHER_COLORS: Record<WeatherType, number> = {
+  [WeatherType.Clear]: 0x888888ff,
+  [WeatherType.Rain]: 0x4488bbff,
+  [WeatherType.Snow]: 0xddddffff,
+  [WeatherType.Storm]: 0xff4444ff,
+};
+
+function timeOfDayIcon(tod: TimeOfDay): string {
+  switch (tod) {
+    case TimeOfDay.Dawn: return '\u263C';
+    case TimeOfDay.Day: return '\u2600';
+    case TimeOfDay.Dusk: return '\u263D';
+    case TimeOfDay.Night: return '\u263E';
+  }
+}
+
+function writeString(buffer: CellBufferDirect, x: number, y: number, text: string, fg: number, bg: number): number {
+  for (let i = 0; i < text.length; i++) {
+    const col = x + i;
+    if (col >= 0 && col < buffer.width && y >= 0 && y < buffer.height) {
+      buffer.setCell(col, y, text[i]!, fg, bg);
+    }
+  }
+  return x + text.length;
+}
+
+function countByRole(units: { role: UnitRole }[], role: UnitRole): number {
+  let count = 0;
+  for (const u of units) {
+    if (u.role === role) count++;
+  }
+  return count;
+}
+
+function findOutermostWalls(structures: Map<number, StructureData>): { left: StructureData | null; right: StructureData | null } {
+  let leftWall: StructureData | null = null;
+  let rightWall: StructureData | null = null;
+
+  for (const [, s] of structures) {
+    if (s.type !== StructureType.WallWood && s.type !== StructureType.WallStone && s.type !== StructureType.WallIron) continue;
+    if (!leftWall || s.x < leftWall.x) leftWall = s;
+    if (!rightWall || s.x > rightWall.x) rightWall = s;
+  }
+
+  return { left: leftWall, right: rightWall };
+}
+
+function drawWallHpBar(buffer: CellBufferDirect, x: number, y: number, label: string, wall: StructureData | null, maxBarWidth: number, bg: number): number {
+  if (!wall) return x;
+
+  let cx = writeString(buffer, x, y, label, COLOR_WALL_WOOD, bg);
+  const ratio = wall.hp / wall.maxHp;
+  const filled = Math.ceil(ratio * maxBarWidth);
+  const barColor = ratio > 0.6 ? COLOR_HP_FULL : ratio > 0.3 ? COLOR_HP_MED : COLOR_HP_LOW;
+
+  for (let i = 0; i < maxBarWidth; i++) {
+    const ch = i < filled ? '\u2588' : '\u2591';
+    const fg = i < filled ? barColor : 0x444444ff;
+    if (cx < buffer.width) {
+      buffer.setCell(cx, y, ch, fg, bg);
+    }
+    cx++;
+  }
+
+  cx = writeString(buffer, cx, y, ` ${wall.hp}/${wall.maxHp} `, COLOR_HUD_TEXT, bg);
+  return cx;
+}
+
+/**
+ * Render the full HUD: top bar, secondary bar (stamina/mount/wave),
+ * unit counts, wall health, blood moon warning, and message log.
+ */
+export function renderHud(state: GameState, buffer: CellBufferDirect): void {
+  // Blood moon detection
+  const isBloodMoon = state.isBloodMoon;
+  const bloodMoonActive = isBloodMoon && state.dayTime >= NIGHT_START;
+  const hudBg = bloodMoonActive && Math.floor(state.totalElapsed * 3) % 2 === 0
+    ? 0x440000ff
+    : COLOR_HUD_BG;
+
+  // ─── Top bar (row 0) ───────────────────────────────────────────
+  const topY = 0;
+  for (let x = 0; x < buffer.width; x++) {
+    buffer.setCell(x, topY, ' ', COLOR_HUD_TEXT, hudBg);
+  }
+
+  let cx = 1;
+
+  // Coins
+  buffer.setCell(cx, topY, CHAR_COIN, COLOR_COIN, hudBg);
+  cx++;
+  cx = writeString(buffer, cx, topY, `${state.monarchCoins} `, COLOR_HUD_TEXT, hudBg);
+
+  // Separator
+  cx = writeString(buffer, cx, topY, '| ', COLOR_HUD_TEXT, hudBg);
+
+  // Day count
+  cx = writeString(buffer, cx, topY, `Day ${state.dayCount} `, COLOR_HUD_TEXT, hudBg);
+
+  // Season and season day
+  const seasonName = SEASON_NAMES[state.season];
+  const seasonColor = SEASON_COLORS[state.season];
+  cx = writeString(buffer, cx, topY, `${seasonName} D${state.seasonDay + 1} `, seasonColor, hudBg);
+
+  // Time of day icon
+  const icon = timeOfDayIcon(state.timeOfDay);
+  buffer.setCell(cx, topY, icon, COLOR_HUD_TEXT, hudBg);
+  cx++;
+
+  cx = writeString(buffer, cx, topY, ' | ', COLOR_HUD_TEXT, hudBg);
+
+  // Island
+  cx = writeString(buffer, cx, topY, `Isle ${state.islandIndex + 1} `, COLOR_HUD_TEXT, hudBg);
+
+  // Weather icon
+  if (state.weather !== WeatherType.Clear) {
+    const wIcon = weatherIcon(state.weather);
+    cx = writeString(buffer, cx, topY, wIcon, WEATHER_COLORS[state.weather], hudBg);
+    cx = writeString(buffer, cx, topY, ' ', COLOR_HUD_TEXT, hudBg);
+  }
+
+  // Gems
+  const gems = state.gems ?? 0;
+  if (gems > 0) {
+    cx = writeString(buffer, cx, topY, '\u25C6', 0x44ccffff, hudBg);
+    cx = writeString(buffer, cx, topY, `${gems} `, COLOR_HUD_TEXT, hudBg);
+  }
+
+  cx = writeString(buffer, cx, topY, '| ', COLOR_HUD_TEXT, hudBg);
+
+  // Unit counts
+  const builders = countByRole(state.units, UnitRole.Builder);
+  const archers = countByRole(state.units, UnitRole.Archer);
+  const farmers = countByRole(state.units, UnitRole.Farmer);
+  const vagrants = countByRole(state.units, UnitRole.Vagrant);
+
+  if (builders > 0) {
+    cx = writeString(buffer, cx, topY, '\u2692', COLOR_BUILDER, hudBg);
+    cx = writeString(buffer, cx, topY, `${builders} `, COLOR_HUD_TEXT, hudBg);
+  }
+  if (archers > 0) {
+    cx = writeString(buffer, cx, topY, '\u2694', COLOR_ARCHER, hudBg);
+    cx = writeString(buffer, cx, topY, `${archers} `, COLOR_HUD_TEXT, hudBg);
+  }
+  if (farmers > 0) {
+    cx = writeString(buffer, cx, topY, '\u2698', COLOR_FARMER, hudBg);
+    cx = writeString(buffer, cx, topY, `${farmers} `, COLOR_HUD_TEXT, hudBg);
+  }
+  if (vagrants > 0) {
+    cx = writeString(buffer, cx, topY, '\u263A', 0x888888ff, hudBg);
+    cx = writeString(buffer, cx, topY, `${vagrants} `, COLOR_HUD_TEXT, hudBg);
+  }
+
+  // Wall health
+  const walls = findOutermostWalls(state.structures);
+  if (walls.left || walls.right) {
+    cx = writeString(buffer, cx, topY, '| ', COLOR_HUD_TEXT, hudBg);
+    if (walls.left) {
+      cx = drawWallHpBar(buffer, cx, topY, 'L:', walls.left, 5, hudBg);
+    }
+    if (walls.right) {
+      cx = drawWallHpBar(buffer, cx, topY, 'R:', walls.right, 5, hudBg);
+    }
+  }
+
+  // Tower count and highest tier
+  let towerCount = 0;
+  let highestTier = TowerTier.None;
+  for (const [, s] of state.structures) {
+    if ((s.towerTier ?? TowerTier.None) > TowerTier.None) {
+      towerCount++;
+      if ((s.towerTier ?? TowerTier.None) > highestTier) highestTier = s.towerTier ?? TowerTier.None;
+    }
+  }
+  if (towerCount > 0) {
+    cx = writeString(buffer, cx, topY, '| ', COLOR_HUD_TEXT, hudBg);
+    cx = writeString(buffer, cx, topY, `T:${towerCount} `, 0x999999ff, hudBg);
+  }
+
+  // Crown dropped warning (flashing red)
+  if (state.crownDropped) {
+    const crownBlink = Math.floor(state.totalElapsed * 4) % 2 === 0;
+    if (crownBlink) {
+      cx = writeString(buffer, cx, topY, '| ', COLOR_HUD_TEXT, hudBg);
+      cx = writeString(buffer, cx, topY, 'Crown! ', COLOR_WARN_FG, hudBg);
+    }
+  }
+
+  // Blood moon warning (pulsing bright/dim red, right side of top bar)
+  if (isBloodMoon && state.dayTime >= NIGHT_START) {
+    const pulse = Math.sin(state.totalElapsed * 6) * 0.3 + 0.7;
+    const r = Math.floor(0xff * pulse);
+    const g = Math.floor(0x22 * pulse);
+    const pulseColor = ((r & 0xff) << 24) | ((g & 0xff) << 16) | (0x22 << 8) | 0xff;
+    const warnX = buffer.width - 13;
+    writeString(buffer, warnX, topY, ' BLOOD MOON ', pulseColor, 0x440000ff);
+  } else if (isBloodMoon && state.dayTime >= DUSK_START) {
+    const warnX = buffer.width - 16;
+    writeString(buffer, warnX, topY, ' Blood moon... ', COLOR_WARN_FG, hudBg);
+  }
+
+  // ─── Secondary bar (row 1): stamina, mount, wave count ─────────
+  const secY = 1;
+  for (let x = 0; x < buffer.width; x++) {
+    buffer.setCell(x, secY, ' ', COLOR_HUD_TEXT, hudBg);
+  }
+
+  let sx = 1;
+
+  // Mount name
+  if (state.mountType !== MountType.None) {
+    const mountName = state.mountType === MountType.Horse ? '\u265E Horse' : 'On foot';
+    sx = writeString(buffer, sx, secY, mountName, COLOR_COIN, hudBg);
+    sx = writeString(buffer, sx, secY, ' ', COLOR_HUD_TEXT, hudBg);
+  }
+
+  // Stamina bar
+  if (state.maxStamina > 0) {
+    sx = writeString(buffer, sx, secY, 'STA:', COLOR_STAMINA, hudBg);
+    const staminaRatio = state.stamina / state.maxStamina;
+    const staminaBarWidth = 10;
+    const staminaFilled = Math.ceil(staminaRatio * staminaBarWidth);
+    const staminaColor = staminaRatio > 0.5 ? COLOR_STAMINA : staminaRatio > 0.2 ? COLOR_HP_MED : COLOR_HP_LOW;
+
+    for (let i = 0; i < staminaBarWidth; i++) {
+      const ch = i < staminaFilled ? '\u2588' : '\u2591';
+      const fg = i < staminaFilled ? staminaColor : 0x444444ff;
+      if (sx < buffer.width) {
+        buffer.setCell(sx, secY, ch, fg, hudBg);
+      }
+      sx++;
+    }
+    sx = writeString(buffer, sx, secY, ' ', COLOR_HUD_TEXT, hudBg);
+  }
+
+  // Wave countdown at night
+  if (state.timeOfDay === TimeOfDay.Night && state.greeds.length > 0) {
+    sx = writeString(buffer, sx, secY, '| ', COLOR_HUD_TEXT, hudBg);
+    sx = writeString(buffer, sx, secY, `Greed: ${state.greeds.length} `, COLOR_GREED, hudBg);
+  }
+
+  // Town center info when monarch is near camp center (within 10 tiles)
+  const monarchX = state.monarch ? Math.round(getPosition(state.world, state.monarch.eid)?.x ?? -999) : -999;
+  const nearCenter = Math.abs(monarchX - CAMP_CENTER_X) <= 10;
+  if (nearCenter) {
+    const tierName = TOWN_CENTER_NAMES[state.townCenterTier];
+    sx = writeString(buffer, sx, secY, '| ', COLOR_HUD_TEXT, hudBg);
+    sx = writeString(buffer, sx, secY, `${tierName} `, COLOR_COIN, hudBg);
+
+    // Show upgrade cost if not max tier
+    if (state.townCenterTier < TownCenterTier.IronKeep) {
+      const nextTier = state.townCenterTier + 1;
+      const nextName = TOWN_CENTER_NAMES[nextTier];
+      const cost = TOWN_CENTER_COSTS[nextTier];
+      sx = writeString(buffer, sx, secY, `Up:${nextName}(${cost}\u25CF) `, 0x888888ff, hudBg);
+    }
+  }
+
+  // Nearby interactable prompt (right-aligned on secondary bar)
+  const interactable = getNearbyInteractable();
+  if (interactable) {
+    const promptX = buffer.width - interactable.length - 2;
+    if (promptX > sx) {
+      writeString(buffer, promptX, secY, interactable, 0xfffffffe, hudBg);
+    }
+  }
+
+  // ─── Minimap (top-right corner, 30x5, toggled with Tab) ────────
+  if (state.showMinimap) {
+    renderMinimap(state, buffer);
+  }
+
+  // ─── Bottom message log (last 3 rows) ──────────────────────────
+  const msgCount = 3;
+  const msgStartY = buffer.height - msgCount;
+  const recentMsgs = state.messages.slice(-msgCount);
+
+  for (let m = 0; m < msgCount; m++) {
+    const my = msgStartY + m;
+    if (my < 0 || my >= buffer.height) continue;
+
+    // Clear message row
+    for (let x = 0; x < buffer.width; x++) {
+      buffer.setCell(x, my, ' ', COLOR_MSG_FG, COLOR_MSG_BG);
+    }
+
+    const msg = recentMsgs[m];
+    if (msg) {
+      writeString(buffer, 1, my, msg.slice(0, buffer.width - 2), COLOR_MSG_FG, COLOR_MSG_BG);
+    }
+  }
+}
+
+// ─── Minimap Rendering ──────────────────────────────────────────
+
+const MINIMAP_W = 30;
+const MINIMAP_H = 5;
+const MINIMAP_BG = 0x111111ff;
+const MINIMAP_BORDER = 0x555555ff;
+
+const MINIMAP_WATER = 0x2244aaff;
+const MINIMAP_FOREST = 0x117722ff;
+const MINIMAP_CLEARED = 0x886633ff;
+const MINIMAP_STRUCTURE = 0xffcc00ff;
+const MINIMAP_PORTAL_ACTIVE = 0xff2266ff;
+const MINIMAP_PORTAL_DEAD = 0x555555ff;
+const MINIMAP_MONARCH = 0xfffffffe;
+
+function renderMinimap(state: GameState, buffer: CellBufferDirect): void {
+  const effectiveMapWidth = state.mapWidth ?? MAP_WIDTH;
+  const startX = buffer.width - MINIMAP_W - 3;
+  const startY = 2;
+
+  if (startX < 0 || startY + MINIMAP_H + 2 > buffer.height) return;
+
+  // Draw border
+  // Top border
+  buffer.setCell(startX, startY, '+', MINIMAP_BORDER, MINIMAP_BG);
+  for (let dx = 1; dx <= MINIMAP_W; dx++) {
+    buffer.setCell(startX + dx, startY, '-', MINIMAP_BORDER, MINIMAP_BG);
+  }
+  buffer.setCell(startX + MINIMAP_W + 1, startY, '+', MINIMAP_BORDER, MINIMAP_BG);
+
+  // Bottom border
+  const botY = startY + MINIMAP_H + 1;
+  buffer.setCell(startX, botY, '+', MINIMAP_BORDER, MINIMAP_BG);
+  for (let dx = 1; dx <= MINIMAP_W; dx++) {
+    buffer.setCell(startX + dx, botY, '-', MINIMAP_BORDER, MINIMAP_BG);
+  }
+  buffer.setCell(startX + MINIMAP_W + 1, botY, '+', MINIMAP_BORDER, MINIMAP_BG);
+
+  // Side borders + fill interior
+  for (let dy = 1; dy <= MINIMAP_H; dy++) {
+    const my = startY + dy;
+    buffer.setCell(startX, my, '|', MINIMAP_BORDER, MINIMAP_BG);
+    for (let dx = 1; dx <= MINIMAP_W; dx++) {
+      buffer.setCell(startX + dx, my, ' ', MINIMAP_BG, MINIMAP_BG);
+    }
+    buffer.setCell(startX + MINIMAP_W + 1, my, '|', MINIMAP_BORDER, MINIMAP_BG);
+  }
+
+  // Map scale: compress entire map to MINIMAP_W columns x MINIMAP_H rows
+  const scaleX = effectiveMapWidth / MINIMAP_W;
+  // Terrain sampling: use ground level row for a 1D cross-section approach,
+  // and also sample a few rows above for forest detection
+  const sampleRows = [GROUND_Y - 3, GROUND_Y - 1, GROUND_Y, GROUND_Y + 1, GROUND_Y + 2];
+
+  for (let mx = 0; mx < MINIMAP_W; mx++) {
+    const worldX = Math.floor(mx * scaleX);
+    for (let my = 0; my < MINIMAP_H; my++) {
+      const sampleY = sampleRows[my];
+      if (sampleY === undefined) continue;
+      const tile = state.tiles[sampleY]?.[worldX];
+      let ch = '.';
+      let fg = MINIMAP_CLEARED;
+
+      if (tile === TileType.Water) {
+        ch = '~'; fg = MINIMAP_WATER;
+      } else if (tile === TileType.Forest) {
+        ch = '#'; fg = MINIMAP_FOREST;
+      } else if (tile === TileType.Grass || tile === TileType.ClearedLand) {
+        ch = '.'; fg = MINIMAP_CLEARED;
+      } else if (tile === TileType.Mountain) {
+        ch = '^'; fg = 0x887766ff;
+      } else if (tile === TileType.Swamp) {
+        ch = '~'; fg = 0x226644ff;
+      } else if (tile === TileType.Sky) {
+        ch = ' '; fg = MINIMAP_BG;
+      }
+
+      buffer.setCell(startX + 1 + mx, startY + 1 + my, ch, fg, MINIMAP_BG);
+    }
+  }
+
+  // Overlay structures (yellow dots)
+  for (const [, s] of state.structures) {
+    if (s.type === StructureType.Portal) continue; // portals handled separately
+    const mmx = Math.floor(s.x / scaleX);
+    if (mmx >= 0 && mmx < MINIMAP_W) {
+      buffer.setCell(startX + 1 + mmx, startY + 1 + Math.floor(MINIMAP_H / 2), '.', MINIMAP_STRUCTURE, MINIMAP_BG);
+    }
+  }
+
+  // Overlay portals (red = active, gray = destroyed)
+  const activePortals = new Set(state.portalPositions);
+  for (const px of state.portalPositions) {
+    const mmx = Math.floor(px / scaleX);
+    if (mmx >= 0 && mmx < MINIMAP_W) {
+      // Check if portal still exists (has hp > 0)
+      const portal = state.structures.get(px);
+      const alive = portal && portal.hp > 0;
+      const color = alive ? MINIMAP_PORTAL_ACTIVE : MINIMAP_PORTAL_DEAD;
+      buffer.setCell(startX + 1 + mmx, startY + 1 + Math.floor(MINIMAP_H / 2), '*', color, MINIMAP_BG);
+    }
+  }
+
+  // Overlay monarch position (white blinking dot)
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (monarchPos) {
+    const mmx = Math.floor(monarchPos.x / scaleX);
+    if (mmx >= 0 && mmx < MINIMAP_W) {
+      const blink = Math.floor(state.totalElapsed * 3) % 2 === 0;
+      if (blink) {
+        buffer.setCell(startX + 1 + mmx, startY + 1 + Math.floor(MINIMAP_H / 2), '@', MINIMAP_MONARCH, MINIMAP_BG);
+      }
+    }
+  }
+
+  // Overlay camera viewport indicator (highlighted region on bottom row)
+  const viewStartMM = Math.floor(state.cameraX / scaleX);
+  const viewEndMM = Math.floor((state.cameraX + state.viewWidth) / scaleX);
+  const indicatorY = startY + MINIMAP_H;
+  for (let mx = Math.max(0, viewStartMM); mx <= Math.min(MINIMAP_W - 1, viewEndMM); mx++) {
+    buffer.setCell(startX + 1 + mx, indicatorY, '=', 0xfffffffe, MINIMAP_BG);
+  }
+}

--- a/kingdom/render/renderer.ts
+++ b/kingdom/render/renderer.ts
@@ -1,0 +1,1691 @@
+/**
+ * Kingdom - Main renderer
+ * Phase-aware rendering: Title screen, Playing (with parallax), Game Over.
+ * Dirty-rect double-buffered ANSI output.
+ */
+
+import { createCellBuffer, getPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  TileType,
+  StructureType,
+  TimeOfDay,
+  Season,
+  TownCenterTier,
+  UnitRole,
+  GreedType,
+  GamePhase,
+  MountType,
+  ConsumableType,
+  WeatherType,
+  TowerTier,
+  TOWER_ARCHER_CAPACITY,
+  CAMP_CENTER_X,
+  CHAR_CROWN,
+  MAP_WIDTH,
+  GROUND_Y,
+  COLOR_SKY_DAY,
+  COLOR_SKY_DUSK,
+  COLOR_SKY_NIGHT,
+  COLOR_SKY_DAWN,
+  COLOR_GROUND,
+  COLOR_DIRT,
+  COLOR_WATER,
+  COLOR_TREE_TRUNK,
+  COLOR_TREE_LEAVES,
+  COLOR_WALL_WOOD,
+  COLOR_WALL_STONE,
+  COLOR_WALL_IRON,
+  COLOR_MONARCH,
+  COLOR_VILLAGER,
+  COLOR_BUILDER,
+  COLOR_ARCHER,
+  COLOR_FARMER,
+  COLOR_GREED,
+  COLOR_GREED_MASK,
+  COLOR_PORTAL,
+  COLOR_COIN,
+  COLOR_FARM,
+  COLOR_SHRINE,
+  COLOR_BG,
+  CHAR_MONARCH,
+  CHAR_VILLAGER,
+  CHAR_BUILDER,
+  CHAR_ARCHER,
+  CHAR_FARMER,
+  CHAR_GREED,
+  CHAR_GREED_MASK,
+  CHAR_PORTAL,
+  CHAR_WALL,
+  CHAR_WALL_DAMAGED,
+  CHAR_TREE_TRUNK,
+  CHAR_GRASS,
+  CHAR_WATER,
+  CHAR_COIN,
+  CHAR_FARM,
+  CHAR_SHRINE,
+  CHAR_ARROW,
+  CHAR_HORSE,
+  ISLAND_NAMES,
+  AIState,
+  DAY_START,
+  DUSK_START,
+  NIGHT_START,
+  worldToScreen,
+  isOnScreen,
+  distance,
+} from '../types';
+import { getBiome, Biome } from '../world/terrain';
+import { getAnimals } from '../entities/animals';
+import { getDroppedCoins } from '../systems/combat';
+import { getBlueprints } from '../systems/construction';
+import { getNpcOrigin, NpcOrigin } from '../entities/villager';
+import { getAvailableHermits, type HermitData, HermitType, getRidingHermit } from '../entities/hermit';
+import { getStatues, type StatueData, BlessingType, getStatueConfig } from '../entities/statue';
+import { getDogX, isDogBarking } from '../entities/dog';
+import { renderHud } from './hud';
+import { applyNightOverlay, updateWaveFlash, updateSparkles, renderWeather, updateCoinSparkles, renderCoinSparkles } from './effects';
+
+// ─── CellBuffer Interface ─────────────────────────────────────────
+
+interface CellBufferDirect {
+  width: number;
+  height: number;
+  cells: { char: string; fg: number; bg: number }[][];
+  setCell: (x: number, y: number, char: string, fg: number, bg: number) => void;
+}
+
+// ─── Double-Buffer State ──────────────────────────────────────────
+
+let currentBuffer: CellBufferDirect | null = null;
+let prevBuffer: CellBufferDirect | null = null;
+let bufferWidth = 0;
+let bufferHeight = 0;
+
+function ensureBuffer(width: number, height: number): CellBufferDirect {
+  if (!currentBuffer || bufferWidth !== width || bufferHeight !== height) {
+    currentBuffer = createCellBuffer(width, height) as CellBufferDirect;
+    prevBuffer = null;
+    bufferWidth = width;
+    bufferHeight = height;
+  }
+  return currentBuffer;
+}
+
+function fillRect(
+  buffer: CellBufferDirect,
+  x: number, y: number, w: number, h: number,
+  char: string, fg: number, bg: number,
+): void {
+  for (let row = y; row < y + h && row < buffer.height; row++) {
+    if (row < 0) continue;
+    for (let col = x; col < x + w && col < buffer.width; col++) {
+      if (col < 0) continue;
+      buffer.setCell(col, row, char, fg, bg);
+    }
+  }
+}
+
+function writeStringCentered(buffer: CellBufferDirect, y: number, text: string, fg: number, bg: number): void {
+  const startX = Math.floor((buffer.width - text.length) / 2);
+  for (let i = 0; i < text.length; i++) {
+    const col = startX + i;
+    if (col >= 0 && col < buffer.width && y >= 0 && y < buffer.height) {
+      buffer.setCell(col, y, text[i]!, fg, bg);
+    }
+  }
+}
+
+function writeString(buffer: CellBufferDirect, x: number, y: number, text: string, fg: number, bg: number): void {
+  for (let i = 0; i < text.length; i++) {
+    const col = x + i;
+    if (col >= 0 && col < buffer.width && y >= 0 && y < buffer.height) {
+      buffer.setCell(col, y, text[i]!, fg, bg);
+    }
+  }
+}
+
+// ─── Parallax: Star Field ─────────────────────────────────────────
+
+interface Star {
+  x: number;
+  y: number;
+  char: string;
+  brightness: number;
+}
+
+let stars: Star[] | null = null;
+
+function generateStars(): Star[] {
+  const result: Star[] = [];
+  const STAR_CHARS = ['.', '\u00B7', '+', '\u2022', '*'];
+  // Deterministic pseudo-random using a simple seed
+  let seed = 42;
+  const rand = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return (seed >> 16) / 32768.0;
+  };
+
+  for (let i = 0; i < 120; i++) {
+    result.push({
+      x: Math.floor(rand() * MAP_WIDTH * 2), // Wider than map for parallax
+      y: Math.floor(rand() * (GROUND_Y - 2)) + 1, // In sky region, below HUD
+      char: STAR_CHARS[Math.floor(rand() * STAR_CHARS.length)]!,
+      brightness: 0.3 + rand() * 0.7,
+    });
+  }
+  return result;
+}
+
+// ─── Parallax: Cloud Layer ────────────────────────────────────────
+
+interface Cloud {
+  x: number;
+  y: number;
+  width: number;
+}
+
+let clouds: Cloud[] | null = null;
+
+function generateClouds(): Cloud[] {
+  const result: Cloud[] = [];
+  let seed = 99;
+  const rand = () => {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    return (seed >> 16) / 32768.0;
+  };
+
+  for (let i = 0; i < 15; i++) {
+    result.push({
+      x: Math.floor(rand() * MAP_WIDTH * 2),
+      y: 2 + Math.floor(rand() * 6),
+      width: 4 + Math.floor(rand() * 8),
+    });
+  }
+  return result;
+}
+
+// ─── Foreground grass detail chars ────────────────────────────────
+
+const GRASS_DETAILS = [',', '\'', '`', '"', ';'];
+
+// ─── Color Interpolation ────────────────────────────────────────
+
+function lerpColor(a: number, b: number, t: number): number {
+  const ar = (a >> 24) & 0xff, ag = (a >> 16) & 0xff, ab = (a >> 8) & 0xff;
+  const br = (b >> 24) & 0xff, bg = (b >> 16) & 0xff, bb = (b >> 8) & 0xff;
+  const r = Math.floor(ar + (br - ar) * t);
+  const g = Math.floor(ag + (bg - ag) * t);
+  const bl = Math.floor(ab + (bb - ab) * t);
+  return ((r & 0xff) << 24) | ((g & 0xff) << 16) | ((bl & 0xff) << 8) | 0xff;
+}
+
+function interpolateSkyColor(dayTime: number, season: Season): number {
+  const dawn = SEASONAL_SKY[season][TimeOfDay.Dawn];
+  const day = SEASONAL_SKY[season][TimeOfDay.Day];
+  const dusk = SEASONAL_SKY[season][TimeOfDay.Dusk];
+  const night = SEASONAL_SKY[season][TimeOfDay.Night];
+
+  if (dayTime < DAY_START) {
+    const t = dayTime / DAY_START;
+    return t < 0.5 ? lerpColor(night, dawn, t * 2) : lerpColor(dawn, day, (t - 0.5) * 2);
+  }
+  if (dayTime < DUSK_START) return day;
+  if (dayTime < NIGHT_START) {
+    const t = (dayTime - DUSK_START) / (NIGHT_START - DUSK_START);
+    return t < 0.5 ? lerpColor(day, dusk, t * 2) : lerpColor(dusk, night, (t - 0.5) * 2);
+  }
+  return night;
+}
+
+// ─── Tile Rendering Helpers ───────────────────────────────────────
+
+// Seasonal sky color table: [season][timeOfDay]
+const SEASONAL_SKY: Record<Season, Record<TimeOfDay, number>> = {
+  [Season.Spring]: {
+    [TimeOfDay.Dawn]: 0x446688ff,
+    [TimeOfDay.Day]: 0x5599ccff,
+    [TimeOfDay.Dusk]: 0x884466ff,
+    [TimeOfDay.Night]: 0x112233ff,
+  },
+  [Season.Summer]: {
+    [TimeOfDay.Dawn]: 0x558899ff,
+    [TimeOfDay.Day]: 0x66aaddff,
+    [TimeOfDay.Dusk]: 0x995544ff,
+    [TimeOfDay.Night]: 0x0a1a2aff,
+  },
+  [Season.Autumn]: {
+    [TimeOfDay.Dawn]: 0x665544ff,
+    [TimeOfDay.Day]: 0x889988ff,
+    [TimeOfDay.Dusk]: 0x774433ff,
+    [TimeOfDay.Night]: 0x111122ff,
+  },
+  [Season.Winter]: {
+    [TimeOfDay.Dawn]: 0x889999ff,
+    [TimeOfDay.Day]: 0x99aabbff,
+    [TimeOfDay.Dusk]: 0x667788ff,
+    [TimeOfDay.Night]: 0x0a0a1aff,
+  },
+};
+
+function getSkyColor(phase: TimeOfDay, season: Season): number {
+  return SEASONAL_SKY[season][phase];
+}
+
+// Blood moon sky override
+const BLOOD_MOON_SKY = 0x331111ff;
+
+// Season-adjusted terrain colors
+function seasonalGrassFg(season: Season): number {
+  switch (season) {
+    case Season.Autumn: return 0xbb9944ff;
+    case Season.Winter: return 0xccccddff;
+    default: return COLOR_GROUND;
+  }
+}
+
+function seasonalGrassBg(season: Season): number {
+  switch (season) {
+    case Season.Winter: return 0xddddffff;
+    default: return 0x115511ff;
+  }
+}
+
+function seasonalForestFg(season: Season): number {
+  switch (season) {
+    case Season.Autumn: return 0xcc5533ff;
+    case Season.Winter: return 0x99aabbff;
+    default: return COLOR_TREE_LEAVES;
+  }
+}
+
+// Town center visual data: [chars, fgColor]
+const TOWN_CENTER_VISUALS: [string, number][] = [
+  ['.', 0x555555ff],        // Ruins
+  ['*', 0xff8833ff],        // Campfire (handled specially for flicker)
+  ['#*', 0xaa7744ff],       // Camp
+  ['|#|', 0xbb8844ff],     // Village
+  ['|##|', 0x999999ff],    // Town Hall
+  ['[###]', 0x888888ff],   // Stone Fort
+  ['|[###]|', 0xcc9944ff], // Castle
+  ['{[###]}', 0xaaaabbff], // Iron Keep
+];
+
+// Tower tier visual data: [chars, fgColor]
+const TOWER_VISUALS: [string, number][] = [
+  ['', 0x000000ff],         // None
+  ['=', 0x886633ff],        // Rock Platform (brown)
+  ['T', 0x886633ff],        // Wood Watchtower
+  ['T', 0x999999ff],        // Stone Tower (gray)
+  ['TTT', 0x999999ff],      // Triplet (3 wide)
+  ['^T^', 0x888888ff],      // Roofed Triplet
+  ['^TT^', 0xaaaabbff],     // Quadruplet (4 wide with roof)
+];
+
+function tileChar(tile: TileType): string {
+  switch (tile) {
+    case TileType.Grass: return CHAR_GRASS;
+    case TileType.Dirt: return CHAR_GRASS;
+    case TileType.Water: return CHAR_WATER;
+    case TileType.Forest: return '\u2660';
+    case TileType.ClearedLand: return '.';
+    case TileType.Swamp: return CHAR_GRASS;
+    case TileType.Mountain: return '^';
+    case TileType.Ruins: return '\u2500'; // horizontal line
+    default: return ' ';
+  }
+}
+
+function tileFg(tile: TileType): number {
+  switch (tile) {
+    case TileType.Grass: return COLOR_GROUND;
+    case TileType.Dirt: return COLOR_DIRT;
+    case TileType.Water: return COLOR_WATER;
+    case TileType.Forest: return COLOR_TREE_LEAVES;
+    case TileType.ClearedLand: return COLOR_GROUND;
+    case TileType.Swamp: return 0x116622ff;
+    case TileType.Mountain: return 0x887766ff;
+    case TileType.Ruins: return 0x444444ff;
+    default: return COLOR_BG;
+  }
+}
+
+function tileBg(tile: TileType): number {
+  switch (tile) {
+    case TileType.Grass: return 0x115511ff;
+    case TileType.Dirt: return 0x442211ff;
+    case TileType.Water: return 0x112255ff;
+    case TileType.Forest: return 0x0a3311ff;
+    case TileType.ClearedLand: return 0x335522ff;
+    case TileType.Swamp: return 0x0a2211ff;
+    case TileType.Mountain: return 0x666655ff;
+    case TileType.Ruins: return 0x222222ff;
+    default: return COLOR_BG;
+  }
+}
+
+function structureChar(s: StructureData): string {
+  // Under construction: hp=0 but maxHp>0
+  if (s.hp === 0 && s.maxHp > 0) return '-';
+
+  switch (s.type) {
+    case StructureType.WallWood:
+    case StructureType.WallStone:
+    case StructureType.WallIron:
+      return s.hp < s.maxHp * 0.5 ? CHAR_WALL_DAMAGED : CHAR_WALL;
+    case StructureType.Farm:
+    case StructureType.FarmIrrigated:
+    case StructureType.FarmWindmill:
+      return CHAR_FARM;
+    case StructureType.Portal: return CHAR_PORTAL;
+    case StructureType.Shrine: return CHAR_SHRINE;
+    case StructureType.BowStand: return ')';
+    case StructureType.HammerStand: return 'T';
+    case StructureType.Campfire: return '*';
+    default: return '?';
+  }
+}
+
+function structureFg(s: StructureData): number {
+  switch (s.type) {
+    case StructureType.WallWood: return COLOR_WALL_WOOD;
+    case StructureType.WallStone: return COLOR_WALL_STONE;
+    case StructureType.WallIron: return COLOR_WALL_IRON;
+    case StructureType.Farm:
+    case StructureType.FarmIrrigated:
+    case StructureType.FarmWindmill:
+      return COLOR_FARM;
+    case StructureType.Portal: return COLOR_PORTAL;
+    case StructureType.Shrine: return COLOR_SHRINE;
+    case StructureType.BowStand: return COLOR_ARCHER;
+    case StructureType.HammerStand: return COLOR_BUILDER;
+    case StructureType.Campfire: return 0xff8833ff;
+    default: return 0xffffffff;
+  }
+}
+
+function unitChar(role: UnitRole): string {
+  switch (role) {
+    case UnitRole.Monarch: return CHAR_MONARCH;
+    case UnitRole.Vagrant: return CHAR_VILLAGER;
+    case UnitRole.Builder: return CHAR_BUILDER;
+    case UnitRole.Archer: return CHAR_ARCHER;
+    case UnitRole.Farmer: return CHAR_FARMER;
+    case UnitRole.Knight: return CHAR_MONARCH;
+    case UnitRole.Pikeman: return CHAR_ARCHER;
+    case UnitRole.Squire: return CHAR_MONARCH;
+  }
+}
+
+function unitFg(role: UnitRole): number {
+  switch (role) {
+    case UnitRole.Monarch: return COLOR_MONARCH;
+    case UnitRole.Vagrant: return COLOR_VILLAGER;
+    case UnitRole.Builder: return COLOR_BUILDER;
+    case UnitRole.Archer: return COLOR_ARCHER;
+    case UnitRole.Farmer: return COLOR_FARMER;
+    case UnitRole.Knight: return COLOR_MONARCH;
+    case UnitRole.Pikeman: return COLOR_BUILDER;
+    case UnitRole.Squire: return COLOR_FARMER;
+  }
+}
+
+// ─── Title Screen ─────────────────────────────────────────────────
+
+const TITLE_ART = [
+  ' \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2557\u2588\u2588\u2557   \u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2588\u2588\u2557   \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2557   \u2588\u2588\u2588\u2557',
+  ' \u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551\u2588\u2588\u2551\u2588\u2588\u2554\u255D \u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255D \u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557 \u2588\u2588\u2554\u2550\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2551',
+  ' \u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255D\u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2551\u2588\u2588\u2588\u2557 \u2588\u2588\u2551  \u2588\u2588\u2551 \u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2554\u2588\u2588\u2588\u2588\u2554\u2588\u2588\u2551',
+  ' \u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u255D  \u2588\u2588\u2551\u2550\u2550\u2588\u2588\u2551\u2588\u2588\u2551  \u2588\u2588\u2551 \u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2551\u255A\u2588\u2588\u2554\u255D\u2588\u2588\u2551',
+  ' \u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2551\u2588\u2588\u2551\u2588\u2588\u2557  \u255A\u2588\u2588\u2588\u2588\u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255D \u255A\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255D\u2588\u2588\u2551 \u255A\u2550\u255D \u2588\u2588\u2551',
+  ' \u255A\u2550\u255D  \u255A\u2550\u255D\u255A\u2550\u255D\u255A\u2550\u255D\u255A\u2550\u255D   \u255A\u2550\u2550\u2550\u2550\u2550\u255D\u255A\u2550\u2550\u2550\u2550\u2550\u255D   \u255A\u2550\u2550\u2550\u2550\u2550\u255D \u255A\u2550\u255D     \u255A\u2550\u255D',
+];
+
+function renderTitleScreen(buffer: CellBufferDirect, totalElapsed: number): void {
+  fillRect(buffer, 0, 0, buffer.width, buffer.height, ' ', 0xffffffff, 0x0a0a1aff);
+
+  // Animated star background
+  const titleStars = stars ?? (stars = generateStars());
+  for (const star of titleStars) {
+    const twinkle = Math.sin(totalElapsed * 2 + star.x * 0.1) * 0.3 + 0.7;
+    const b = Math.floor(star.brightness * twinkle * 255);
+    const sx = (star.x + Math.floor(totalElapsed * 3)) % buffer.width;
+    const fg = ((b & 0xff) << 24) | ((b & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
+    if (star.y >= 0 && star.y < buffer.height && sx >= 0 && sx < buffer.width) {
+      buffer.setCell(sx, star.y, star.char, fg, 0x0a0a1aff);
+    }
+  }
+
+  // Title art
+  const titleStartY = Math.floor(buffer.height / 2) - 5;
+  const flicker = Math.sin(totalElapsed * 4) * 0.1 + 0.9;
+  const goldR = Math.floor(255 * flicker);
+  const goldG = Math.floor(200 * flicker);
+  const titleColor = ((goldR & 0xff) << 24) | ((goldG & 0xff) << 16) | (0x00 << 8) | 0xff;
+
+  for (let row = 0; row < TITLE_ART.length; row++) {
+    const line = TITLE_ART[row]!;
+    writeStringCentered(buffer, titleStartY + row, line, titleColor, 0x0a0a1aff);
+  }
+
+  // Subtitle
+  const subtitleY = titleStartY + TITLE_ART.length + 2;
+  writeStringCentered(buffer, subtitleY, 'A Kingdom: Two Crowns Tribute', 0x888899ff, 0x0a0a1aff);
+
+  // Menu options
+  const menuY = subtitleY + 3;
+  writeStringCentered(buffer, menuY, '[N] New Game    [C] Continue    [Q] Quit', 0xfffffffe, 0x0a0a1aff);
+
+  // Blinking cursor on menu
+  const blink = Math.floor(totalElapsed * 2) % 2 === 0;
+  if (blink) {
+    writeStringCentered(buffer, menuY + 2, '\u25B6', 0xffcc00ff, 0x0a0a1aff);
+  }
+
+  // Controls hint
+  const controlsY = buffer.height - 3;
+  writeStringCentered(buffer, controlsY, 'Arrow Keys: Move  |  Shift: Sprint  |  Space: Drop Coin  |  Q: Quit', 0x555577ff, 0x0a0a1aff);
+}
+
+// ─── Game Over Screen ─────────────────────────────────────────────
+
+function renderGameOverScreen(buffer: CellBufferDirect, state: GameState): void {
+  fillRect(buffer, 0, 0, buffer.width, buffer.height, ' ', 0xffffffff, 0x1a0505ff);
+
+  const centerY = Math.floor(buffer.height / 2);
+  const COLOR_RED = 0xff3333ff;
+  const COLOR_DIM = 0x884444ff;
+
+  // Main message
+  writeStringCentered(buffer, centerY - 4, '\u2620  YOUR CROWN HAS BEEN LOST  \u2620', COLOR_RED, 0x1a0505ff);
+
+  // Divider
+  const divider = '\u2500'.repeat(40);
+  writeStringCentered(buffer, centerY - 2, divider, COLOR_DIM, 0x1a0505ff);
+
+  // Stats
+  writeStringCentered(buffer, centerY, `Days Survived: ${state.dayCount}`, 0xccaaaaff, 0x1a0505ff);
+  writeStringCentered(buffer, centerY + 1, `Island: ${state.islandIndex + 1}`, 0xccaaaaff, 0x1a0505ff);
+  writeStringCentered(buffer, centerY + 2, `Subjects: ${state.units.length}`, 0xccaaaaff, 0x1a0505ff);
+
+  // Divider
+  writeStringCentered(buffer, centerY + 4, divider, COLOR_DIM, 0x1a0505ff);
+
+  // Restart prompt
+  const blink = Math.floor(state.totalElapsed * 2) % 2 === 0;
+  if (blink) {
+    writeStringCentered(buffer, centerY + 6, '[ Press R to restart  |  Q to quit ]', 0xfffffffe, 0x1a0505ff);
+  }
+}
+
+// ─── Victory Screen ──────────────────────────────────────────────
+
+function renderVictoryScreen(buffer: CellBufferDirect, state: GameState): void {
+  fillRect(buffer, 0, 0, buffer.width, buffer.height, ' ', 0xffffffff, 0x0a0a05ff);
+
+  const centerY = Math.floor(buffer.height / 2);
+  const COLOR_GOLD = 0xffcc00ff;
+  const COLOR_DIM_GOLD = 0x886600ff;
+
+  // Main message
+  writeStringCentered(buffer, centerY - 4, '\u2655  THE KINGDOM IS SECURED  \u2655', COLOR_GOLD, 0x0a0a05ff);
+
+  // Divider
+  const divider = '\u2550'.repeat(40);
+  writeStringCentered(buffer, centerY - 2, divider, COLOR_DIM_GOLD, 0x0a0a05ff);
+
+  // Stats
+  writeStringCentered(buffer, centerY, `Days Survived: ${state.dayCount}`, 0xcccc88ff, 0x0a0a05ff);
+  writeStringCentered(buffer, centerY + 1, `Island: ${state.islandIndex + 1}`, 0xcccc88ff, 0x0a0a05ff);
+  writeStringCentered(buffer, centerY + 2, `Subjects: ${state.units.length}`, 0xcccc88ff, 0x0a0a05ff);
+  writeStringCentered(buffer, centerY + 3, `Greeds Defeated: ${state.greeds.length === 0 ? 'All' : state.greeds.length + ' remain'}`, 0xcccc88ff, 0x0a0a05ff);
+
+  // Divider
+  writeStringCentered(buffer, centerY + 5, divider, COLOR_DIM_GOLD, 0x0a0a05ff);
+
+  // Prompt
+  const blink = Math.floor(state.totalElapsed * 2) % 2 === 0;
+  if (blink) {
+    writeStringCentered(buffer, centerY + 7, '[ Press R to restart  |  Q to quit ]', 0xfffffffe, 0x0a0a05ff);
+  }
+}
+
+// ─── Island Select Screen ────────────────────────────────────────
+
+function renderIslandSelectScreen(buffer: CellBufferDirect, state: GameState): void {
+  fillRect(buffer, 0, 0, buffer.width, buffer.height, ' ', 0xffffffff, 0x0a0a1aff);
+
+  const centerY = Math.floor(buffer.height / 2) - 4;
+  writeStringCentered(buffer, centerY, 'SELECT YOUR ISLAND', 0xffcc00ff, 0x0a0a1aff);
+
+  const divider = '\u2550'.repeat(40);
+  writeStringCentered(buffer, centerY + 2, divider, 0x555577ff, 0x0a0a1aff);
+
+  // Draw 5 islands in a horizontal row
+  const islandW = 12;
+  const totalW = islandW * 5 + 4 * 2; // 5 islands + 4 gaps
+  const startX = Math.floor((buffer.width - totalW) / 2);
+  const islandY = centerY + 4;
+
+  for (let i = 0; i < 5; i++) {
+    const ix = startX + i * (islandW + 2);
+    const name = ISLAND_NAMES[i] ?? `Island ${i + 1}`;
+    const isUnlocked = state.islandUnlocked[i] ?? false;
+    const isSelected = state.selectedIsland === i;
+
+    // Status
+    let status: string;
+    let statusColor: number;
+    if (!isUnlocked) {
+      status = 'LOCKED';
+      statusColor = 0x555555ff;
+    } else if (i === state.islandIndex) {
+      status = 'ACTIVE';
+      statusColor = 0x44cc44ff;
+    } else {
+      status = 'OPEN';
+      statusColor = 0x44aaffff;
+    }
+
+    // Island box
+    const boxBg = isSelected ? 0x222244ff : 0x0a0a1aff;
+    const borderChar = isSelected ? '\u2588' : '.';
+    const borderColor = isSelected ? 0xffcc00ff : (isUnlocked ? 0x555577ff : 0x333333ff);
+
+    // Top border
+    for (let dx = 0; dx < islandW; dx++) {
+      if (ix + dx >= 0 && ix + dx < buffer.width && islandY >= 0) {
+        buffer.setCell(ix + dx, islandY, dx === 0 || dx === islandW - 1 ? '+' : '-', borderColor, boxBg);
+      }
+    }
+
+    // Name (centered in box)
+    const nameStr = name.slice(0, islandW - 2);
+    const nameX = ix + 1 + Math.floor((islandW - 2 - nameStr.length) / 2);
+    const nameFg = isUnlocked ? 0xfffffffe : 0x555555ff;
+    writeString(buffer, nameX, islandY + 1, nameStr, nameFg, boxBg);
+
+    // Island number
+    writeString(buffer, ix + 1, islandY + 2, `  Isle ${i + 1}  `, 0x888899ff, boxBg);
+
+    // Status
+    const statusStr = `[${status}]`;
+    const statX = ix + 1 + Math.floor((islandW - 2 - statusStr.length) / 2);
+    writeString(buffer, statX, islandY + 3, statusStr, statusColor, boxBg);
+
+    // Stats (if unlocked)
+    if (isUnlocked && state.islandStats[i]) {
+      const stats = state.islandStats[i];
+      writeString(buffer, ix + 1, islandY + 4, `P:${stats.portalsDestroyed}`, 0x888888ff, boxBg);
+      writeString(buffer, ix + 5, islandY + 4, `D:${stats.daysVisited}`, 0x888888ff, boxBg);
+    }
+
+    // Bottom border
+    for (let dx = 0; dx < islandW; dx++) {
+      if (ix + dx >= 0 && ix + dx < buffer.width && islandY + 5 < buffer.height) {
+        buffer.setCell(ix + dx, islandY + 5, dx === 0 || dx === islandW - 1 ? '+' : '-', borderColor, boxBg);
+      }
+    }
+
+    // Selection arrow
+    if (isSelected) {
+      const arrowX = ix + Math.floor(islandW / 2);
+      if (arrowX >= 0 && arrowX < buffer.width && islandY + 6 < buffer.height) {
+        const blink = Math.floor(state.totalElapsed * 3) % 2 === 0;
+        if (blink) {
+          buffer.setCell(arrowX, islandY + 6, '\u25B2', 0xffcc00ff, 0x0a0a1aff);
+        }
+      }
+    }
+  }
+
+  // Controls hint
+  const controlsY = islandY + 8;
+  if (controlsY < buffer.height) {
+    writeStringCentered(buffer, controlsY, 'Left/Right: Select  |  Enter: Embark  |  Q: Back', 0x888899ff, 0x0a0a1aff);
+  }
+}
+
+// ─── Pause Screen Overlay ────────────────────────────────────────
+
+function renderPauseOverlay(buffer: CellBufferDirect): void {
+  // Dim the entire screen by 50%
+  for (let y = 0; y < buffer.height; y++) {
+    const row = buffer.cells[y];
+    if (!row) continue;
+    for (let x = 0; x < buffer.width; x++) {
+      const cell = row[x];
+      if (!cell) continue;
+      const bgR = Math.floor(((cell.bg >> 24) & 0xff) * 0.5);
+      const bgG = Math.floor(((cell.bg >> 16) & 0xff) * 0.5);
+      const bgB = Math.floor(((cell.bg >> 8) & 0xff) * 0.5);
+      cell.bg = ((bgR & 0xff) << 24) | ((bgG & 0xff) << 16) | ((bgB & 0xff) << 8) | 0xff;
+      const fgR = Math.floor(((cell.fg >> 24) & 0xff) * 0.5);
+      const fgG = Math.floor(((cell.fg >> 16) & 0xff) * 0.5);
+      const fgB = Math.floor(((cell.fg >> 8) & 0xff) * 0.5);
+      cell.fg = ((fgR & 0xff) << 24) | ((fgG & 0xff) << 16) | ((fgB & 0xff) << 8) | 0xff;
+    }
+  }
+
+  const centerY = Math.floor(buffer.height / 2);
+  const pauseBg = 0x111111ff;
+
+  // Draw background box
+  const boxW = 30;
+  const boxH = 5;
+  const boxX = Math.floor((buffer.width - boxW) / 2);
+  const boxY = centerY - 2;
+  fillRect(buffer, boxX, boxY, boxW, boxH, ' ', 0xffffffff, pauseBg);
+
+  writeStringCentered(buffer, centerY - 1, 'PAUSED', 0xfffffffe, pauseBg);
+  writeStringCentered(buffer, centerY + 0, 'Press P to resume', 0x888888ff, pauseBg);
+  writeStringCentered(buffer, centerY + 1, 'Press Q to quit', 0x888888ff, pauseBg);
+}
+
+// ─── Mount Rendering Data ────────────────────────────────────────
+
+interface MountRender {
+  mountChar: string;
+  mountColor: number;
+}
+
+function getMountRenderData(mountType: MountType, time: number): MountRender {
+  switch (mountType) {
+    case MountType.Horse:
+      return { mountChar: 'H', mountColor: COLOR_MONARCH };
+    case MountType.Stag:
+      return { mountChar: 'S', mountColor: 0xaa6633ff };
+    case MountType.Griffin: {
+      // Alternate between G and g for flapping wings
+      const flap = Math.floor(time * 4) % 2 === 0;
+      return { mountChar: flap ? 'G' : 'g', mountColor: 0xddaa33ff };
+    }
+    case MountType.Warhorse:
+      return { mountChar: 'W', mountColor: 0x778899ff };
+    case MountType.Bear: {
+      // Sway animation: alternate B and b
+      const sway = Math.floor(time * 2) % 2 === 0;
+      return { mountChar: sway ? 'B' : 'b', mountColor: 0x664422ff };
+    }
+    case MountType.Lizard:
+      return { mountChar: 'L', mountColor: 0x55aa33ff };
+    case MountType.Unicorn:
+      return { mountChar: 'U', mountColor: 0xffddffff };
+    case MountType.None:
+    default:
+      return { mountChar: CHAR_MONARCH, mountColor: COLOR_MONARCH };
+  }
+}
+
+// ─── Hermit Cottage Rendering Helpers ────────────────────────────
+
+function hermitTypeMarker(type: HermitType): string {
+  switch (type) {
+    case HermitType.Ballista: return 'b';
+    case HermitType.Stable: return 's';
+    case HermitType.Bakery: return 'k';
+    case HermitType.Knight: return 'n';
+    case HermitType.Horn: return 'o';
+    case HermitType.FireTower: return 'f';
+    case HermitType.Berserker: return 'r';
+    default: return '?';
+  }
+}
+
+// ─── Statue Rendering Helpers ────────────────────────────────────
+
+function statueIcon(type: BlessingType): string {
+  switch (type) {
+    case BlessingType.Archer: return ')'; // bow
+    case BlessingType.Farmer: return '/'; // scythe
+    case BlessingType.Builder: return '#'; // wall
+    case BlessingType.Knight: return '+'; // sword
+    default: return '?';
+  }
+}
+
+// ─── Playing Phase Render ─────────────────────────────────────────
+
+function renderPlaying(buffer: CellBufferDirect, state: GameState, dt: number): void {
+  const { viewWidth, viewHeight, tiles, timeOfDay } = state;
+  const shakeOffset = state.screenShakeTimer > 0 ? (Math.random() - 0.5) * 3 : 0;
+  const cameraX = state.cameraX + shakeOffset;
+  const camXi = Math.floor(cameraX);
+
+  // Vertical offset: push world to bottom of screen on tall terminals
+  const MAP_H = tiles.length || 30;
+  const yOffset = Math.max(0, viewHeight - MAP_H);
+
+  // Helper to convert world Y to screen Y
+  const toScreenY = (wy: number): number => wy + yOffset;
+
+  // 1. Sky background (season-aware, blood moon override)
+  const sky = state.isBloodMoon ? BLOOD_MOON_SKY : interpolateSkyColor(state.dayTime, state.season);
+  fillRect(buffer, 0, 0, viewWidth, viewHeight, ' ', sky, sky);
+
+  // Blood moon: large red moon at top of screen
+  if (state.isBloodMoon) {
+    const moonX = Math.floor(viewWidth / 2);
+    const moonY = 3;
+    if (moonY < viewHeight) {
+      buffer.setCell(moonX, moonY, 'O', 0xff2222ff, BLOOD_MOON_SKY);
+      if (moonX - 1 >= 0) buffer.setCell(moonX - 1, moonY, '(', 0x882222ff, BLOOD_MOON_SKY);
+      if (moonX + 1 < viewWidth) buffer.setCell(moonX + 1, moonY, ')', 0x882222ff, BLOOD_MOON_SKY);
+    }
+  }
+
+  // 1.5 Sun/moon celestial bodies
+  if (!state.isBloodMoon) {
+    if (state.dayTime >= DAY_START && state.dayTime < DUSK_START) {
+      // Sun arcs during day
+      const dayProgress = (state.dayTime - DAY_START) / (DUSK_START - DAY_START);
+      const sunX = Math.floor(dayProgress * viewWidth);
+      const sunArc = Math.sin(dayProgress * Math.PI);
+      const sunY = Math.floor((1 - sunArc) * (GROUND_Y + yOffset - 6)) + 2;
+      if (sunX >= 0 && sunX < viewWidth && sunY >= 0 && sunY < viewHeight) {
+        buffer.setCell(sunX, sunY, 'O', 0xffdd44ff, sky);
+      }
+    } else if (state.dayTime >= NIGHT_START || state.dayTime < DAY_START) {
+      // Moon arcs during night
+      const nightTotal = (1.0 - NIGHT_START) + DAY_START;
+      const nightProgress = state.dayTime >= NIGHT_START
+        ? (state.dayTime - NIGHT_START) / nightTotal
+        : ((1.0 - NIGHT_START) + state.dayTime) / nightTotal;
+      const moonX = Math.floor(nightProgress * viewWidth);
+      const moonArc = Math.sin(nightProgress * Math.PI);
+      const moonY = Math.floor((1 - moonArc) * (GROUND_Y + yOffset - 6)) + 2;
+      if (moonX >= 0 && moonX < viewWidth && moonY >= 0 && moonY < viewHeight) {
+        buffer.setCell(moonX, moonY, 'C', 0xddddffff, sky);
+      }
+    }
+  }
+
+  // 2. Parallax: stars at 0.5x scroll speed (only visible at dusk/night/dawn)
+  if (timeOfDay !== TimeOfDay.Day) {
+    if (!stars) stars = generateStars();
+    const starScrollX = Math.floor(cameraX * 0.5);
+    for (const star of stars) {
+      const sx = star.x - starScrollX;
+      const wrappedX = ((sx % viewWidth) + viewWidth) % viewWidth;
+      const starSY = star.y + yOffset;
+      if (starSY >= 1 && starSY < toScreenY(GROUND_Y) && wrappedX >= 0 && wrappedX < viewWidth) {
+        const twinkle = Math.sin(state.totalElapsed * 1.5 + star.x * 0.3) * 0.3 + 0.7;
+        const b = Math.floor(star.brightness * twinkle * 180);
+        const fg = ((b & 0xff) << 24) | ((b & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
+        buffer.setCell(wrappedX, starSY, star.char, fg, sky);
+      }
+    }
+
+    // 2.3 Constellation warning (2 days before crown stealer, around day 28)
+    if (state.dayCount >= 26 && state.dayCount <= 30) {
+      const constellationStars: [number, number][] = [
+        [0.3, 1], [0.4, 2], [0.5, 1], [0.6, 2], [0.7, 1],
+        [0.45, 3], [0.55, 3],
+      ];
+      const daysIn = state.dayCount - 26;
+      const visibleCount = Math.min(constellationStars.length, Math.floor(daysIn * 2) + 2);
+      const fade = state.dayCount >= 29 ? 0.5 : 1.0;
+      for (let ci = 0; ci < visibleCount; ci++) {
+        const [xFrac, row] = constellationStars[ci]!;
+        const cx = Math.floor(xFrac * viewWidth);
+        const constY = row + yOffset;
+        if (cx >= 0 && cx < viewWidth && constY >= 0 && constY < viewHeight) {
+          const twinkle = Math.sin(state.totalElapsed * 2 + ci * 1.7) * 0.2 + 0.8;
+          const cr = Math.floor(0x88 * twinkle * fade);
+          const cg = Math.floor(0x22 * twinkle * fade);
+          const cb = Math.floor(0x22 * twinkle * fade);
+          const cfg = ((cr & 0xff) << 24) | ((cg & 0xff) << 16) | ((cb & 0xff) << 8) | 0xff;
+          buffer.setCell(cx, constY, '*', cfg, sky);
+        }
+      }
+    }
+  }
+
+  // 2.5 Northern lights (winter clear nights only)
+  if (state.season === Season.Winter && state.weather === WeatherType.Clear && !state.isBloodMoon
+      && (timeOfDay === TimeOfDay.Night || timeOfDay === TimeOfDay.Dusk)) {
+    let auroraIntensity = 0;
+    if (state.dayTime >= NIGHT_START) {
+      auroraIntensity = Math.sin(((state.dayTime - NIGHT_START) / (1.0 - NIGHT_START)) * Math.PI);
+    } else if (state.dayTime < DAY_START) {
+      auroraIntensity = 1 - state.dayTime / DAY_START;
+    } else if (state.dayTime >= DUSK_START) {
+      auroraIntensity = ((state.dayTime - DUSK_START) / (NIGHT_START - DUSK_START)) * 0.5;
+    }
+    if (auroraIntensity > 0.05) {
+      for (let aRow = 2; aRow <= 5; aRow++) {
+        const row = aRow + yOffset;
+        if (row >= viewHeight) continue;
+        for (let col = 0; col < viewWidth; col++) {
+          const wave = Math.sin(col / 5 + state.totalElapsed * 0.5 + row * 0.8);
+          if (wave > 0.3) {
+            const bi = (wave - 0.3) * auroraIntensity;
+            const isGreen = (row + Math.floor(state.totalElapsed * 0.3)) % 2 === 0;
+            const ar = isGreen ? Math.floor(0x33 * bi) : Math.floor(0x88 * bi);
+            const ag = isGreen ? Math.floor(0xaa * bi) : Math.floor(0x33 * bi);
+            const ab = isGreen ? Math.floor(0x66 * bi) : Math.floor(0xaa * bi);
+            if (ar > 5 || ag > 5 || ab > 5) {
+              const afg = ((ar & 0xff) << 24) | ((ag & 0xff) << 16) | ((ab & 0xff) << 8) | 0xff;
+              buffer.setCell(col, row, '\u2591', afg, sky);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 3. Parallax: clouds at 0.5x scroll speed (with slow drift)
+  if (!clouds) clouds = generateClouds();
+  const cloudDrift = Math.floor(state.totalElapsed * 2);
+  const cloudScrollX = Math.floor(cameraX * 0.5) - cloudDrift;
+  const cloudFg = timeOfDay === TimeOfDay.Night ? 0x222244ff : 0xccddeeee;
+  for (const cloud of clouds) {
+    const sx = cloud.x - cloudScrollX;
+    const wrappedX = ((sx % (viewWidth + 20)) + viewWidth + 20) % (viewWidth + 20) - 10;
+    for (let dx = 0; dx < cloud.width; dx++) {
+      const cx = wrappedX + dx;
+      const cloudSY = cloud.y + yOffset;
+      if (cx >= 0 && cx < viewWidth && cloudSY >= 1 && cloudSY < toScreenY(GROUND_Y) - 4) {
+        buffer.setCell(cx, cloudSY, '\u2592', cloudFg, sky);
+      }
+    }
+  }
+
+  // 3.5 Weather effects (rain/snow/storm overlay in sky area)
+  renderWeather(buffer, viewWidth, viewHeight, state.weather, state.totalElapsed, toScreenY(GROUND_Y));
+
+  // 4. Terrain tiles (animated water + tree sway)
+  for (let sy = 0; sy < viewHeight; sy++) {
+    const tileY = sy - yOffset;
+    const tileRow = tiles[tileY];
+    if (!tileRow) continue;
+    for (let sx = 0; sx < viewWidth; sx++) {
+      const worldX = camXi + sx;
+      if (worldX < 0 || worldX >= tileRow.length) continue;
+      const tile = tileRow[worldX]!;
+      if (tile === TileType.Sky) continue;
+
+      // Animated water: seasonal, flow direction, reflections
+      if (tile === TileType.Water) {
+        if (state.season === Season.Winter) {
+          buffer.setCell(sx, sy, '=', 0xaabbccff, 0x223344ff);
+        } else {
+          const waterTime = Math.floor(state.totalElapsed * 2 + worldX * 0.15);
+          const waterChar = waterTime % 2 === 0 ? '~' : '-';
+          const biome = getBiome(worldX);
+          if (biome === Biome.Swamp) {
+            buffer.setCell(sx, sy, waterChar, 0x227766ff, 0x112233ff);
+          } else {
+            const colorPhase = Math.sin(state.totalElapsed * 1.5 + worldX * 0.2);
+            const waterFg = colorPhase > 0 ? 0x3366aaff : 0x4477bbff;
+            buffer.setCell(sx, sy, waterChar, waterFg, 0x112255ff);
+          }
+          // Night star reflections in water
+          if (timeOfDay === TimeOfDay.Night || timeOfDay === TimeOfDay.Dusk) {
+            const reflHash = ((worldX * 2654435761 + sy * 31) >>> 0) % 11;
+            if (reflHash < 2) {
+              const rb = Math.floor(40 + Math.sin(state.totalElapsed + worldX * 0.7) * 20);
+              const rfg = ((rb & 0xff) << 24) | ((rb & 0xff) << 16) | ((rb & 0xff) << 8) | 0xff;
+              buffer.setCell(sx, sy, '.', rfg, 0x112255ff);
+            }
+          }
+        }
+        continue;
+      }
+
+      // Swamp ground: darker green with occasional murk
+      if (tile === TileType.Swamp) {
+        const swampPhase = Math.sin(state.totalElapsed * 0.5 + worldX * 0.7);
+        const swampChar = swampPhase > 0.3 ? CHAR_GRASS : ',';
+        buffer.setCell(sx, sy, swampChar, 0x116622ff, 0x0a2211ff);
+        continue;
+      }
+
+      // Mountain: rocky elevated terrain
+      if (tile === TileType.Mountain) {
+        const rockHash = ((worldX * 13 + sy * 7) >>> 0) % 5;
+        const mountainChar = rockHash < 2 ? '^' : rockHash < 4 ? '.' : '\u2592';
+        buffer.setCell(sx, sy, mountainChar, 0x887766ff, 0x666655ff);
+        continue;
+      }
+
+      // Ruins: broken walls with box-drawing characters
+      if (tile === TileType.Ruins) {
+        const ruinChars = ['\u250C', '\u2510', '\u2514', '\u2518', '\u2502', '\u2500'];
+        const ruinIdx = ((worldX * 11 + sy * 5) >>> 0) % ruinChars.length;
+        buffer.setCell(sx, sy, ruinChars[ruinIdx]!, 0x444444ff, 0x222222ff);
+        continue;
+      }
+
+      // Tree sway: alternate canopy chars (season-aware colors)
+      if (tile === TileType.Forest) {
+        if (tileY === GROUND_Y) {
+          buffer.setCell(sx, sy, CHAR_TREE_TRUNK, COLOR_TREE_TRUNK, 0x0a3311ff);
+        } else {
+          const swayPhase = Math.sin(state.totalElapsed * 0.8 + worldX * 0.5);
+          const treeChar = swayPhase > 0.3 ? '\u2660' : '\u2663';
+          buffer.setCell(sx, sy, treeChar, seasonalForestFg(state.season), 0x0a3311ff);
+        }
+        continue;
+      }
+
+      // Grass: season-aware coloring
+      if (tile === TileType.Grass) {
+        buffer.setCell(sx, sy, CHAR_GRASS, seasonalGrassFg(state.season), seasonalGrassBg(state.season));
+        continue;
+      }
+
+      buffer.setCell(sx, sy, tileChar(tile), tileFg(tile), tileBg(tile));
+    }
+  }
+
+  // 4.1 Fill rows below terrain map with animated reflective water
+  const tileRows = tiles.length;
+  const tileBottomRow = tileRows + yOffset;
+  if (viewHeight > tileBottomRow) {
+    for (let sy = tileBottomRow; sy < viewHeight; sy++) {
+      for (let sx = 0; sx < viewWidth; sx++) {
+        const worldX = camXi + sx;
+        const depth = sy - tileBottomRow; // Distance below terrain edge
+        if (state.season === Season.Winter) {
+          // Frozen deep water
+          buffer.setCell(sx, sy, '=', 0x8899aaff, 0x112233ff);
+        } else {
+          // Animated deep water with reflections
+          const wt = Math.floor(state.totalElapsed * 1.5 + worldX * 0.12 + depth * 0.3);
+          const waterChar = wt % 3 === 0 ? '~' : wt % 3 === 1 ? '-' : '\u2248';
+          const colorPhase = Math.sin(state.totalElapsed * 1.2 + worldX * 0.15 + depth * 0.5);
+          const depthFade = Math.max(0, 1.0 - depth * 0.1);
+          const baseR = Math.floor(0x22 * depthFade);
+          const baseG = Math.floor((0x44 + colorPhase * 0x11) * depthFade);
+          const baseB = Math.floor((0x88 + colorPhase * 0x22) * depthFade);
+          const waterFg = ((baseR & 0xff) << 24) | ((baseG & 0xff) << 16) | ((baseB & 0xff) << 8) | 0xff;
+          const bgR = Math.floor(0x08 * depthFade);
+          const bgG = Math.floor(0x15 * depthFade);
+          const bgB = Math.floor((0x33 + colorPhase * 0x11) * depthFade);
+          const waterBg = ((bgR & 0xff) << 24) | ((bgG & 0xff) << 16) | ((bgB & 0xff) << 8) | 0xff;
+          buffer.setCell(sx, sy, waterChar, waterFg, waterBg);
+
+          // Star/sky reflections in water (night/dusk)
+          if (timeOfDay === TimeOfDay.Night || timeOfDay === TimeOfDay.Dusk) {
+            const reflHash = ((worldX * 2654435761 + sy * 37) >>> 0) % 17;
+            if (reflHash < 2) {
+              const sparkle = Math.sin(state.totalElapsed * 0.8 + worldX * 0.5 + depth);
+              if (sparkle > 0.3) {
+                const rb = Math.floor(30 + sparkle * 40);
+                const rfg = ((rb & 0xff) << 24) | ((rb & 0xff) << 16) | (((rb + 20) & 0xff) << 8) | 0xff;
+                buffer.setCell(sx, sy, '.', rfg, waterBg);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 4.5 Blood moon ambient glow on ground tiles
+  if (state.isBloodMoon) {
+    for (let sx = 0; sx < viewWidth; sx++) {
+      const sy = toScreenY(GROUND_Y);
+      if (sy >= viewHeight) continue;
+      const cell = buffer.cells[sy]?.[sx];
+      if (cell) {
+        // Tint existing fg with red-orange
+        const r = Math.min(255, ((cell.fg >> 24) & 0xff) + 40);
+        const g = Math.max(0, ((cell.fg >> 16) & 0xff) - 20);
+        const b = Math.max(0, ((cell.fg >> 8) & 0xff) - 30);
+        cell.fg = ((r & 0xff) << 24) | ((g & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
+      }
+    }
+  }
+
+  // 4.6 Campfire warm glow radius (night/dusk only)
+  if (timeOfDay === TimeOfDay.Night || timeOfDay === TimeOfDay.Dusk) {
+    let glowRadius = 0;
+    if (state.townCenterTier >= TownCenterTier.Village) glowRadius = 12;
+    else if (state.townCenterTier >= TownCenterTier.Camp) glowRadius = 8;
+    else if (state.townCenterTier >= TownCenterTier.Campfire) glowRadius = 5;
+    if (glowRadius > 0) {
+      const campSX = worldToScreen(CAMP_CENTER_X, cameraX);
+      const tintR = state.isBloodMoon ? 0x66 : 0x44;
+      const tintG = state.isBloodMoon ? 0x11 : 0x22;
+      const glowGroundY = toScreenY(GROUND_Y);
+      for (let gx = Math.max(0, campSX - glowRadius); gx <= Math.min(viewWidth - 1, campSX + glowRadius); gx++) {
+        const dist = Math.abs(gx - campSX);
+        const intensity = 0.3 * (1 - dist / glowRadius);
+        if (intensity <= 0) continue;
+        for (let gy = Math.max(0, glowGroundY - 3); gy < Math.min(viewHeight, glowGroundY + 3); gy++) {
+          const cell = buffer.cells[gy]?.[gx];
+          if (!cell) continue;
+          const bgR = (cell.bg >> 24) & 0xff;
+          const bgG = (cell.bg >> 16) & 0xff;
+          const bgB = (cell.bg >> 8) & 0xff;
+          const nr = Math.floor(bgR * (1 - intensity) + tintR * intensity);
+          const ng = Math.floor(bgG * (1 - intensity) + tintG * intensity);
+          const nb = Math.floor(bgB * (1 - intensity));
+          cell.bg = ((nr & 0xff) << 24) | ((ng & 0xff) << 16) | ((nb & 0xff) << 8) | 0xff;
+        }
+      }
+    }
+  }
+
+  // 5. Parallax: foreground grass details at 1.2x scroll speed
+  const grassY = toScreenY(GROUND_Y + 1); // Just below ground level, on dirt
+  if (grassY < viewHeight) {
+    const grassScrollX = Math.floor(cameraX * 1.2);
+    for (let sx = 0; sx < viewWidth; sx++) {
+      const worldGrassX = grassScrollX + sx;
+      // Use deterministic pattern based on world position
+      const hash = ((worldGrassX * 2654435761) >>> 0) % 7;
+      if (hash < 3) {
+        const ch = GRASS_DETAILS[hash]!;
+        const tileRow = tiles[GROUND_Y + 1];
+        if (tileRow) {
+          const tileWorldX = camXi + sx;
+          const tile = tileRow[tileWorldX];
+          if (tile === TileType.Dirt) {
+            buffer.setCell(sx, grassY, ch, 0x336622ff, 0x442211ff);
+          }
+        }
+      }
+    }
+  }
+
+  // 5.5 Construction blueprints (dim, blinking outlines)
+  for (const bx of getBlueprints()) {
+    if (!isOnScreen(bx, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(bx, cameraX);
+    const sy = toScreenY(GROUND_Y);
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      const bpColor = Math.floor(state.totalElapsed * 2) % 2 === 0 ? 0x664433ff : 0x332211ff;
+      buffer.setCell(sx, sy, CHAR_WALL, bpColor, COLOR_BG);
+    }
+  }
+
+  // 5.7 Town center multi-char rendering
+  {
+    const tier = state.townCenterTier;
+    const [tcChars, tcColor] = TOWN_CENTER_VISUALS[tier]!;
+    const tcStartX = CAMP_CENTER_X - Math.floor(tcChars.length / 2);
+    for (let i = 0; i < tcChars.length; i++) {
+      const wx = tcStartX + i;
+      if (!isOnScreen(wx, cameraX, viewWidth)) continue;
+      const sx = worldToScreen(wx, cameraX);
+      const sy = toScreenY(GROUND_Y);
+      if (sx < 0 || sx >= viewWidth || sy < 0 || sy >= viewHeight) continue;
+      if (tier === TownCenterTier.Campfire) {
+        // Flickering campfire
+        const fireColor = Math.floor(state.totalElapsed * 4) % 2 === 0 ? 0xff6600ff : 0xff8800ff;
+        buffer.setCell(sx, sy, '*', fireColor, COLOR_BG);
+      } else {
+        buffer.setCell(sx, sy, tcChars[i]!, tcColor, COLOR_BG);
+      }
+    }
+    // Castle tier: banner char above center
+    if (tier >= TownCenterTier.Castle) {
+      const bannerX = CAMP_CENTER_X;
+      if (isOnScreen(bannerX, cameraX, viewWidth)) {
+        const bsx = worldToScreen(bannerX, cameraX);
+        const bsy = toScreenY(GROUND_Y - 1);
+        if (bsx >= 0 && bsx < viewWidth && bsy >= 0 && bsy < viewHeight) {
+          const bannerColor = Math.floor(state.totalElapsed * 2) % 2 === 0 ? 0xffcc00ff : 0xffaa00ff;
+          buffer.setCell(bsx, bsy, '\u2691', bannerColor, COLOR_BG);
+        }
+      }
+    }
+  }
+
+  // 6. Structures (towers, under-construction pulses, wall HP bars)
+  for (const [, structure] of state.structures) {
+    if (!isOnScreen(structure.x, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(structure.x, cameraX);
+    const sy = toScreenY(GROUND_Y);
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      if (structure.type === StructureType.Campfire) {
+        continue;
+      } else if (structure.hp === 0 && structure.maxHp > 0) {
+        const buildPulse = Math.sin(state.totalElapsed * 3) * 0.3 + 0.5;
+        const b = Math.floor(0x88 * buildPulse);
+        const buildColor = ((b & 0xff) << 24) | ((b & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
+        buffer.setCell(sx, sy, '-', buildColor, COLOR_BG);
+      } else if ((structure.towerTier ?? TowerTier.None) > TowerTier.None) {
+        // Tower rendering based on tier
+        const tier = structure.towerTier!;
+        const [towerChars, towerColor] = TOWER_VISUALS[tier]!;
+        const towerStartX = sx - Math.floor(towerChars.length / 2);
+        for (let ti = 0; ti < towerChars.length; ti++) {
+          const tx = towerStartX + ti;
+          if (tx >= 0 && tx < viewWidth) {
+            buffer.setCell(tx, sy, towerChars[ti]!, towerColor, COLOR_BG);
+          }
+        }
+        // Stone tower and above: render 2 chars high
+        if (tier >= TowerTier.StoneTower) {
+          const topY = sy - 1;
+          if (topY >= 0 && topY < viewHeight) {
+            if (tier >= TowerTier.RoofedTriplet) {
+              // Roofed: show roof char above center
+              const roofColor = 0x777788ff;
+              buffer.setCell(sx, topY, '^', roofColor, COLOR_BG);
+            } else {
+              buffer.setCell(sx, topY, '|', towerColor, COLOR_BG);
+            }
+          }
+        }
+        // Archer count above tower
+        const capacity = TOWER_ARCHER_CAPACITY[tier] ?? 0;
+        if (capacity > 0) {
+          const countY = sy - (tier >= TowerTier.StoneTower ? 2 : 1);
+          if (countY >= 0 && countY < viewHeight) {
+            const assigned = structure.assignedWorkers.length;
+            const countStr = `${assigned}/${capacity}`;
+            const countColor = assigned >= capacity ? 0x44cc44ff : 0xcccc44ff;
+            for (let ci = 0; ci < countStr.length; ci++) {
+              const cx = sx - Math.floor(countStr.length / 2) + ci;
+              if (cx >= 0 && cx < viewWidth) {
+                buffer.setCell(cx, countY, countStr[ci]!, countColor, COLOR_BG);
+              }
+            }
+          }
+        }
+      } else {
+        buffer.setCell(sx, sy, structureChar(structure), structureFg(structure), COLOR_BG);
+      }
+
+      // Wall HP bars
+      const isWall = structure.type === StructureType.WallWood
+        || structure.type === StructureType.WallStone
+        || structure.type === StructureType.WallIron;
+      if (isWall && structure.hp > 0 && structure.hp < structure.maxHp) {
+        const hpY = toScreenY(GROUND_Y - 1);
+        if (hpY >= 0 && hpY < viewHeight) {
+          const ratio = structure.hp / structure.maxHp;
+          const hpColor = ratio > 0.66 ? 0x44cc44ff : ratio > 0.33 ? 0xcccc44ff : 0xff4444ff;
+          buffer.setCell(sx, hpY, '\u2588', hpColor, COLOR_BG);
+        }
+      }
+    }
+  }
+
+  // 6.5 Consumable spots (pulse/sparkle to attract attention)
+  for (const [x, type] of state.consumableSpots) {
+    if (state.consumedSpots.has(x)) continue;
+    if (!isOnScreen(x, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(x, cameraX);
+    const sy = toScreenY(GROUND_Y - 1);
+    if (sx < 0 || sx >= viewWidth || sy < 0 || sy >= viewHeight) continue;
+
+    const pulse = Math.sin(state.totalElapsed * 3) * 0.3 + 0.7;
+
+    switch (type) {
+      case ConsumableType.FoodCache: {
+        const r = Math.floor(255 * pulse);
+        const g = Math.floor(204 * pulse);
+        const fg = ((r & 0xff) << 24) | ((g & 0xff) << 16) | (0x00 << 8) | 0xff;
+        buffer.setCell(sx, sy, CHAR_COIN, fg, COLOR_BG);
+        break;
+      }
+      case ConsumableType.RestShrine: {
+        const r = Math.floor(0x44 * pulse);
+        const g = Math.floor(0xcc * pulse);
+        const b = Math.floor(0xff * pulse);
+        const fg = ((r & 0xff) << 24) | ((g & 0xff) << 16) | ((b & 0xff) << 8) | 0xff;
+        buffer.setCell(sx, sy, '\u2726', fg, COLOR_BG);
+        break;
+      }
+      case ConsumableType.PowerWell: {
+        const rb = Math.floor(0xff * pulse);
+        const fg = ((rb & 0xff) << 24) | (0x00 << 16) | ((rb & 0xff) << 8) | 0xff;
+        buffer.setCell(sx, sy, '\u25C6', fg, COLOR_BG);
+        break;
+      }
+    }
+  }
+
+  // 6.7 Hermit cottages (small houses in forest)
+  for (const hermit of getAvailableHermits()) {
+    if (!isOnScreen(hermit.x, cameraX, viewWidth)) continue;
+    const hsx = worldToScreen(hermit.x, cameraX);
+    const hsy = toScreenY(GROUND_Y);
+    if (hsx < 0 || hsx >= viewWidth || hsy < 0 || hsy >= viewHeight) continue;
+
+    if (hermit.kidnapped) {
+      // Dim empty cottage
+      buffer.setCell(hsx, hsy, 'h', 0x333333ff, COLOR_BG);
+    } else {
+      // Cottage with roof
+      buffer.setCell(hsx, hsy, 'h', 0x228833ff, COLOR_BG);
+      // Hermit type marker next to cottage when home (not riding)
+      if (!hermit.riding && hsx + 1 < viewWidth) {
+        buffer.setCell(hsx + 1, hsy, hermitTypeMarker(hermit.type), 0x88aa44ff, COLOR_BG);
+      }
+      // Small roof char above
+      const roofY = hsy - 1;
+      if (roofY >= 0 && roofY < viewHeight) {
+        buffer.setCell(hsx, roofY, '^', 0x664422ff, COLOR_BG);
+      }
+    }
+  }
+
+  // 6.8 Statues (pedestal + icon, blessing particles)
+  for (const statue of getStatues()) {
+    if (!isOnScreen(statue.x, cameraX, viewWidth)) continue;
+    const ssx = worldToScreen(statue.x, cameraX);
+    const ssy = toScreenY(GROUND_Y);
+    if (ssx < 0 || ssx >= viewWidth || ssy < 0 || ssy >= viewHeight) continue;
+
+    if (statue.blessingActive) {
+      // Active (blessed): bright gold with particles
+      buffer.setCell(ssx, ssy, '!', 0xffcc00ff, COLOR_BG);
+      // Icon above pedestal
+      const iconY = ssy - 1;
+      if (iconY >= 0 && iconY < viewHeight) {
+        buffer.setCell(ssx, iconY, statueIcon(statue.type), 0xffcc00ff, COLOR_BG);
+      }
+      // Radiating particles (small dots orbiting)
+      const particlePhase = state.totalElapsed * 3;
+      for (let p = 0; p < 4; p++) {
+        const angle = particlePhase + p * (Math.PI / 2);
+        const pdx = Math.round(Math.cos(angle) * 2);
+        const pdy = Math.round(Math.sin(angle) * 1);
+        const px = ssx + pdx;
+        const py = ssy + pdy;
+        if (px >= 0 && px < viewWidth && py >= 0 && py < viewHeight) {
+          buffer.setCell(px, py, '.', 0xffee88ff, COLOR_BG);
+        }
+      }
+    } else if (statue.unlocked) {
+      // Unlocked but not active: dim gold
+      buffer.setCell(ssx, ssy, '!', 0x886600ff, COLOR_BG);
+      const iconY = ssy - 1;
+      if (iconY >= 0 && iconY < viewHeight) {
+        buffer.setCell(ssx, iconY, statueIcon(statue.type), 0x886600ff, COLOR_BG);
+      }
+    } else {
+      // Not unlocked: dim gray pedestal
+      buffer.setCell(ssx, ssy, '|', 0x555555ff, COLOR_BG);
+    }
+
+    // Show cost in HUD area when monarch is within 5 tiles
+    const monarchPos = getPosition(state.world, state.monarch.eid);
+    if (monarchPos && distance(monarchPos.x, statue.x) <= 5) {
+      const config = getStatueConfig(statue.type);
+      if (config) {
+        const costY = ssy - 2;
+        if (costY >= 0 && costY < viewHeight) {
+          const costStr = statue.unlocked ? `${config.coinCost}\u25CF` : `${config.gemCost}\u25C6`;
+          const costColor = statue.unlocked ? COLOR_COIN : 0x44ccffff;
+          for (let ci = 0; ci < costStr.length; ci++) {
+            const cx = ssx - Math.floor(costStr.length / 2) + ci;
+            if (cx >= 0 && cx < viewWidth) {
+              buffer.setCell(cx, costY, costStr[ci]!, costColor, COLOR_BG);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 7. Units (with NPC subtype rendering for vagrants)
+  for (const unit of state.units) {
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (!isOnScreen(pos.x, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(pos.x, cameraX);
+    const sy = toScreenY(Math.floor(pos.y));
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      if (unit.role === UnitRole.Vagrant) {
+        const origin = getNpcOrigin(unit.eid);
+        let ch: string;
+        let fg: number;
+        switch (origin) {
+          case NpcOrigin.Warrior:
+            ch = '\u2694'; fg = 0xff4444ff; break;
+          case NpcOrigin.Scout:
+            ch = '\u2192'; fg = 0x44ff44ff; break;
+          case NpcOrigin.Craftsman:
+            ch = '\u2692'; fg = 0x4488ffff; break;
+          case NpcOrigin.Peasant:
+            ch = '\u2698'; fg = 0xffdd44ff; break;
+          default:
+            ch = CHAR_VILLAGER; fg = COLOR_VILLAGER; break;
+        }
+        buffer.setCell(sx, sy, ch, fg, COLOR_BG);
+      } else {
+        buffer.setCell(sx, sy, unitChar(unit.role), unitFg(unit.role), COLOR_BG);
+        // Entity detail accessories
+        const detailX = sx + 1;
+        if (detailX < viewWidth) {
+          if (unit.role === UnitRole.Builder && unit.aiState === AIState.Working) {
+            buffer.setCell(detailX, sy, '/', COLOR_BUILDER, COLOR_BG);
+          } else if (unit.role === UnitRole.Archer) {
+            buffer.setCell(detailX, sy, unit.aiState === AIState.Attacking ? '>' : ')', COLOR_ARCHER, COLOR_BG);
+          } else if (unit.role === UnitRole.Farmer && timeOfDay === TimeOfDay.Day) {
+            buffer.setCell(detailX, sy, '/', COLOR_FARMER, COLOR_BG);
+          } else if (unit.role === UnitRole.Knight) {
+            buffer.setCell(detailX, sy, unit.aiState === AIState.Defending ? '|' : '+', COLOR_MONARCH, COLOR_BG);
+          } else if (unit.role === UnitRole.Pikeman) {
+            buffer.setCell(detailX, sy, unit.aiState === AIState.Attacking ? 'I' : '|', COLOR_BUILDER, COLOR_BG);
+          } else if (unit.role === UnitRole.Squire) {
+            buffer.setCell(detailX, sy, ']', COLOR_FARMER, COLOR_BG);
+          }
+        }
+      }
+    }
+  }
+
+  // 7.5 Animals (rabbits and deer in forest areas)
+  for (const animal of getAnimals()) {
+    if (!isOnScreen(animal.x, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(animal.x, cameraX);
+    const sy = toScreenY(Math.floor(animal.y));
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      const ch = animal.type === 'rabbit' ? 'r' : 'D';
+      const fg = animal.type === 'rabbit' ? 0xccaa88ff : 0x886644ff;
+      buffer.setCell(sx, sy, ch, fg, COLOR_BG);
+    }
+  }
+
+  // 7.6 Dog companion
+  if (state.hasDog && !state.dogCaptured) {
+    const dogWorldX = getDogX();
+    if (isOnScreen(dogWorldX, cameraX, viewWidth)) {
+      const dsx = worldToScreen(dogWorldX, cameraX);
+      const dsy = toScreenY(GROUND_Y);
+      if (dsx >= 0 && dsx < viewWidth && dsy >= 0 && dsy < viewHeight) {
+        buffer.setCell(dsx, dsy, 'd', 0xaa8866ff, COLOR_BG);
+        if (isDogBarking() && dsx + 1 < viewWidth) {
+          buffer.setCell(dsx + 1, dsy, '!', 0xff4444ff, COLOR_BG);
+        }
+      }
+    }
+  }
+
+  // 8. Monarch (mount type specific rendering) + crown visual
+  {
+    const pos = getPosition(state.world, state.monarch.eid);
+    if (pos && isOnScreen(pos.x, cameraX, viewWidth)) {
+      const sx = worldToScreen(pos.x, cameraX);
+      const sy = toScreenY(Math.floor(pos.y));
+      if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+        const mount = getMountRenderData(state.mountType, state.totalElapsed);
+        // Render mount body character
+        buffer.setCell(sx, sy, mount.mountChar, mount.mountColor, COLOR_BG);
+        // For bear: wider body (extra char to the right)
+        if (state.mountType === MountType.Bear && sx + 1 < viewWidth) {
+          buffer.setCell(sx + 1, sy, mount.mountChar, mount.mountColor, COLOR_BG);
+        }
+        // Render '@' monarch on top of mount (or just monarch char if no mount)
+        if (state.mountType !== MountType.None) {
+          const monarchOnMountY = sy - 1;
+          if (monarchOnMountY >= 0 && monarchOnMountY < viewHeight) {
+            buffer.setCell(sx, monarchOnMountY, '@', COLOR_MONARCH, COLOR_BG);
+          }
+        }
+
+        // Crown above monarch when not dropped
+        if (!state.crownDropped) {
+          const crownY = state.mountType !== MountType.None ? sy - 2 : sy - 1;
+          if (crownY >= 0 && crownY < viewHeight) {
+            buffer.setCell(sx, crownY, CHAR_CROWN, COLOR_MONARCH, COLOR_BG);
+          }
+        }
+        // Monarch coin count
+        if (state.monarchCoins > 0) {
+          const coinCountX = sx + (state.mountType === MountType.Bear ? 2 : 1);
+          const coinCountY = state.mountType !== MountType.None ? sy - 1 : sy;
+          const countStr = String(state.monarchCoins);
+          for (let ci = 0; ci < countStr.length; ci++) {
+            if (coinCountX + ci >= 0 && coinCountX + ci < viewWidth && coinCountY >= 0 && coinCountY < viewHeight) {
+              buffer.setCell(coinCountX + ci, coinCountY, countStr[ci]!, COLOR_COIN, COLOR_BG);
+            }
+          }
+        }
+        // Hermit riding indicator
+        const ridingHermit = getRidingHermit();
+        if (ridingHermit !== null) {
+          const hx = sx - 1;
+          const hy = state.mountType !== MountType.None ? sy - 1 : sy;
+          if (hx >= 0 && hx < viewWidth && hy >= 0 && hy < viewHeight) {
+            buffer.setCell(hx, hy, 'h', 0x88aa44ff, COLOR_BG);
+          }
+        }
+      }
+    }
+  }
+
+  // 8.5 Dropped crown (bouncing on ground, sparkle effect)
+  if (state.crownDropped) {
+    if (isOnScreen(state.crownX, cameraX, viewWidth)) {
+      const sx = worldToScreen(state.crownX, cameraX);
+      const bounceOffset = Math.floor(Math.sin(state.totalElapsed * 8) * 1.5);
+      const sy = toScreenY(Math.floor(state.crownY)) + bounceOffset;
+      if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+        const crownChar = Math.floor(state.totalElapsed * 2) % 2 === 0 ? CHAR_CROWN : '*';
+        buffer.setCell(sx, sy, crownChar, 0xffcc00ff, COLOR_BG);
+      }
+    }
+  }
+
+  // 9. Greeds
+  for (const greed of state.greeds) {
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (!isOnScreen(pos.x, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(pos.x, cameraX);
+    const sy = toScreenY(Math.floor(pos.y));
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      const ch = greed.type === GreedType.Masked ? CHAR_GREED_MASK : CHAR_GREED;
+      const col = greed.type === GreedType.Masked ? COLOR_GREED_MASK : COLOR_GREED;
+      buffer.setCell(sx, sy, ch, col, COLOR_BG);
+    }
+  }
+
+  // 9.5 Dropped coins (pulsing on the ground)
+  for (const coin of getDroppedCoins()) {
+    if (!isOnScreen(coin.x, cameraX, viewWidth)) continue;
+    const sx = worldToScreen(coin.x, cameraX);
+    const sy = toScreenY(Math.floor(coin.y));
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      const coinPulse = Math.sin(state.totalElapsed * 4 + coin.x) * 0.2 + 0.8;
+      const cr = Math.floor(0xff * coinPulse);
+      const cg = Math.floor(0xcc * coinPulse);
+      const coinFg = ((cr & 0xff) << 24) | ((cg & 0xff) << 16) | (0x00 << 8) | 0xff;
+      buffer.setCell(sx, sy, CHAR_COIN, coinFg, COLOR_BG);
+    }
+  }
+
+  // 10. Projectiles
+  for (const proj of state.projectiles) {
+    const sx = worldToScreen(proj.x, cameraX);
+    const sy = toScreenY(Math.floor(proj.y));
+    if (sx >= 0 && sx < viewWidth && sy >= 0 && sy < viewHeight) {
+      const ch = proj.vx >= 0 ? CHAR_ARROW : '\u2190';
+      buffer.setCell(sx, sy, ch, COLOR_COIN, COLOR_BG);
+    }
+  }
+
+  // 11. Night overlay (smooth gradient)
+  applyNightOverlay(buffer, timeOfDay, state.dayTime, state.isBloodMoon);
+
+  // 12. Sparkle effects + coin sparkles
+  updateSparkles(buffer, dt);
+  updateCoinSparkles(dt);
+  renderCoinSparkles(buffer);
+
+  // 13. Wave flash
+  updateWaveFlash(buffer, dt);
+
+  // 14. HUD (after overlay so it's always readable)
+  renderHud(state, buffer);
+}
+
+// ─── Main Render Entry Point ──────────────────────────────────────
+
+let lastRenderTime = Date.now();
+
+/**
+ * Phase-aware render: delegates to title screen, playing, or game over renderer.
+ * Flushes to stdout with dirty-rect optimization.
+ */
+export function render(state: GameState): void {
+  const { viewWidth, viewHeight } = state;
+  const buffer = ensureBuffer(viewWidth, viewHeight);
+
+  const now = Date.now();
+  const dt = (now - lastRenderTime) / 1000;
+  lastRenderTime = now;
+
+  switch (state.phase) {
+    case GamePhase.Title:
+      renderTitleScreen(buffer, state.totalElapsed);
+      break;
+    case GamePhase.IslandSelect:
+      renderIslandSelectScreen(buffer, state);
+      break;
+    case GamePhase.Playing:
+      renderPlaying(buffer, state, dt);
+      if (state.isPaused) {
+        renderPauseOverlay(buffer);
+      }
+      break;
+    case GamePhase.GameOver:
+      renderGameOverScreen(buffer, state);
+      break;
+    case GamePhase.Victory:
+      renderVictoryScreen(buffer, state);
+      break;
+  }
+
+  flushBuffer(buffer, state.needsFullRedraw);
+  state.needsFullRedraw = false;
+}
+
+// ─── ANSI Output with Dirty-Rect Diffing ──────────────────────────
+
+function flushBuffer(buffer: CellBufferDirect, forceFullRedraw: boolean): void {
+  const stdout = process.stdout;
+
+  if (forceFullRedraw || !prevBuffer || prevBuffer.width !== buffer.width || prevBuffer.height !== buffer.height) {
+    stdout.write(bufferToAnsiFull(buffer));
+    prevBuffer = cloneBufferDeep(buffer);
+    return;
+  }
+
+  let output = '';
+  let lastFg = -1;
+  let lastBg = -1;
+  let lastOutX = -2;
+  let lastOutY = -1;
+
+  for (let y = 0; y < buffer.height; y++) {
+    const currentRow = buffer.cells[y];
+    const prevRow = prevBuffer.cells[y];
+    if (!currentRow) continue;
+
+    for (let x = 0; x < buffer.width; x++) {
+      const cur = currentRow[x];
+      const prev = prevRow?.[x];
+      if (!cur) continue;
+
+      if (prev && cur.char === prev.char && cur.fg === prev.fg && cur.bg === prev.bg) {
+        continue;
+      }
+
+      // Skip cursor repositioning for consecutive cells on same row
+      if (y !== lastOutY || x !== lastOutX + 1) {
+        output += `\x1b[${y + 1};${x + 1}H`;
+      }
+
+      if (cur.fg !== lastFg || cur.bg !== lastBg) {
+        const fgR = (cur.fg >> 24) & 0xff;
+        const fgG = (cur.fg >> 16) & 0xff;
+        const fgB = (cur.fg >> 8) & 0xff;
+        const bgR = (cur.bg >> 24) & 0xff;
+        const bgG = (cur.bg >> 16) & 0xff;
+        const bgB = (cur.bg >> 8) & 0xff;
+        output += `\x1b[38;2;${fgR};${fgG};${fgB};48;2;${bgR};${bgG};${bgB}m`;
+        lastFg = cur.fg;
+        lastBg = cur.bg;
+      }
+
+      output += cur.char;
+      lastOutX = x;
+      lastOutY = y;
+
+      if (prev) {
+        prev.char = cur.char;
+        prev.fg = cur.fg;
+        prev.bg = cur.bg;
+      }
+    }
+  }
+
+  if (output) {
+    stdout.write(output);
+  }
+}
+
+function bufferToAnsiFull(buffer: CellBufferDirect): string {
+  let output = '\x1b[H';
+  let lastFg = -1;
+  let lastBg = -1;
+
+  for (let y = 0; y < buffer.height; y++) {
+    const row = buffer.cells[y];
+    if (!row) continue;
+    for (let x = 0; x < buffer.width; x++) {
+      const cell = row[x];
+      if (!cell) continue;
+      if (cell.fg !== lastFg || cell.bg !== lastBg) {
+        const fgR = (cell.fg >> 24) & 0xff;
+        const fgG = (cell.fg >> 16) & 0xff;
+        const fgB = (cell.fg >> 8) & 0xff;
+        const bgR = (cell.bg >> 24) & 0xff;
+        const bgG = (cell.bg >> 16) & 0xff;
+        const bgB = (cell.bg >> 8) & 0xff;
+        output += `\x1b[38;2;${fgR};${fgG};${fgB};48;2;${bgR};${bgG};${bgB}m`;
+        lastFg = cell.fg;
+        lastBg = cell.bg;
+      }
+      output += cell.char;
+    }
+    if (y < buffer.height - 1) {
+      output += '\n';
+    }
+  }
+
+  return output;
+}
+
+function cloneBufferDeep(buffer: CellBufferDirect): CellBufferDirect {
+  const cells: { char: string; fg: number; bg: number }[][] = [];
+  for (let y = 0; y < buffer.height; y++) {
+    const srcRow = buffer.cells[y];
+    const row: { char: string; fg: number; bg: number }[] = [];
+    if (srcRow) {
+      for (let x = 0; x < buffer.width; x++) {
+        const c = srcRow[x];
+        row.push(c ? { char: c.char, fg: c.fg, bg: c.bg } : { char: ' ', fg: 0xffffffff, bg: 0x000000ff });
+      }
+    }
+    cells.push(row);
+  }
+  return {
+    width: buffer.width,
+    height: buffer.height,
+    cells,
+    setCell(x: number, y: number, char: string, fg: number, bg: number) {
+      const r = cells[y];
+      if (r) {
+        const cell = r[x];
+        if (cell) {
+          cell.char = char;
+          cell.fg = fg;
+          cell.bg = bg;
+        }
+      }
+    },
+  };
+}

--- a/kingdom/render/sound.ts
+++ b/kingdom/render/sound.ts
@@ -1,0 +1,78 @@
+/**
+ * Kingdom - Sound cues
+ * Terminal bell-based audio feedback with multiple patterns.
+ */
+
+let soundEnabled = true;
+
+export function setSoundEnabled(enabled: boolean): void {
+  soundEnabled = enabled;
+}
+
+export function isSoundEnabled(): boolean {
+  return soundEnabled;
+}
+
+function bell(): void {
+  if (!soundEnabled) return;
+  process.stdout.write('\x07');
+}
+
+/**
+ * Play a single terminal bell. Used for positive events like coin collection.
+ */
+export function playBell(): void {
+  bell();
+}
+
+/**
+ * Play a rapid double-bell. Used for alerts like night starting or wall breach.
+ */
+export function playAlert(): void {
+  bell();
+  setTimeout(() => bell(), 100);
+}
+
+/**
+ * Blood moon warning: 3 rapid beeps.
+ * Call ~40 seconds before midnight.
+ */
+export function playBloodMoonWarning(): void {
+  bell();
+  setTimeout(() => bell(), 80);
+  setTimeout(() => bell(), 160);
+}
+
+/**
+ * Crown drop alert: continuous rapid beeping while crown is on ground.
+ * Returns a timer ID that should be cleared when crown is recovered.
+ */
+export function playCrownAlert(): ReturnType<typeof setInterval> | null {
+  if (!soundEnabled) return null;
+  bell();
+  return setInterval(() => bell(), 300);
+}
+
+/**
+ * Recruitment sound: single short beep.
+ */
+export function playRecruit(): void {
+  bell();
+}
+
+/**
+ * Build completion: two short beeps.
+ */
+export function playBuildComplete(): void {
+  bell();
+  setTimeout(() => bell(), 150);
+}
+
+/**
+ * Greed breach: long-ish beep pattern (triple tap, spaced wider).
+ */
+export function playGreedBreach(): void {
+  bell();
+  setTimeout(() => bell(), 200);
+  setTimeout(() => bell(), 400);
+}

--- a/kingdom/structures/bomb.ts
+++ b/kingdom/structures/bomb.ts
@@ -1,0 +1,253 @@
+/**
+ * Bomb structure: late-game weapon to permanently destroy portals.
+ *
+ * Requires Iron Keep (TownCenterTier >= 7) and 18 coins to build.
+ * 3 builders push bomb toward nearest active portal at 0.3x speed.
+ * Knight escort required (at least 1 knight must accompany).
+ * 5 coins to ignite at portal. 20 second escape timer.
+ * After timer: portal destroyed permanently, all greed from that portal die.
+ * Builders caught in blast radius are lost.
+ */
+
+import { getPosition } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  TownCenterTier,
+  UnitRole,
+  AIState,
+  GamePhase,
+} from '../types';
+import { getActivePortals, destroyPortal } from './portal';
+
+const BOMB_COST = 18;
+const BOMB_IGNITE_COST = 5;
+const BOMB_BUILDER_COUNT = 3;
+const BOMB_PUSH_SPEED = 0.3;
+const BOMB_ESCAPE_TIME = 20.0;
+const BOMB_BLAST_RADIUS = 15;
+const MIN_TOWN_CENTER_TIER = TownCenterTier.IronKeep;
+
+interface BombState {
+  built: boolean;
+  x: number;
+  pushers: Entity[];
+  escortKnight: Entity | null;
+  targetPortalX: number;
+  ignited: boolean;
+  escapeTimer: number;
+  pushing: boolean;
+}
+
+let bombState: BombState = {
+  built: false,
+  x: 0,
+  pushers: [],
+  escortKnight: null,
+  targetPortalX: 0,
+  ignited: false,
+  escapeTimer: 0,
+  pushing: false,
+};
+
+/** Check if a bomb is currently active (built or being pushed) */
+export function isBombActive(): boolean {
+  return bombState.built;
+}
+
+/** Get current bomb state (read-only) */
+export function getBombState(): Readonly<BombState> {
+  return bombState;
+}
+
+/** Create a bomb near the town center. Returns true if successful. */
+export function createBomb(state: GameState): boolean {
+  if (bombState.built) return false;
+  if (state.townCenterTier < MIN_TOWN_CENTER_TIER) return false;
+  if (state.monarchCoins < BOMB_COST) return false;
+
+  // Need 3 idle builders nearby
+  const idleBuilders: Entity[] = [];
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Builder) continue;
+    if (unit.aiState !== AIState.Idle && unit.aiState !== AIState.Working) continue;
+    idleBuilders.push(unit.eid);
+    if (idleBuilders.length >= BOMB_BUILDER_COUNT) break;
+  }
+
+  if (idleBuilders.length < BOMB_BUILDER_COUNT) return false;
+
+  state.monarchCoins -= BOMB_COST;
+
+  // Find nearest active portal
+  const portals = getActivePortals(state);
+  if (portals.length === 0) return false;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  const monarchX = monarchPos?.x ?? 600;
+  let nearestPortal = portals[0];
+  let nearestDist = Math.abs(monarchX - portals[0]);
+  for (let i = 1; i < portals.length; i++) {
+    const dist = Math.abs(monarchX - portals[i]);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearestPortal = portals[i];
+    }
+  }
+
+  bombState = {
+    built: true,
+    x: monarchX,
+    pushers: idleBuilders.slice(0, BOMB_BUILDER_COUNT),
+    escortKnight: null,
+    targetPortalX: nearestPortal,
+    ignited: false,
+    escapeTimer: 0,
+    pushing: false,
+  };
+
+  // Mark builders as working
+  for (const eid of bombState.pushers) {
+    const unit = state.units.find(u => u.eid === eid);
+    if (unit) unit.aiState = AIState.Working;
+  }
+
+  state.messages.push('Bomb constructed! Assign a knight escort to begin pushing.');
+  return true;
+}
+
+/** Start pushing the bomb toward the target portal */
+export function startBombPush(state: GameState): boolean {
+  if (!bombState.built || bombState.pushing || bombState.ignited) return false;
+
+  // Find nearest knight to escort
+  let bestKnight: Entity | null = null;
+  let bestDist = Infinity;
+
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Knight) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    const dist = Math.abs(pos.x - bombState.x);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestKnight = unit.eid;
+    }
+  }
+
+  if (bestKnight === null) {
+    state.messages.push('A knight escort is required to push the bomb!');
+    return false;
+  }
+
+  bombState.escortKnight = bestKnight;
+  bombState.pushing = true;
+
+  const knight = state.units.find(u => u.eid === bestKnight);
+  if (knight) knight.aiState = AIState.Working;
+
+  state.messages.push('Bomb push started toward portal!');
+  return true;
+}
+
+/** Ignite the bomb at the portal. Costs BOMB_IGNITE_COST coins. */
+export function igniteBomb(state: GameState): boolean {
+  if (!bombState.built || !bombState.pushing || bombState.ignited) return false;
+  if (state.monarchCoins < BOMB_IGNITE_COST) return false;
+
+  const distToPortal = Math.abs(bombState.x - bombState.targetPortalX);
+  if (distToPortal > 3) return false;
+
+  state.monarchCoins -= BOMB_IGNITE_COST;
+  bombState.ignited = true;
+  bombState.escapeTimer = BOMB_ESCAPE_TIME;
+
+  state.messages.push(`Bomb ignited! ${BOMB_ESCAPE_TIME}s until detonation. Escape!`);
+  return true;
+}
+
+/** Update bomb state each frame */
+export function updateBomb(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+  if (!bombState.built) return;
+
+  // Clean up dead pushers
+  bombState.pushers = bombState.pushers.filter(eid =>
+    state.units.some(u => u.eid === eid && u.hp > 0)
+  );
+
+  // Check knight escort is alive
+  if (bombState.escortKnight !== null) {
+    const knightAlive = state.units.some(
+      u => u.eid === bombState.escortKnight && u.hp > 0
+    );
+    if (!knightAlive) {
+      bombState.escortKnight = null;
+      if (bombState.pushing && !bombState.ignited) {
+        bombState.pushing = false;
+        state.messages.push('Knight escort lost! Bomb push halted.');
+      }
+    }
+  }
+
+  // Handle ignited bomb: escape timer
+  if (bombState.ignited) {
+    bombState.escapeTimer -= dt;
+
+    if (bombState.escapeTimer <= 0) {
+      // Detonation: destroy portal permanently
+      destroyPortal(state, bombState.targetPortalX);
+
+      // Kill all greed near the portal
+      for (const greed of state.greeds) {
+        if (greed.hp <= 0) continue;
+        const pos = getPosition(state.world, greed.eid);
+        if (!pos) continue;
+        if (Math.abs(pos.x - bombState.targetPortalX) <= BOMB_BLAST_RADIUS) {
+          greed.hp = 0;
+        }
+      }
+
+      // Builders caught in blast radius are lost
+      for (const eid of bombState.pushers) {
+        const unit = state.units.find(u => u.eid === eid);
+        if (!unit) continue;
+        const pos = getPosition(state.world, unit.eid);
+        if (!pos) continue;
+        if (Math.abs(pos.x - bombState.targetPortalX) <= BOMB_BLAST_RADIUS) {
+          unit.hp = 0;
+        }
+      }
+
+      state.messages.push('BOOM! The portal has been permanently destroyed!');
+
+      // Reset bomb state
+      bombState = {
+        built: false,
+        x: 0,
+        pushers: [],
+        escortKnight: null,
+        targetPortalX: 0,
+        ignited: false,
+        escapeTimer: 0,
+        pushing: false,
+      };
+    }
+    return;
+  }
+
+  // Push bomb toward target portal
+  if (bombState.pushing && bombState.pushers.length > 0 && bombState.escortKnight !== null) {
+    const direction = bombState.x < bombState.targetPortalX ? 1 : -1;
+    const distToPortal = Math.abs(bombState.x - bombState.targetPortalX);
+
+    if (distToPortal > 1) {
+      bombState.x += BOMB_PUSH_SPEED * direction * dt;
+    }
+  }
+}
+
+/** Check if a builder is assigned to the bomb */
+export function isBombBuilder(eid: Entity): boolean {
+  return bombState.pushers.includes(eid);
+}

--- a/kingdom/structures/catapult.ts
+++ b/kingdom/structures/catapult.ts
@@ -1,0 +1,189 @@
+/**
+ * Catapult siege weapon: heavy AoE damage.
+ * Requires TownCenterTier >= 5 (Stone Fort).
+ * One per side maximum. 1-2 builders operate.
+ * 15 damage, 3-tile AoE radius, 15-tile range.
+ * Reload: 8s (1 builder), 4s (2 builders).
+ * Auto-fires when loaded and greed in range during night.
+ */
+
+import { getPosition } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  StructureType,
+  TownCenterTier,
+  TimeOfDay,
+  GamePhase,
+  AIState,
+  UnitRole,
+} from '../types';
+import { getOutermostWalls } from './wall';
+
+export const CATAPULT_TYPE = 18 as StructureType;
+export const CATAPULT_COST = 6;
+
+const CATAPULT_DAMAGE = 15;
+const CATAPULT_AOE_RADIUS = 3;
+const CATAPULT_RANGE = 15;
+const CATAPULT_RELOAD_BASE = 8.0;
+const CATAPULT_RELOAD_DUAL = 4.0;
+const MAX_CATAPULT_BUILDERS = 2;
+const PLACEMENT_RADIUS = 5;
+const MIN_TOWN_CENTER_TIER = TownCenterTier.StoneFort;
+
+export interface CatapultData {
+  x: number;
+  loaded: boolean;
+  reloadTimer: number;
+  builders: Entity[];
+}
+
+/** Module-level catapult state: one per side */
+const catapults: Map<string, CatapultData> = new Map();
+
+/**
+ * Create a catapult on the given side ('left' or 'right').
+ * Placed near the outermost wall. Returns null if requirements not met.
+ */
+export function createCatapult(state: GameState, side: 'left' | 'right'): CatapultData | null {
+  if (catapults.has(side)) return null;
+  if (state.townCenterTier < MIN_TOWN_CENTER_TIER) return null;
+  if (state.monarchCoins < CATAPULT_COST) return null;
+
+  const walls = getOutermostWalls(state);
+  const wallX = side === 'left' ? walls.left : walls.right;
+  if (wallX === null) return null;
+
+  state.monarchCoins -= CATAPULT_COST;
+
+  const offset = side === 'left' ? -PLACEMENT_RADIUS : PLACEMENT_RADIUS;
+  const x = wallX + offset;
+
+  const data: CatapultData = {
+    x,
+    loaded: false,
+    reloadTimer: CATAPULT_RELOAD_BASE,
+    builders: [],
+  };
+
+  catapults.set(side, data);
+  state.messages.push(`Catapult built on ${side} flank!`);
+  return data;
+}
+
+/** Check if a builder entity is assigned to a catapult */
+export function isCatapultBuilder(eid: Entity): boolean {
+  for (const [, cat] of catapults) {
+    if (cat.builders.includes(eid)) return true;
+  }
+  return false;
+}
+
+/** Assign a builder to a catapult. Returns true if assigned. */
+export function assignBuilderToCatapult(_state: GameState, side: string, builderEid: Entity): boolean {
+  const catapult = catapults.get(side);
+  if (!catapult) return false;
+  if (catapult.builders.length >= MAX_CATAPULT_BUILDERS) return false;
+  if (catapult.builders.includes(builderEid)) return false;
+
+  catapult.builders.push(builderEid);
+  return true;
+}
+
+/** Find the nearest greed within catapult range */
+function findNearestGreedInRange(state: GameState, catapultX: number): number | null {
+  let nearestX: number | null = null;
+  let nearestDist = Infinity;
+
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+
+    const dist = Math.abs(pos.x - catapultX);
+    if (dist <= CATAPULT_RANGE && dist < nearestDist) {
+      nearestDist = dist;
+      nearestX = pos.x;
+    }
+  }
+
+  return nearestX;
+}
+
+/** Fire catapult at target position, dealing AoE damage */
+function fireCatapult(state: GameState, catapult: CatapultData, targetX: number): void {
+  let hitCount = 0;
+
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+
+    if (Math.abs(pos.x - targetX) <= CATAPULT_AOE_RADIUS) {
+      greed.hp -= CATAPULT_DAMAGE;
+      hitCount++;
+    }
+  }
+
+  catapult.loaded = false;
+  const reloadTime = catapult.builders.length >= 2 ? CATAPULT_RELOAD_DUAL : CATAPULT_RELOAD_BASE;
+  catapult.reloadTimer = reloadTime;
+
+  if (hitCount > 0) {
+    state.messages.push(`Catapult fires! ${hitCount} greeds hit for ${CATAPULT_DAMAGE} damage.`);
+  }
+}
+
+/** Update all catapults: auto-assign idle builders, reload, fire */
+export function updateCatapults(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+
+  for (const [, catapult] of catapults) {
+    // Clean up dead/gone builders
+    catapult.builders = catapult.builders.filter(eid => {
+      return state.units.some(u => u.eid === eid && u.hp > 0);
+    });
+
+    // Auto-assign nearby idle builders
+    if (catapult.builders.length < MAX_CATAPULT_BUILDERS) {
+      for (const unit of state.units) {
+        if (unit.role !== UnitRole.Builder) continue;
+        if (unit.aiState !== AIState.Idle) continue;
+        if (catapult.builders.includes(unit.eid)) continue;
+
+        const pos = getPosition(state.world, unit.eid);
+        if (!pos) continue;
+
+        if (Math.abs(pos.x - catapult.x) <= PLACEMENT_RADIUS) {
+          catapult.builders.push(unit.eid);
+          unit.aiState = AIState.Working;
+          if (catapult.builders.length >= MAX_CATAPULT_BUILDERS) break;
+        }
+      }
+    }
+
+    // Only fire during night
+    if (state.timeOfDay !== TimeOfDay.Night) continue;
+    if (catapult.builders.length === 0) continue;
+
+    if (!catapult.loaded) {
+      catapult.reloadTimer -= dt;
+      if (catapult.reloadTimer <= 0) {
+        catapult.loaded = true;
+      }
+      continue;
+    }
+
+    // Find target and fire
+    const targetX = findNearestGreedInRange(state, catapult.x);
+    if (targetX !== null) {
+      fireCatapult(state, catapult, targetX);
+    }
+  }
+}
+
+/** Get all catapults (read-only) */
+export function getCatapults(): ReadonlyMap<string, CatapultData> {
+  return catapults;
+}

--- a/kingdom/structures/farm.ts
+++ b/kingdom/structures/farm.ts
@@ -1,0 +1,250 @@
+/**
+ * Farm structure creation, upgrade, income, growth cycle, and limits.
+ *
+ * Farm tier system:
+ *   Tier 1: Water Well / Basic Farm (5 coins to build)
+ *     - Up to 4 crop plots, 1 farmer assigned
+ *     - Harvest: 6 coins per plot (24 coins total per cycle)
+ *   Tier 2: Farmhouse / Mill House (8 coins to upgrade)
+ *     - Up to 6 crop plots, 2 farmers assignable
+ *     - Provides nighttime shelter for farmers
+ *     - Harvest: 6 coins per plot (36 coins total per cycle)
+ *   Tier 3: Blessed Farm (via Farmer Statue)
+ *     - +2 additional plots (8 total), +50% yield
+ *     - Only while Farmer Statue blessing is active
+ *
+ * Max 3 farms per side (6 total).
+ * Farm placement: only near water/stream tiles.
+ * Farm destruction by greed: reverts to wild land, farmer loses scythe.
+ *
+ * Newly built farms produce nothing for 10 seconds (growing phase).
+ * Windmill farms support extra workers to attract more farmers.
+ */
+
+import { addEntity, setPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  GROUND_Y,
+  CAMP_CENTER_X,
+} from '../types';
+
+const FARM_UPGRADE_ORDER: StructureType[] = [
+  StructureType.Farm,
+  StructureType.FarmIrrigated,
+  StructureType.FarmWindmill,
+];
+
+const FARM_GROWTH_TIME = 10; // seconds before new farm produces
+const MAX_FARMS_PER_SIDE = 3;
+const WINDMILL_BONUS_WORKERS = 1; // extra worker slots for windmill
+
+/** Farm tier constants */
+const FARM_TIER_BUILD_COST = 5;
+const FARM_TIER_UPGRADE_COST = 8;
+
+/** Crop plots per tier */
+const FARM_TIER_PLOTS: Record<number, number> = {
+  1: 4,
+  2: 6,
+  3: 8, // blessed: +2 from tier 2
+};
+
+/** Max farmers per tier */
+const FARM_TIER_FARMERS: Record<number, number> = {
+  1: 1,
+  2: 2,
+  3: 2,
+};
+
+/** Coins per plot per harvest cycle */
+const COINS_PER_PLOT = 6;
+
+/** Blessed farm yield bonus */
+const BLESSED_YIELD_BONUS = 1.5;
+
+/** Track growth timers by farm x position (seconds remaining) */
+const farmGrowthTimers: Map<number, number> = new Map();
+
+/** Track blessed status per farm */
+const blessedFarms: Set<number> = new Set();
+
+/** Tick all farm growth timers. Call once per frame. */
+export function updateFarmGrowth(dt: number): void {
+  for (const [x, remaining] of farmGrowthTimers) {
+    const next = remaining - dt;
+    if (next <= 0) {
+      farmGrowthTimers.delete(x);
+    } else {
+      farmGrowthTimers.set(x, next);
+    }
+  }
+}
+
+/** Check if a farm at position x is still in its growth phase */
+export function isFarmGrowing(x: number): boolean {
+  return farmGrowthTimers.has(x);
+}
+
+/** Check if a new farm can be built on the given side (max 3 per side) */
+export function canBuildFarm(state: GameState, x: number): boolean {
+  const side = x < CAMP_CENTER_X ? 'left' : 'right';
+  let count = 0;
+  for (const [fx, s] of state.structures) {
+    if (!isFarmStructure(s.type)) continue;
+    const farmSide = fx < CAMP_CENTER_X ? 'left' : 'right';
+    if (farmSide === side) count++;
+  }
+  return count < MAX_FARMS_PER_SIDE;
+}
+
+/** Create a farm at the given x position (should be on cleared land near water) */
+export function createFarm(state: GameState, x: number): StructureData | null {
+  if (!canBuildFarm(state, x)) return null;
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const farm: StructureData = {
+    eid,
+    type: StructureType.Farm,
+    x,
+    hp: 5,
+    maxHp: 5,
+    level: 1,
+    assignedWorkers: [],
+    farmTier: 1,
+  };
+
+  state.structures.set(x, farm);
+
+  // Start growth timer
+  farmGrowthTimers.set(x, FARM_GROWTH_TIME);
+
+  return farm;
+}
+
+/**
+ * Upgrade a farm to the next tier.
+ * Tier 1 -> 2: costs 8 coins (Farmhouse)
+ * Tier 2 -> 3 via Blessed Farm only happens through blessFarm.
+ * Also upgrades underlying StructureType: Farm -> FarmIrrigated -> FarmWindmill.
+ */
+export function upgradeFarm(state: GameState, x: number): boolean {
+  const farm = state.structures.get(x);
+  if (!farm || !isFarmStructure(farm.type)) return false;
+
+  const currentTier = farm.farmTier ?? 1;
+  if (currentTier >= 2) return false; // tier 3 only via blessing
+
+  if (state.monarchCoins < FARM_TIER_UPGRADE_COST) return false;
+
+  state.monarchCoins -= FARM_TIER_UPGRADE_COST;
+
+  const currentIndex = FARM_UPGRADE_ORDER.indexOf(farm.type);
+  if (currentIndex >= 0 && currentIndex < FARM_UPGRADE_ORDER.length - 1) {
+    farm.type = FARM_UPGRADE_ORDER[currentIndex + 1];
+  }
+
+  farm.farmTier = 2;
+  farm.level = 2;
+  farm.maxHp += 3;
+  farm.hp = farm.maxHp;
+
+  state.messages.push('Farm upgraded to Farmhouse! +2 crop plots, 2 farmers.');
+  return true;
+}
+
+/** Bless a farm (via Farmer Statue). Upgrades to tier 3 with bonus plots and yield. */
+export function blessFarm(state: GameState, x: number): boolean {
+  const farm = state.structures.get(x);
+  if (!farm || !isFarmStructure(farm.type)) return false;
+
+  const currentTier = farm.farmTier ?? 1;
+  if (currentTier < 2) return false; // must be tier 2+ to bless
+
+  farm.farmTier = 3;
+  blessedFarms.add(x);
+
+  state.messages.push('Farm blessed! +2 plots, +50% yield while blessing active.');
+  return true;
+}
+
+/** Remove blessing from a farm */
+export function unblessFarm(x: number): void {
+  const wasBlessed = blessedFarms.delete(x);
+  if (wasBlessed) {
+    // farmTier reverts to 2 when blessing ends
+    // (actual tier update happens in the calling code)
+  }
+}
+
+/** Check if a farm is blessed */
+export function isFarmBlessed(x: number): boolean {
+  return blessedFarms.has(x);
+}
+
+/** Get the number of crop plots for a farm tier */
+export function getFarmCapacity(tier: number): number {
+  return FARM_TIER_PLOTS[tier] ?? 4;
+}
+
+/** Get the coin yield for a farm based on tier and blessed status */
+export function getFarmYield(tier: number, blessed: boolean): number {
+  const plots = getFarmCapacity(tier);
+  const baseYield = plots * COINS_PER_PLOT;
+  return blessed ? Math.floor(baseYield * BLESSED_YIELD_BONUS) : baseYield;
+}
+
+/** Get the coin yield for a farm structure. Returns 0 if still growing. */
+export function getFarmOutput(farm: StructureData): number {
+  if (farmGrowthTimers.has(farm.x)) return 0;
+  const tier = farm.farmTier ?? 1;
+  const blessed = blessedFarms.has(farm.x);
+  return getFarmYield(tier, blessed);
+}
+
+/** Get max farmers assignable to a farm tier */
+export function getFarmMaxFarmers(tier: number): number {
+  return FARM_TIER_FARMERS[tier] ?? 1;
+}
+
+/** Find the first farm that has room for more workers, or null */
+export function getAvailableFarm(state: GameState): StructureData | null {
+  for (const [, structure] of state.structures) {
+    if (!isFarmStructure(structure.type)) continue;
+
+    const tier = structure.farmTier ?? 1;
+    const maxWorkers = getFarmMaxFarmers(tier);
+
+    // Windmill farms get bonus worker slots
+    const bonusSlots = structure.type === StructureType.FarmWindmill
+      ? WINDMILL_BONUS_WORKERS
+      : 0;
+    const totalSlots = maxWorkers + bonusSlots;
+
+    if (structure.assignedWorkers.length < totalSlots) {
+      return structure;
+    }
+  }
+  return null;
+}
+
+/** Check if a structure type is any farm tier */
+export function isFarmStructure(type: StructureType): boolean {
+  return type === StructureType.Farm
+    || type === StructureType.FarmIrrigated
+    || type === StructureType.FarmWindmill;
+}
+
+/** Get the build cost for a tier-1 farm */
+export function getFarmBuildCost(): number {
+  return FARM_TIER_BUILD_COST;
+}
+
+/** Get the upgrade cost for the next farm tier */
+export function getFarmUpgradeCost(currentTier: number): number {
+  if (currentTier >= 2) return 0; // tier 3 is via blessing, free
+  return FARM_TIER_UPGRADE_COST;
+}

--- a/kingdom/structures/forge.ts
+++ b/kingdom/structures/forge.ts
@@ -1,0 +1,153 @@
+/**
+ * Forge structure: produces iron swords for squires to become knights.
+ *
+ * Found on islands 3+ as ruins at a fixed position (x = 400).
+ * 8 coins to repair from ruins.
+ * Produces iron swords: 12 coins per sword.
+ * Sword appears at forge position; squire walks to forge, picks up sword, becomes Knight.
+ * One sword produced at a time, 30-second production time.
+ * Requires TownCenterTier >= 7 (Iron Keep).
+ */
+
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  TownCenterTier,
+  UnitRole,
+  AIState,
+  GamePhase,
+} from '../types';
+
+const FORGE_REPAIR_COST = 8;
+const FORGE_SWORD_COST = 12;
+const FORGE_PRODUCTION_TIME = 30.0;
+const FORGE_X_DEFAULT = 400;
+const MIN_ISLAND = 3;
+const MIN_TOWN_CENTER_TIER = TownCenterTier.IronKeep;
+
+interface ForgeState {
+  built: boolean;
+  x: number;
+  swordReady: boolean;
+  swordTimer: number;
+  producing: boolean;
+}
+
+let forgeState: ForgeState = {
+  built: false,
+  x: FORGE_X_DEFAULT,
+  swordReady: false,
+  swordTimer: 0,
+  producing: false,
+};
+
+/** Check if the forge is built */
+export function isForgeBuilt(): boolean {
+  return forgeState.built;
+}
+
+/** Check if a sword is ready for pickup */
+export function isSwordReady(): boolean {
+  return forgeState.swordReady;
+}
+
+/** Get forge position */
+export function getForgeX(): number {
+  return forgeState.x;
+}
+
+/** Get forge state (read-only) */
+export function getForgeState(): Readonly<ForgeState> {
+  return forgeState;
+}
+
+/** Repair the forge from ruins. Costs 8 coins. */
+export function buildForge(state: GameState): boolean {
+  if (forgeState.built) return false;
+  if (state.islandIndex < MIN_ISLAND) return false;
+  if (state.townCenterTier < MIN_TOWN_CENTER_TIER) return false;
+  if (state.monarchCoins < FORGE_REPAIR_COST) return false;
+
+  state.monarchCoins -= FORGE_REPAIR_COST;
+  forgeState.built = true;
+  forgeState.x = FORGE_X_DEFAULT;
+
+  state.messages.push('Forge repaired! Drop coins to begin producing swords.');
+  return true;
+}
+
+/** Start producing a sword. Costs 12 coins. */
+export function startSwordProduction(state: GameState): boolean {
+  if (!forgeState.built) return false;
+  if (forgeState.producing || forgeState.swordReady) return false;
+  if (state.monarchCoins < FORGE_SWORD_COST) return false;
+
+  state.monarchCoins -= FORGE_SWORD_COST;
+  forgeState.producing = true;
+  forgeState.swordTimer = FORGE_PRODUCTION_TIME;
+
+  state.messages.push('Forge begins producing an iron sword...');
+  return true;
+}
+
+/** Collect the sword: nearest squire becomes a knight */
+export function collectSword(state: GameState): boolean {
+  if (!forgeState.swordReady) return false;
+
+  // Find nearest squire to forge
+  let bestSquire = -1;
+  let bestDist = Infinity;
+
+  for (let i = 0; i < state.units.length; i++) {
+    const unit = state.units[i];
+    if (unit.role !== UnitRole.Squire) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    const dist = Math.abs(pos.x - forgeState.x);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestSquire = i;
+    }
+  }
+
+  if (bestSquire === -1) return false;
+
+  // Promote squire to knight
+  const squire = state.units[bestSquire];
+  squire.role = UnitRole.Knight;
+  squire.hp = 5;
+  squire.maxHp = 5;
+  squire.aiState = AIState.Idle;
+
+  forgeState.swordReady = false;
+  state.messages.push('Squire picks up iron sword and becomes a Knight!');
+  return true;
+}
+
+/** Update forge production timer */
+export function updateForge(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+  if (!forgeState.built) return;
+  if (!forgeState.producing) return;
+
+  forgeState.swordTimer -= dt;
+  if (forgeState.swordTimer <= 0) {
+    forgeState.producing = false;
+    forgeState.swordReady = true;
+    state.messages.push('Iron sword ready at the forge!');
+
+    // Auto-collect if a squire is nearby
+    collectSword(state);
+  }
+}
+
+/** Reset forge state (for island transitions) */
+export function resetForge(): void {
+  forgeState = {
+    built: false,
+    x: FORGE_X_DEFAULT,
+    swordReady: false,
+    swordTimer: 0,
+    producing: false,
+  };
+}

--- a/kingdom/structures/lighthouse.ts
+++ b/kingdom/structures/lighthouse.ts
@@ -1,0 +1,120 @@
+/**
+ * Lighthouse structure: decay protection for islands.
+ *
+ * Located at island edge (x = 10 or x = MAP_WIDTH - 10).
+ * 3 upgrade tiers:
+ *   Wooden (6 coins): 10 days decay protection
+ *   Stone (12 coins): 20 days decay protection
+ *   Iron (18 coins): 30 days decay protection
+ *
+ * With lighthouse: safe landing when monarch returns.
+ * Without lighthouse: boat crashes, lose some coins.
+ */
+
+import {
+  type GameState,
+  MAP_WIDTH,
+} from '../types';
+
+export enum LighthouseTier {
+  Ruins = 0,
+  Wooden = 1,
+  Stone = 2,
+  Iron = 3,
+}
+
+const LIGHTHOUSE_COSTS: Record<number, number> = {
+  [LighthouseTier.Wooden]: 6,
+  [LighthouseTier.Stone]: 12,
+  [LighthouseTier.Iron]: 18,
+};
+
+const LIGHTHOUSE_PROTECTION_DAYS: Record<number, number> = {
+  [LighthouseTier.Ruins]: 0,
+  [LighthouseTier.Wooden]: 10,
+  [LighthouseTier.Stone]: 20,
+  [LighthouseTier.Iron]: 30,
+};
+
+const LIGHTHOUSE_NAMES: Record<number, string> = {
+  [LighthouseTier.Ruins]: 'Ruins',
+  [LighthouseTier.Wooden]: 'Wooden Lighthouse',
+  [LighthouseTier.Stone]: 'Stone Lighthouse',
+  [LighthouseTier.Iron]: 'Iron Lighthouse',
+};
+
+/** Per-island lighthouse state */
+interface LighthouseState {
+  tier: LighthouseTier;
+  x: number;
+}
+
+/** Lighthouse state per island index */
+const lighthouseStates: Map<number, LighthouseState> = new Map();
+
+/** Get default lighthouse positions */
+const LIGHTHOUSE_LEFT_X = 10;
+const LIGHTHOUSE_RIGHT_X = MAP_WIDTH - 10;
+
+/** Get the lighthouse state for the current island */
+function getLighthouseState(state: GameState): LighthouseState {
+  let ls = lighthouseStates.get(state.islandIndex);
+  if (!ls) {
+    ls = { tier: LighthouseTier.Ruins, x: LIGHTHOUSE_LEFT_X };
+    lighthouseStates.set(state.islandIndex, ls);
+  }
+  return ls;
+}
+
+/** Build or upgrade the lighthouse. Deducts coins. */
+export function upgradeLighthouse(state: GameState): boolean {
+  const ls = getLighthouseState(state);
+  const nextTier = ls.tier + 1;
+  if (nextTier > LighthouseTier.Iron) return false;
+
+  const cost = LIGHTHOUSE_COSTS[nextTier];
+  if (cost === undefined || state.monarchCoins < cost) return false;
+
+  state.monarchCoins -= cost;
+  ls.tier = nextTier;
+
+  const name = LIGHTHOUSE_NAMES[nextTier] ?? 'Lighthouse';
+  state.messages.push(`${name} built! ${LIGHTHOUSE_PROTECTION_DAYS[nextTier]} days of decay protection.`);
+  return true;
+}
+
+/** Check if the lighthouse can be upgraded */
+export function canUpgradeLighthouse(state: GameState): boolean {
+  const ls = getLighthouseState(state);
+  const nextTier = ls.tier + 1;
+  if (nextTier > LighthouseTier.Iron) return false;
+  const cost = LIGHTHOUSE_COSTS[nextTier];
+  return cost !== undefined && state.monarchCoins >= cost;
+}
+
+/** Get the number of days of decay protection from the lighthouse */
+export function getLighthouseDecayProtection(state: GameState): number {
+  const ls = getLighthouseState(state);
+  return LIGHTHOUSE_PROTECTION_DAYS[ls.tier] ?? 0;
+}
+
+/** Get the current lighthouse tier for an island */
+export function getLighthouseTier(state: GameState): LighthouseTier {
+  return getLighthouseState(state).tier;
+}
+
+/** Get the lighthouse x position for the current island */
+export function getLighthouseX(state: GameState): number {
+  return getLighthouseState(state).x;
+}
+
+/** Create the lighthouse (place at island edge) */
+export function createLighthouse(state: GameState, x?: number): void {
+  const ls = getLighthouseState(state);
+  ls.x = x ?? LIGHTHOUSE_LEFT_X;
+}
+
+/** Update lighthouse (no per-frame updates needed currently) */
+export function updateLighthouse(_state: GameState, _dt: number): void {
+  // Reserved for future lighthouse animations or effects
+}

--- a/kingdom/structures/portal.ts
+++ b/kingdom/structures/portal.ts
@@ -1,0 +1,689 @@
+/**
+ * Portal structure management and world layout for the 1200-wide world.
+ *
+ * Portal positions from map.ts: 30, 220, 540, 880, 1170 (between settlements).
+ * Settlements from map.ts: 150, 400, 600, 800, 1050.
+ * Each portal has independent difficulty that scales per night survived.
+ * Destroying a portal permanently clears the area for settlement expansion.
+ * Victory: all portals destroyed on island 5.
+ */
+
+import { addEntity, setPosition, getPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  UnitRole,
+  AIState,
+  TowerTier,
+  GROUND_Y,
+  PORTAL_HP,
+  GamePhase,
+  GreedType,
+  PortalType,
+} from '../types';
+import { isWallStructure, isTowerStructure } from './wall';
+import { SETTLEMENT_CENTERS } from '../world/map';
+import { dropGemsOnPortalDestruction } from '../systems/gems';
+
+export const FINAL_ISLAND = 5;
+export const TOTAL_ISLANDS = 9; // 0-5 main + 6-8 challenge
+
+// ─── Challenge Island System ─────────────────────────────────────────
+
+/** Challenge islands are post-campaign (islands 6-8) */
+export function isChallengeIsland(index: number): boolean {
+  return index >= 6 && index <= 8;
+}
+
+export interface ChallengeRules {
+  name: string;
+  description: string;
+  endless: boolean;
+  difficultyMultiplier: number;
+  mapWidth: number;
+  allTypesFromNight1: boolean;
+  maxVagrantCamps: number;
+  hasMerchant: boolean;
+  hasBanker: boolean;
+  victoryCondition: string;
+  goldMedalNights: number;
+  diamondMedalNights: number;
+  hasPlagueCrawlers: boolean;
+  surviveAfterPortals: number;
+}
+
+const CHALLENGE_RULES: Record<number, ChallengeRules> = {
+  6: { // Skull Island
+    name: 'Skull Island',
+    description: 'Endless survival, no portals to destroy',
+    endless: true,
+    difficultyMultiplier: 3.0,
+    mapWidth: 400,
+    allTypesFromNight1: false,
+    maxVagrantCamps: 4,
+    hasMerchant: true,
+    hasBanker: true,
+    victoryCondition: 'survive',
+    goldMedalNights: 30,
+    diamondMedalNights: 50,
+    hasPlagueCrawlers: false,
+    surviveAfterPortals: 0,
+  },
+  7: { // Dire Island
+    name: 'Dire Island',
+    description: 'Island 5 difficulty x3, all greed types from night 1',
+    endless: false,
+    difficultyMultiplier: 5.0,
+    mapWidth: 1200,
+    allTypesFromNight1: true,
+    maxVagrantCamps: 2,
+    hasMerchant: false,
+    hasBanker: false,
+    victoryCondition: 'destroyAllPortals',
+    goldMedalNights: 0,
+    diamondMedalNights: 0,
+    hasPlagueCrawlers: false,
+    surviveAfterPortals: 0,
+  },
+  8: { // Plague Island
+    name: 'Plague Island',
+    description: 'Plague Crawlers climb over walls and poison units',
+    endless: false,
+    difficultyMultiplier: 2.5,
+    mapWidth: 1000,
+    allTypesFromNight1: false,
+    maxVagrantCamps: 4,
+    hasMerchant: true,
+    hasBanker: true,
+    victoryCondition: 'destroyAndSurvive',
+    goldMedalNights: 0,
+    diamondMedalNights: 0,
+    hasPlagueCrawlers: true,
+    surviveAfterPortals: 10,
+  },
+};
+
+/** Get challenge rules for an island index, or null for non-challenge islands */
+export function getChallengeRules(index: number): ChallengeRules | null {
+  return CHALLENGE_RULES[index] ?? null;
+}
+
+/** Get the difficulty multiplier for a challenge island */
+export function getChallengeDifficulty(index: number): number {
+  return CHALLENGE_RULES[index]?.difficultyMultiplier ?? 1.0;
+}
+
+/** Fixed world layout positions (must match map.ts) */
+export const PORTAL_POSITIONS_WORLD: readonly number[] = [30, 220, 540, 880, 1170];
+export const SETTLEMENT_POSITIONS: readonly number[] = SETTLEMENT_CENTERS;
+
+/** Defense rating search radius around a settlement center */
+const DEFENSE_RADIUS = 20;
+
+/** Retaliation wave flag: set when a portal is destroyed */
+let retaliationPending = false;
+
+/** Per-portal difficulty: number of nights this portal has been active */
+const portalDifficulty: Map<number, number> = new Map();
+
+/** Permanently destroyed portal positions (cleared areas) */
+const destroyedPortalPositions: Set<number> = new Set();
+
+/** Get the expected number of portals for an island (base 2 + 1 per island) */
+export function getPortalCountForIsland(islandIndex: number): number {
+  return 1 + islandIndex;
+}
+
+/** Get per-portal difficulty multiplier (1.0 base + 0.1 per night survived) */
+export function getPortalDifficulty(portalX: number): number {
+  const nights = portalDifficulty.get(portalX) ?? 0;
+  return 1 + nights * 0.1;
+}
+
+/** Increment difficulty for all active portals (call once per night start) */
+export function incrementPortalDifficulty(state: GameState): void {
+  for (const x of state.portalPositions) {
+    if (isPortalActive(state, x)) {
+      const current = portalDifficulty.get(x) ?? 0;
+      portalDifficulty.set(x, current + 1);
+    }
+  }
+}
+
+/** Check if a portal position has been permanently destroyed */
+export function isPortalCleared(x: number): boolean {
+  return destroyedPortalPositions.has(x);
+}
+
+/** Get the nearest settlement center to a given x position */
+export function getNearestSettlement(x: number): number {
+  let best = SETTLEMENT_POSITIONS[0];
+  let bestDist = Math.abs(x - best);
+
+  for (let i = 1; i < SETTLEMENT_POSITIONS.length; i++) {
+    const dist = Math.abs(x - SETTLEMENT_POSITIONS[i]);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = SETTLEMENT_POSITIONS[i];
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Calculate defense rating for a settlement.
+ * Walls: +1 each, Towers: +3 each, Archers within radius: +2 each.
+ */
+export function getSettlementDefenseRating(state: GameState, settlementX: number): number {
+  let rating = 0;
+
+  // Count walls and towers
+  for (const [x, structure] of state.structures) {
+    if (Math.abs(x - settlementX) > DEFENSE_RADIUS) continue;
+    if (isWallStructure(structure.type)) rating += 1;
+    if (isTowerStructure(structure.type)) rating += 3;
+  }
+
+  // Count archers
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Archer) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - settlementX) <= DEFENSE_RADIUS) {
+      rating += 2;
+    }
+  }
+
+  return rating;
+}
+
+/**
+ * Get the weakest settlement (lowest defense rating).
+ * Returns the settlement x position.
+ */
+export function getWeakestSettlement(state: GameState): number {
+  let weakest = SETTLEMENT_POSITIONS[0];
+  let lowestRating = getSettlementDefenseRating(state, weakest);
+
+  for (let i = 1; i < SETTLEMENT_POSITIONS.length; i++) {
+    const sx = SETTLEMENT_POSITIONS[i];
+    const rating = getSettlementDefenseRating(state, sx);
+    if (rating < lowestRating) {
+      lowestRating = rating;
+      weakest = sx;
+    }
+  }
+
+  return weakest;
+}
+
+/** Create a portal at the given x position */
+export function createPortal(state: GameState, x: number): StructureData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const portal: StructureData = {
+    eid,
+    type: StructureType.Portal,
+    x,
+    hp: PORTAL_HP,
+    maxHp: PORTAL_HP,
+    level: 1,
+    assignedWorkers: [],
+    towerTier: TowerTier.None,
+    isRoofed: false,
+  };
+
+  state.structures.set(x, portal);
+
+  if (!state.portalPositions.includes(x)) {
+    state.portalPositions.push(x);
+  }
+
+  portalDifficulty.set(x, 0);
+
+  return portal;
+}
+
+/** Apply damage to a portal. Returns remaining hp. */
+export function damagePortal(state: GameState, x: number, dmg: number): number {
+  const portal = state.structures.get(x);
+  if (!portal || portal.type !== StructureType.Portal) return 0;
+
+  portal.hp -= dmg;
+  if (portal.hp <= 0) {
+    portal.hp = 0;
+    destroyPortal(state, x);
+    return 0;
+  }
+  return portal.hp;
+}
+
+/** Destroy a portal. Permanently clears the area. Triggers retaliation. */
+export function destroyPortal(state: GameState, x: number): void {
+  const portal = state.structures.get(x);
+  if (!portal || portal.type !== StructureType.Portal) return;
+
+  state.structures.delete(x);
+
+  const idx = state.portalPositions.indexOf(x);
+  if (idx !== -1) {
+    state.portalPositions.splice(idx, 1);
+  }
+
+  // Permanently mark as cleared
+  destroyedPortalPositions.add(x);
+  portalDifficulty.delete(x);
+
+  retaliationPending = true;
+
+  // Drop gems on portal destruction
+  const gemsDropped = dropGemsOnPortalDestruction(state, x);
+  state.messages.push(`Portal destroyed at ${x}! +${gemsDropped} gems. Retaliation incoming!`);
+
+  // Victory check: all portals destroyed on the final island
+  if (state.islandIndex >= FINAL_ISLAND && getActivePortals(state).length === 0) {
+    state.phase = GamePhase.Victory;
+    state.messages.push('All portals destroyed! The kingdom is saved!');
+  }
+}
+
+/** Check if a retaliation wave should be spawned */
+export function isRetaliationPending(): boolean {
+  return retaliationPending;
+}
+
+/** Clear the retaliation flag after spawning the wave */
+export function clearRetaliation(): void {
+  retaliationPending = false;
+}
+
+/** Check if a portal at position x exists and has hp > 0 */
+export function isPortalActive(state: GameState, x: number): boolean {
+  const portal = state.structures.get(x);
+  return portal !== undefined
+    && portal.type === StructureType.Portal
+    && portal.hp > 0;
+}
+
+/** Return all active portal x positions */
+export function getActivePortals(state: GameState): number[] {
+  return state.portalPositions.filter(x => isPortalActive(state, x));
+}
+
+// ─── Portal Assault System ──────────────────────────────────────────
+
+/** Knight DPS against portal during assault */
+const KNIGHT_PORTAL_DPS = 2;
+/** Archer DPS against portal during assault */
+const ARCHER_PORTAL_DPS = 1;
+/** Portal defense wave spawn interval during assault (seconds) */
+const DEFENSE_WAVE_INTERVAL = 10;
+/** Portal defense wave size */
+const DEFENSE_WAVE_SIZE_MIN = 3;
+const DEFENSE_WAVE_SIZE_MAX = 5;
+
+/** Timer for next defense wave spawn */
+let defenseWaveTimer = DEFENSE_WAVE_INTERVAL;
+
+/** Entities assigned to current assault */
+const assaultKnights: Set<number> = new Set();
+const assaultArchers: Set<number> = new Set();
+
+/**
+ * Start a portal assault on the given side ('left' or 'right').
+ * Dispatches the nearest knight and archers toward the nearest portal.
+ */
+export function startPortalAssault(state: GameState, side: 'left' | 'right'): boolean {
+  if (state.portalAssaultActive) return false;
+
+  const portals = getActivePortals(state);
+  if (portals.length === 0) return false;
+
+  // Find nearest portal on the given side
+  const centerX = 600;
+  let targetPortal: number | null = null;
+  let bestDist = Infinity;
+
+  for (const px of portals) {
+    if (side === 'left' && px >= centerX) continue;
+    if (side === 'right' && px < centerX) continue;
+    const dist = Math.abs(px - centerX);
+    if (dist < bestDist) {
+      bestDist = dist;
+      targetPortal = px;
+    }
+  }
+
+  // Fallback: any portal
+  if (targetPortal === null) {
+    targetPortal = portals[0];
+  }
+
+  // Find nearest knight
+  let bestKnight = -1;
+  let bestKnightDist = Infinity;
+  for (let i = 0; i < state.units.length; i++) {
+    const unit = state.units[i];
+    if (unit.role !== UnitRole.Knight || unit.hp <= 0) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    const dist = Math.abs(pos.x - targetPortal);
+    if (dist < bestKnightDist) {
+      bestKnightDist = dist;
+      bestKnight = i;
+    }
+  }
+
+  if (bestKnight === -1) {
+    state.messages.push('No knight available for portal assault!');
+    return false;
+  }
+
+  const knight = state.units[bestKnight];
+  knight.aiState = AIState.Attacking;
+  knight.targetX = targetPortal;
+  assaultKnights.add(knight.eid);
+
+  // Find nearby archers to accompany
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Archer || unit.hp <= 0) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - knight.targetX) < 30) {
+      unit.aiState = AIState.Attacking;
+      unit.targetX = targetPortal;
+      assaultArchers.add(unit.eid);
+    }
+  }
+
+  state.portalAssaultActive = true;
+  state.assaultTargetPortal = targetPortal;
+  defenseWaveTimer = DEFENSE_WAVE_INTERVAL;
+
+  state.messages.push(`Portal assault launched toward x=${targetPortal}!`);
+  return true;
+}
+
+/** Update the portal assault each frame */
+export function updatePortalAssault(state: GameState, dt: number): void {
+  if (!state.portalAssaultActive) return;
+
+  const portalX = state.assaultTargetPortal;
+
+  // Check if target portal is still active
+  if (!isPortalActive(state, portalX)) {
+    state.portalAssaultActive = false;
+    assaultKnights.clear();
+    assaultArchers.clear();
+    return;
+  }
+
+  // Clean up dead assault units
+  for (const eid of assaultKnights) {
+    if (!state.units.some(u => u.eid === eid && u.hp > 0)) {
+      assaultKnights.delete(eid);
+    }
+  }
+  for (const eid of assaultArchers) {
+    if (!state.units.some(u => u.eid === eid && u.hp > 0)) {
+      assaultArchers.delete(eid);
+    }
+  }
+
+  // If no more knights, abort assault
+  if (assaultKnights.size === 0) {
+    state.portalAssaultActive = false;
+    assaultArchers.clear();
+    state.messages.push('Portal assault failed: no knights remaining.');
+    return;
+  }
+
+  // Apply DPS from knights near the portal
+  let totalDps = 0;
+  for (const eid of assaultKnights) {
+    const pos = getPosition(state.world, eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - portalX) <= 3) {
+      totalDps += KNIGHT_PORTAL_DPS;
+    }
+  }
+  for (const eid of assaultArchers) {
+    const pos = getPosition(state.world, eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - portalX) <= 15) {
+      totalDps += ARCHER_PORTAL_DPS;
+    }
+  }
+
+  if (totalDps > 0) {
+    damagePortal(state, portalX, totalDps * dt);
+  }
+
+  // Spawn defense waves from the portal
+  defenseWaveTimer -= dt;
+  if (defenseWaveTimer <= 0) {
+    defenseWaveTimer = DEFENSE_WAVE_INTERVAL;
+    const waveSize = DEFENSE_WAVE_SIZE_MIN + Math.floor(
+      Math.random() * (DEFENSE_WAVE_SIZE_MAX - DEFENSE_WAVE_SIZE_MIN + 1)
+    );
+    // Import would be circular; use state.greeds directly to add basic greeds
+    // The spawnGreed import would cause circular deps. We simulate by pushing greed data.
+    for (let i = 0; i < waveSize; i++) {
+      const offset = (Math.random() - 0.5) * 4;
+      // Minimal greed data; combat system handles the rest
+      state.greeds.push({
+        eid: 0 as any, // Will be cleaned up if no entity
+        type: GreedType.Basic,
+        hp: 1,
+        speed: 3,
+        damage: 1,
+        carryingCoins: 0,
+      });
+    }
+    state.messages.push(`Portal spawns ${waveSize} defenders!`);
+  }
+}
+
+// ─── Cave Portal System ─────────────────────────────────────────────
+
+/** Cave portal appears on islands 3+ (one per island) */
+const CAVE_MIN_ISLAND = 3;
+/** Cave spawn rate multiplier vs cliff portals */
+const CAVE_SPAWN_RATE_MULT = 2;
+/** Cave blood moon spawn multiplier */
+const CAVE_BLOOD_MOON_MULT = 3;
+
+/** Track cave portal positions and their hive counts */
+const cavePortalPositions: Map<number, number> = new Map(); // x -> hiveCount
+/** Track portal types */
+const portalTypes: Map<number, PortalType> = new Map();
+
+/** Create a cave portal at the given position. Cave HP = 200 * islandIndex. */
+export function createCavePortal(state: GameState, x: number): StructureData {
+  const hiveCount = state.islandIndex;
+  const caveHp = 200 * state.islandIndex;
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const portal: StructureData = {
+    eid,
+    type: StructureType.Portal,
+    x,
+    hp: caveHp,
+    maxHp: caveHp,
+    level: 1,
+    assignedWorkers: [],
+    towerTier: TowerTier.None,
+    isRoofed: false,
+  };
+
+  state.structures.set(x, portal);
+
+  if (!state.portalPositions.includes(x)) {
+    state.portalPositions.push(x);
+  }
+
+  portalDifficulty.set(x, 0);
+  cavePortalPositions.set(x, hiveCount);
+  portalTypes.set(x, PortalType.Cave);
+
+  return portal;
+}
+
+/** Check if a portal at position x is a cave portal */
+export function isCavePortal(x: number): boolean {
+  return portalTypes.get(x) === PortalType.Cave;
+}
+
+/** Get the number of hives inside a cave portal */
+export function getCaveHiveCount(x: number): number {
+  return cavePortalPositions.get(x) ?? 0;
+}
+
+/** Get the spawn rate multiplier for a portal (cave portals spawn faster) */
+export function getPortalSpawnMultiplier(x: number, isBloodMoon: boolean): number {
+  if (!isCavePortal(x)) return 1;
+  return isBloodMoon ? CAVE_BLOOD_MOON_MULT : CAVE_SPAWN_RATE_MULT;
+}
+
+/** Get the portal type for a given position */
+export function getPortalType(x: number): PortalType {
+  return portalTypes.get(x) ?? PortalType.Cliff;
+}
+
+/** Set the portal type for a position */
+export function setPortalType(x: number, type: PortalType): void {
+  portalTypes.set(x, type);
+}
+
+/**
+ * Destroy a cave portal via bomb. ALL greed on island die immediately.
+ * Island marked as "cleared" (no more greed spawn ever).
+ * Gem reward: 4-8 gems.
+ */
+export function destroyCavePortal(state: GameState, x: number): void {
+  if (!isCavePortal(x)) return;
+
+  // Kill all greed on the island
+  for (const greed of state.greeds) {
+    greed.hp = 0;
+  }
+
+  // Remove from tracking
+  cavePortalPositions.delete(x);
+  portalTypes.delete(x);
+
+  // Destroy the portal structure
+  state.structures.delete(x);
+  const idx = state.portalPositions.indexOf(x);
+  if (idx !== -1) {
+    state.portalPositions.splice(idx, 1);
+  }
+
+  destroyedPortalPositions.add(x);
+  portalDifficulty.delete(x);
+
+  // Gem reward: 4-8 gems
+  const gemReward = 4 + Math.floor(Math.random() * 5);
+  state.gems = Math.min(state.gemCapacity, state.gems + gemReward);
+
+  state.messages.push(`Cave portal destroyed! All greed vanquished! +${gemReward} gems.`);
+
+  // Victory check
+  if (state.islandIndex >= FINAL_ISLAND && getActivePortals(state).length === 0) {
+    state.phase = GamePhase.Victory;
+    state.messages.push('All portals destroyed! The kingdom is saved!');
+  }
+}
+
+// ─── Teleporter System ──────────────────────────────────────────────
+
+/** Days after portal destruction before teleporter activates */
+const TELEPORTER_ACTIVATION_DAYS = 3;
+/** Cost to use a teleporter */
+const TELEPORTER_USE_COST = 2;
+
+/** Track teleporter status: destroyed portal x -> { dayDestroyed, ready } */
+interface TeleporterData {
+  dayDestroyed: number;
+  ready: boolean;
+}
+const teleporters: Map<number, TeleporterData> = new Map();
+
+/**
+ * Convert a destroyed portal position to a teleporter.
+ * Called internally after portal destruction; activates after 3 days.
+ */
+export function convertToTeleporter(x: number, dayCount: number): void {
+  if (!destroyedPortalPositions.has(x)) return;
+  if (teleporters.has(x)) return;
+
+  teleporters.set(x, {
+    dayDestroyed: dayCount,
+    ready: false,
+  });
+}
+
+/**
+ * Update teleporter readiness. Call once per day.
+ * Teleporters become ready 3 days after portal destruction.
+ */
+export function updateTeleporters(dayCount: number): void {
+  for (const [x, data] of teleporters) {
+    if (!data.ready && dayCount - data.dayDestroyed >= TELEPORTER_ACTIVATION_DAYS) {
+      data.ready = true;
+    }
+  }
+
+  // Auto-convert any destroyed portals that don't have teleporters yet
+  for (const x of destroyedPortalPositions) {
+    if (!teleporters.has(x)) {
+      teleporters.set(x, {
+        dayDestroyed: dayCount,
+        ready: false,
+      });
+    }
+  }
+}
+
+/** Get all available (ready) teleporter positions */
+export function getAvailableTeleporters(): number[] {
+  const result: number[] = [];
+  for (const [x, data] of teleporters) {
+    if (data.ready) result.push(x);
+  }
+  return result;
+}
+
+/** Check if a position has a ready teleporter */
+export function isTeleporterReady(x: number): boolean {
+  const data = teleporters.get(x);
+  return data?.ready ?? false;
+}
+
+/**
+ * Use a teleporter to move the monarch to another teleporter.
+ * Costs 2 coins. Returns the destination x, or -1 if failed.
+ */
+export function useTeleporter(
+  state: GameState,
+  fromX: number,
+  toX: number,
+): number {
+  if (!isTeleporterReady(fromX)) return -1;
+  if (!isTeleporterReady(toX)) return -1;
+  if (fromX === toX) return -1;
+  if (state.monarchCoins < TELEPORTER_USE_COST) return -1;
+
+  state.monarchCoins -= TELEPORTER_USE_COST;
+
+  // Move monarch to destination
+  setPosition(state.world, state.monarch.eid, toX, GROUND_Y);
+  state.messages.push(`Teleported to x=${toX}!`);
+
+  return toX;
+}

--- a/kingdom/structures/resources.ts
+++ b/kingdom/structures/resources.ts
@@ -1,0 +1,241 @@
+/**
+ * Resource nodes: gold veins, berry bushes, trees, and fishing streams.
+ *
+ * Gold Veins:
+ *   Finite: 50 coins per vein, becomes inert when depleted.
+ *   Miners extract 1 coin every 10 seconds.
+ *   3-5 gold veins per island.
+ *
+ * Berry Bushes (winter):
+ *   4 berries per bush, 1 coin per berry.
+ *   Regrow after 2 days if still winter.
+ *   8-12 bushes per island during winter.
+ *
+ * Trees:
+ *   Drop 1 coin when cut by builder.
+ *   Block wall placement (must be cut first).
+ *   Regrow slowly: 1 per day in spring/summer, no regrowth in autumn/winter.
+ *
+ * Streams:
+ *   Pikemen can fish for 1 coin, 8-second fishing time.
+ *   Only in non-frozen streams (not winter).
+ */
+
+import { type GameState, MAP_WIDTH, Season } from '../types';
+
+export enum ResourceType {
+  GoldVein = 'goldVein',
+  BerryBush = 'berryBush',
+  Tree = 'tree',
+  Stream = 'stream',
+}
+
+export interface ResourceNode {
+  x: number;
+  type: ResourceType;
+  harvestsRemaining: number;
+  depleted: boolean;
+  respawnTimer: number;
+}
+
+/** Gold vein constants */
+const GOLD_VEIN_MAX_HARVESTS = 50;
+const GOLD_VEIN_HARVEST_INTERVAL = 10; // seconds
+
+/** Berry bush constants */
+const BERRY_BUSH_HARVESTS = 4;
+const BERRY_BUSH_REGROW_DAYS = 2;
+
+/** Tree constants */
+const TREE_HARVESTS = 1;
+
+/** Fishing constants */
+export const FISHING_TIME = 8; // seconds per fish
+const FISHING_HARVESTS = 99; // effectively unlimited per stream
+
+/** All resource nodes keyed by x position */
+const resources: Map<number, ResourceNode> = new Map();
+
+/** Per-resource harvest cooldown (seconds remaining) */
+const harvestCooldowns: Map<number, number> = new Map();
+
+/** Track positions of winter berry bushes for cleanup */
+const winterBerryPositions: Set<number> = new Set();
+
+/** Track depleted berry bush positions for regrowth */
+const depletedBerryTimers: Map<number, number> = new Map();
+
+/** Tree positions that have been cut (for wall placement check) */
+const cutTrees: Set<number> = new Set();
+
+/** Create a resource node at the given x position */
+export function createResource(_state: GameState, x: number, type: ResourceType): void {
+  let maxHarvests: number;
+  switch (type) {
+    case ResourceType.GoldVein:
+      maxHarvests = GOLD_VEIN_MAX_HARVESTS;
+      break;
+    case ResourceType.BerryBush:
+      maxHarvests = BERRY_BUSH_HARVESTS;
+      break;
+    case ResourceType.Tree:
+      maxHarvests = TREE_HARVESTS;
+      break;
+    case ResourceType.Stream:
+      maxHarvests = FISHING_HARVESTS;
+      break;
+    default:
+      maxHarvests = 20;
+  }
+
+  resources.set(x, {
+    x,
+    type,
+    harvestsRemaining: maxHarvests,
+    depleted: false,
+    respawnTimer: 0,
+  });
+}
+
+/** Harvest a resource at x. Returns coins gained (0 if unavailable or on cooldown). */
+export function harvestResource(_state: GameState, x: number): number {
+  const node = resources.get(x);
+  if (!node || node.depleted) return 0;
+
+  const cooldown = harvestCooldowns.get(x) ?? 0;
+  if (cooldown > 0) return 0;
+
+  node.harvestsRemaining -= 1;
+
+  // Set cooldown based on resource type
+  switch (node.type) {
+    case ResourceType.GoldVein:
+      harvestCooldowns.set(x, GOLD_VEIN_HARVEST_INTERVAL);
+      break;
+    case ResourceType.Stream:
+      harvestCooldowns.set(x, FISHING_TIME);
+      break;
+    default:
+      harvestCooldowns.set(x, 1); // 1 second for berries/trees
+  }
+
+  if (node.harvestsRemaining <= 0) {
+    node.depleted = true;
+
+    if (node.type === ResourceType.Tree) {
+      cutTrees.add(x);
+    }
+
+    // Gold veins stay inert (no respawn)
+    // Berry bushes track for regrowth
+    if (node.type === ResourceType.BerryBush) {
+      depletedBerryTimers.set(x, 0);
+    }
+  }
+
+  return 1;
+}
+
+/** Get the resource node at position x, or null */
+export function getResourceAt(_state: GameState, x: number): ResourceNode | null {
+  return resources.get(x) ?? null;
+}
+
+/** Check if a tree exists at position x (blocks wall placement) */
+export function hasTreeAt(x: number): boolean {
+  const node = resources.get(x);
+  return node !== null && node !== undefined && node.type === ResourceType.Tree && !node.depleted;
+}
+
+/** Check if fishing is available at position x (not winter) */
+export function canFishAt(x: number, season: Season): boolean {
+  if (season === Season.Winter) return false;
+  const node = resources.get(x);
+  return node !== null && node !== undefined && node.type === ResourceType.Stream && !node.depleted;
+}
+
+/** Update resource respawn timers, harvest cooldowns, and seasonal effects. */
+export function updateResources(dt: number, season?: Season, dayLength?: number): void {
+  // Update harvest cooldowns
+  for (const [x, cooldown] of harvestCooldowns) {
+    const next = cooldown - dt;
+    if (next <= 0) {
+      harvestCooldowns.delete(x);
+    } else {
+      harvestCooldowns.set(x, next);
+    }
+  }
+
+  // Update depleted berry bush regrowth (only in winter)
+  if (season === Season.Winter) {
+    const dayDuration = dayLength ?? 180;
+    for (const [x, timer] of depletedBerryTimers) {
+      const newTimer = timer + dt;
+      if (newTimer >= BERRY_BUSH_REGROW_DAYS * dayDuration) {
+        // Regrow the berry bush
+        const node = resources.get(x);
+        if (node && node.type === ResourceType.BerryBush) {
+          node.depleted = false;
+          node.harvestsRemaining = BERRY_BUSH_HARVESTS;
+        }
+        depletedBerryTimers.delete(x);
+      } else {
+        depletedBerryTimers.set(x, newTimer);
+      }
+    }
+  }
+
+  // Tree regrowth: 1 per day in spring/summer (handled externally via regrowTree)
+}
+
+/** Regrow a single tree at position x (called by game loop, 1 per day in spring/summer) */
+export function regrowTree(x: number): boolean {
+  if (!cutTrees.has(x)) return false;
+
+  resources.set(x, {
+    x,
+    type: ResourceType.Tree,
+    harvestsRemaining: TREE_HARVESTS,
+    depleted: false,
+    respawnTimer: 0,
+  });
+  cutTrees.delete(x);
+  return true;
+}
+
+/** Get all cut tree positions (for regrowth selection) */
+export function getCutTreePositions(): ReadonlySet<number> {
+  return cutTrees;
+}
+
+/**
+ * Spawn 8-12 berry bushes across the map when winter starts.
+ * Each bush has 4 harvests at 1 coin per berry.
+ */
+export function spawnWinterBerries(_state: GameState): void {
+  const count = 8 + Math.floor(Math.random() * 5); // 8-12
+
+  for (let i = 0; i < count; i++) {
+    const x = 50 + Math.floor(Math.random() * (MAP_WIDTH - 100));
+    if (resources.has(x)) continue;
+
+    resources.set(x, {
+      x,
+      type: ResourceType.BerryBush,
+      harvestsRemaining: BERRY_BUSH_HARVESTS,
+      depleted: false,
+      respawnTimer: 0,
+    });
+    winterBerryPositions.add(x);
+  }
+}
+
+/** Remove all winter berry bushes when winter ends */
+export function clearWinterBerries(_state: GameState): void {
+  for (const x of winterBerryPositions) {
+    resources.delete(x);
+    harvestCooldowns.delete(x);
+    depletedBerryTimers.delete(x);
+  }
+  winterBerryPositions.clear();
+}

--- a/kingdom/structures/ship.ts
+++ b/kingdom/structures/ship.ts
@@ -1,0 +1,312 @@
+/**
+ * Ship/Boat structure: full boat mechanics for island travel.
+ *
+ * Boat wreck found at island edge (x = 5 or x = MAP_WIDTH - 5).
+ * Restoration process:
+ *   - 10 coins to begin restoration (initial repair)
+ *   - 59 hull pieces needed, 2 coins each (118 coins total)
+ *     - Island 1: all pieces free (tutorial), Island 2: 40 free
+ *   - Builders hammer pieces into place (1 builder per piece, 5 seconds each)
+ *   - Uninstalled hull pieces can be stolen by greedlings during night
+ * Launch: 2 coins to launch boat into water
+ * Dock sequence:
+ *   - Builders push vessel toward dock (0.5x speed, 2+ builders)
+ *   - Dock bell: 2 coins to summon 3 vagrants and 3 archers as crew
+ * Departure: 10 coins to depart
+ *   - Dog and hermits auto-board
+ *   - Knight squads can be assigned as escort
+ * Return trip: arriving at destination island
+ *   - If lighthouse exists: safe landing
+ *   - If no lighthouse: crash landing, lose 20% of coins
+ *
+ * State: boatState, hullPieces, boatBuilders, boardedEntities
+ */
+
+import { addEntity, setPosition, getPosition } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  GROUND_Y,
+  MAP_WIDTH,
+  UnitRole,
+  AIState,
+} from '../types';
+import { FINAL_ISLAND } from './portal';
+import { getLighthouseTier } from './lighthouse';
+
+const SHIP_LEFT_X = 5;
+const SHIP_RIGHT_X = MAP_WIDTH - 5;
+const SHIP_MAX_HP = 20;
+
+const RESTORATION_COST = 10;
+const HULL_PIECE_COST = 2;
+const HULL_PIECES_TOTAL = 59;
+const HULL_PIECE_BUILD_TIME = 5.0;
+const LAUNCH_COST = 2;
+const DOCK_BELL_COST = 2;
+const DEPARTURE_COST = 10;
+
+const PUSH_SPEED = 0.5;
+const MIN_PUSH_BUILDERS = 2;
+
+/** Free hull pieces by island (tutorial assistance) */
+const FREE_PIECES: Record<number, number> = {
+  1: 59, // all free on island 1
+  2: 40,
+};
+
+/** Hull piece installation progress per x position */
+const hullBuildTimers: Map<number, number> = new Map();
+
+/** Builder entities assigned to boat work */
+const boatBuilders: Set<Entity> = new Set();
+
+/** Entities boarded on the ship */
+const boardedEntities: Set<Entity> = new Set();
+
+/** Ship x position (can move when being pushed) */
+let shipX = SHIP_LEFT_X;
+
+/** Side the ship is on */
+let shipSide: 'left' | 'right' = 'left';
+
+/** Get current ship x position */
+export function getShipX(): number {
+  return shipX;
+}
+
+/** Get which side the ship is on */
+export function getShipSide(): 'left' | 'right' {
+  return shipSide;
+}
+
+/** Check if a builder is assigned to boat work */
+export function isBoatBuilder(eid: Entity): boolean {
+  return boatBuilders.has(eid);
+}
+
+/** Get the number of free hull pieces for current island */
+function getFreePieces(islandIndex: number): number {
+  return FREE_PIECES[islandIndex] ?? 0;
+}
+
+/** Get the cost for a hull piece (0 if free pieces remain) */
+function getHullPieceCost(state: GameState): number {
+  const free = getFreePieces(state.islandIndex);
+  if (state.hullPieces < free) return 0;
+  return HULL_PIECE_COST;
+}
+
+/** Create a ship structure at the island edge */
+export function createShip(state: GameState, side: 'left' | 'right' = 'left'): StructureData {
+  shipSide = side;
+  shipX = side === 'left' ? SHIP_LEFT_X : SHIP_RIGHT_X;
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, shipX, GROUND_Y);
+
+  const ship: StructureData = {
+    eid,
+    type: StructureType.Ship,
+    x: shipX,
+    hp: 0,
+    maxHp: SHIP_MAX_HP,
+    level: 1,
+    assignedWorkers: [],
+  };
+
+  state.structures.set(shipX, ship);
+  state.boatState = 'wreck';
+  state.hullPieces = 0;
+  return ship;
+}
+
+/** Start boat restoration. Costs 10 coins for initial repair. */
+export function startBoatRestoration(state: GameState): boolean {
+  if (state.boatState !== 'wreck') return false;
+  if (state.monarchCoins < RESTORATION_COST) return false;
+
+  state.monarchCoins -= RESTORATION_COST;
+  state.boatState = 'restoring';
+  state.hullPieces = 0;
+
+  state.messages.push('Boat restoration begun! Builders will install hull pieces.');
+  return true;
+}
+
+/** Add a hull piece to the boat. Costs 2 coins (or free on early islands). */
+export function addHullPiece(state: GameState): boolean {
+  if (state.boatState !== 'restoring') return false;
+  if (state.hullPieces >= HULL_PIECES_TOTAL) return false;
+
+  const cost = getHullPieceCost(state);
+  if (state.monarchCoins < cost) return false;
+
+  state.monarchCoins -= cost;
+  state.hullPieces += 1;
+
+  if (state.hullPieces >= HULL_PIECES_TOTAL) {
+    state.boatState = 'ready';
+    state.messages.push('All hull pieces installed! Pay 2 coins to launch.');
+  }
+
+  return true;
+}
+
+/** Launch the boat into water. Costs 2 coins. */
+export function launchBoat(state: GameState): boolean {
+  if (state.boatState !== 'ready') return false;
+  if (state.monarchCoins < LAUNCH_COST) return false;
+
+  state.monarchCoins -= LAUNCH_COST;
+  state.boatState = 'launched';
+
+  state.messages.push('Boat launched! Assign 2+ builders to push to dock.');
+  return true;
+}
+
+/** Dock the boat (called when builders push it to dock position). */
+export function dockBoat(state: GameState): boolean {
+  if (state.boatState !== 'launched') return false;
+
+  state.boatState = 'docked';
+  state.messages.push('Boat docked! Pay 2 coins for dock bell, then 10 coins to depart.');
+  return true;
+}
+
+/** Ring the dock bell. Costs 2 coins, summons crew. */
+export function ringDockBell(state: GameState): boolean {
+  if (state.boatState !== 'docked') return false;
+  if (state.monarchCoins < DOCK_BELL_COST) return false;
+
+  state.monarchCoins -= DOCK_BELL_COST;
+
+  // Summon crew is handled by the entity spawning system
+  state.messages.push('Dock bell rings! Crew summoned. Pay 10 coins to depart.');
+  return true;
+}
+
+/** Board an entity onto the ship */
+export function boardEntity(_state: GameState, eid: Entity): boolean {
+  if (boardedEntities.has(eid)) return false;
+  boardedEntities.add(eid);
+  return true;
+}
+
+/** Depart to next island. Costs 10 coins. */
+export function departBoat(state: GameState): boolean {
+  if (state.boatState !== 'docked') return false;
+  if (state.monarchCoins < DEPARTURE_COST) return false;
+  if (state.islandIndex >= FINAL_ISLAND) {
+    state.messages.push('This is the final island. Destroy all portals to win!');
+    return false;
+  }
+
+  state.monarchCoins -= DEPARTURE_COST;
+  state.boatState = 'departed';
+
+  // Auto-board dog and hermits
+  for (const unit of state.units) {
+    if (unit.role === UnitRole.Knight) {
+      const pos = getPosition(state.world, unit.eid);
+      if (pos && Math.abs(pos.x - shipX) <= 5) {
+        boardedEntities.add(unit.eid);
+      }
+    }
+  }
+
+  // Transition to next island
+  state.islandIndex += 1;
+  state.difficultyMultiplier = 1 + (state.islandIndex - 1) * 0.5;
+
+  // Check for lighthouse on destination for safe landing
+  const lighthouseTier = getLighthouseTier(state);
+  if (lighthouseTier <= 0) {
+    // Crash landing: lose 20% of coins
+    const lost = Math.floor(state.monarchCoins * 0.2);
+    state.monarchCoins -= lost;
+    state.messages.push(`Crash landing on island ${state.islandIndex}! Lost ${lost} coins.`);
+  } else {
+    state.messages.push(`Safe landing on island ${state.islandIndex} (lighthouse guides the way).`);
+  }
+
+  // Reset boat to wreck on new island
+  state.boatState = 'wreck';
+  state.hullPieces = 0;
+  boatBuilders.clear();
+  boardedEntities.clear();
+
+  return true;
+}
+
+/** Check if the ship is fully restored and ready to launch */
+export function isShipReady(state: GameState): boolean {
+  return state.boatState === 'ready' || state.boatState === 'launched' || state.boatState === 'docked';
+}
+
+/** Update boat state each frame (builder push logic) */
+export function updateBoat(state: GameState, dt: number): void {
+  if (state.boatState !== 'launched') return;
+
+  // Count builders near the ship
+  let pushBuilders = 0;
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Builder) continue;
+    if (unit.aiState !== AIState.Working) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - shipX) <= 3) {
+      pushBuilders++;
+      boatBuilders.add(unit.eid);
+    }
+  }
+
+  if (pushBuilders < MIN_PUSH_BUILDERS) return;
+
+  // Push toward dock (center of map)
+  const dockX = MAP_WIDTH / 2;
+  const direction = shipX < dockX ? 1 : -1;
+  const distToDock = Math.abs(shipX - dockX);
+
+  if (distToDock <= 2) {
+    dockBoat(state);
+    return;
+  }
+
+  shipX += PUSH_SPEED * direction * dt;
+
+  // Update ship structure position
+  const oldX = Math.round(shipX - PUSH_SPEED * direction * dt);
+  const ship = state.structures.get(oldX);
+  if (ship && ship.type === StructureType.Ship) {
+    state.structures.delete(oldX);
+    ship.x = Math.round(shipX);
+    state.structures.set(ship.x, ship);
+  }
+}
+
+/** Steal hull pieces during night (greed attack) */
+export function stealHullPiece(state: GameState): boolean {
+  if (state.boatState !== 'restoring') return false;
+  if (state.hullPieces <= 0) return false;
+
+  state.hullPieces -= 1;
+  state.messages.push('A greedling stole a hull piece!');
+  return true;
+}
+
+/**
+ * Legacy compatibility: sailToNextIsland wraps departBoat.
+ * Each island: +1 portal count, +0.5 greed hp, +0.5 wave multiplier.
+ * Cannot sail past the final island (5).
+ */
+export function sailToNextIsland(state: GameState): boolean {
+  return departBoat(state);
+}
+
+/** Repair the ship (legacy compatibility). Starts restoration. */
+export function repairShip(state: GameState): boolean {
+  return startBoatRestoration(state);
+}

--- a/kingdom/structures/shrine.ts
+++ b/kingdom/structures/shrine.ts
@@ -1,0 +1,244 @@
+/**
+ * Shrine structure: 4 shrine types with escalating costs and cooldowns.
+ *
+ * Speed Shrine: +30% movement speed for 1 day (5 coins + 2 per previous use)
+ * Damage Shrine: +50% arrow damage for 1 day (5 coins + 2 per previous use)
+ * Shield Shrine: +30% wall HP for 2 days (8 coins + 3 per previous use)
+ * Spawn Shrine: spawn 3 archers immediately (10 coins, once per day)
+ *
+ * 2-3 shrines per island, 1-day cooldown between uses per shrine.
+ */
+
+import { addEntity, setPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  GROUND_Y,
+  DAY_LENGTH,
+} from '../types';
+
+export enum ShrineBuffType {
+  ArcherDamage = 'archerDamage',
+  BuilderSpeed = 'builderSpeed',
+  WallDurability = 'wallDurability',
+  SpawnArchers = 'spawnArchers',
+}
+
+export interface ShrineBuff {
+  type: ShrineBuffType;
+  remaining: number; // seconds remaining
+  multiplier: number;
+}
+
+/** Shrine-specific type assigned to each shrine position */
+export enum ShrineKind {
+  Speed = 0,
+  Damage = 1,
+  Shield = 2,
+  Spawn = 3,
+}
+
+interface ShrineConfig {
+  buffType: ShrineBuffType;
+  baseCost: number;
+  costPerUse: number;
+  durationDays: number;
+  multiplier: number;
+}
+
+const SHRINE_CONFIGS: Record<ShrineKind, ShrineConfig> = {
+  [ShrineKind.Speed]: {
+    buffType: ShrineBuffType.BuilderSpeed,
+    baseCost: 5,
+    costPerUse: 2,
+    durationDays: 1,
+    multiplier: 1.3,
+  },
+  [ShrineKind.Damage]: {
+    buffType: ShrineBuffType.ArcherDamage,
+    baseCost: 5,
+    costPerUse: 2,
+    durationDays: 1,
+    multiplier: 1.5,
+  },
+  [ShrineKind.Shield]: {
+    buffType: ShrineBuffType.WallDurability,
+    baseCost: 8,
+    costPerUse: 3,
+    durationDays: 2,
+    multiplier: 1.3,
+  },
+  [ShrineKind.Spawn]: {
+    buffType: ShrineBuffType.SpawnArchers,
+    baseCost: 10,
+    costPerUse: 0,
+    durationDays: 0, // instant effect
+    multiplier: 1,
+  },
+};
+
+/** Per-shrine tracking: x -> kind */
+const shrineKinds: Map<number, ShrineKind> = new Map();
+
+/** Per-shrine use count (for escalating costs) */
+const shrineUseCount: Map<number, number> = new Map();
+
+/** Per-shrine cooldown timer (seconds remaining, 1-day cooldown) */
+const shrineCooldowns: Map<number, number> = new Map();
+
+/** Active buffs (multiple can be active simultaneously) */
+const activeBuffs: ShrineBuff[] = [];
+
+/** Track spawn shrine daily use: day number -> set of shrine x positions used */
+let lastSpawnShrineDay = -1;
+const spawnShrineUsedToday: Set<number> = new Set();
+
+/** Create a shrine at the given x position with a specific kind */
+export function createShrine(state: GameState, x: number, kind?: ShrineKind): StructureData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const shrine: StructureData = {
+    eid,
+    type: StructureType.Shrine,
+    x,
+    hp: 10,
+    maxHp: 10,
+    level: 1,
+    assignedWorkers: [],
+  };
+
+  // Assign kind (random if not specified)
+  const assignedKind = kind ?? (Math.floor(Math.random() * 4) as ShrineKind);
+  shrineKinds.set(x, assignedKind);
+  shrineUseCount.set(x, 0);
+
+  state.structures.set(x, shrine);
+  return shrine;
+}
+
+/** Get the shrine kind at a position */
+export function getShrineType(x: number): ShrineKind | null {
+  return shrineKinds.get(x) ?? null;
+}
+
+/** Get the current cost to activate a shrine at position x */
+export function getShrineCost(x: number): number {
+  const kind = shrineKinds.get(x);
+  if (kind === undefined) return 0;
+  const config = SHRINE_CONFIGS[kind];
+  const uses = shrineUseCount.get(x) ?? 0;
+  return config.baseCost + config.costPerUse * uses;
+}
+
+/** Get the effect description for a shrine kind */
+export function getShrineEffect(kind: ShrineKind): string {
+  switch (kind) {
+    case ShrineKind.Speed: return '+30% movement speed (1 day)';
+    case ShrineKind.Damage: return '+50% arrow damage (1 day)';
+    case ShrineKind.Shield: return '+30% wall HP (2 days)';
+    case ShrineKind.Spawn: return 'Spawn 3 archers (once per day)';
+  }
+}
+
+/**
+ * Activate a shrine at position x.
+ * Returns the buff type granted, or null if unavailable.
+ */
+export function activateShrine(state: GameState, x: number): ShrineBuffType | null {
+  const kind = shrineKinds.get(x);
+  if (kind === undefined) return null;
+
+  const config = SHRINE_CONFIGS[kind];
+  const cost = getShrineCost(x);
+
+  if (state.monarchCoins < cost) return null;
+
+  // Check cooldown
+  const cooldown = shrineCooldowns.get(x) ?? 0;
+  if (cooldown > 0) return null;
+
+  // Check spawn shrine daily limit
+  if (kind === ShrineKind.Spawn) {
+    if (state.dayCount !== lastSpawnShrineDay) {
+      lastSpawnShrineDay = state.dayCount;
+      spawnShrineUsedToday.clear();
+    }
+    if (spawnShrineUsedToday.has(x)) return null;
+  }
+
+  state.monarchCoins -= cost;
+  shrineUseCount.set(x, (shrineUseCount.get(x) ?? 0) + 1);
+
+  // Set 1-day cooldown
+  shrineCooldowns.set(x, DAY_LENGTH);
+
+  if (kind === ShrineKind.Spawn) {
+    spawnShrineUsedToday.add(x);
+    state.messages.push('Spawn Shrine: 3 archers summoned!');
+    return ShrineBuffType.SpawnArchers;
+  }
+
+  // Add timed buff
+  const duration = config.durationDays * DAY_LENGTH;
+  activeBuffs.push({
+    type: config.buffType,
+    remaining: duration,
+    multiplier: config.multiplier,
+  });
+
+  const names: Record<ShrineKind, string> = {
+    [ShrineKind.Speed]: 'Speed',
+    [ShrineKind.Damage]: 'Damage',
+    [ShrineKind.Shield]: 'Shield',
+    [ShrineKind.Spawn]: 'Spawn',
+  };
+  state.messages.push(`${names[kind]} Shrine activated for ${config.durationDays} day(s)!`);
+  return config.buffType;
+}
+
+/** Tick down buff durations and cooldowns. Call each frame with dt. */
+export function updateShrineBuff(dt: number): void {
+  // Update active buffs
+  for (let i = activeBuffs.length - 1; i >= 0; i--) {
+    activeBuffs[i].remaining -= dt;
+    if (activeBuffs[i].remaining <= 0) {
+      activeBuffs.splice(i, 1);
+    }
+  }
+
+  // Update shrine cooldowns
+  for (const [x, cd] of shrineCooldowns) {
+    const next = cd - dt;
+    if (next <= 0) {
+      shrineCooldowns.delete(x);
+    } else {
+      shrineCooldowns.set(x, next);
+    }
+  }
+}
+
+/** Get the current active buff of a specific type, or null */
+export function getActiveBuff(): ShrineBuff | null {
+  // Return the strongest active buff (backward compat: returns first match)
+  return activeBuffs.length > 0 ? activeBuffs[0] : null;
+}
+
+/** Get all active buffs */
+export function getAllActiveBuffs(): readonly ShrineBuff[] {
+  return activeBuffs;
+}
+
+/** Check if a specific buff type is active */
+export function isBuffActive(type: ShrineBuffType): boolean {
+  return activeBuffs.some(b => b.type === type);
+}
+
+/** Get the multiplier for a specific buff type (1.0 if not active) */
+export function getBuffMultiplier(type: ShrineBuffType): number {
+  for (const buff of activeBuffs) {
+    if (buff.type === type) return buff.multiplier;
+  }
+  return 1.0;
+}

--- a/kingdom/structures/siege.ts
+++ b/kingdom/structures/siege.ts
@@ -1,0 +1,314 @@
+/**
+ * Siege weapons: Ballista and Catapult with fire barrel upgrade.
+ *
+ * Ballista:
+ *   Piercing damage: hits ALL greed in path (line)
+ *   Range: 25 tiles, Damage: 5 per hit, Reload: 3s (2s with 2 builders)
+ *   1-2 builders operate
+ *
+ * Catapult (from Phase 6):
+ *   AoE damage: 15 damage in 3-tile radius
+ *   Range: 20 tiles, Reload: 8s (4s with 2 builders)
+ *   Auto-target: breeders > floaters > largest greedling cluster
+ *   1-2 builders operate
+ *
+ * Fire Barrel (catapult upgrade):
+ *   Requires Iron Keep tier
+ *   5 coins per barrel, adds 3s burn to AoE
+ *   Ground fire patch (3x3) for 5 seconds, 2 DPS to passing greed
+ */
+
+import { addEntity, setPosition, getPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  TimeOfDay,
+  GamePhase,
+  GreedType,
+  UnitRole,
+  TownCenterTier,
+  GROUND_Y,
+} from '../types';
+import { applyBurn } from '../systems/combat';
+
+/** Ballista extends StructureType without modifying the shared types file */
+const BALLISTA_TYPE = 14 as StructureType;
+
+export const BALLISTA_COST = 12;
+const BALLISTA_HP = 15;
+const BALLISTA_DAMAGE = 5;
+const BALLISTA_RANGE = 25;
+const BALLISTA_COOLDOWN = 3.0;
+const BALLISTA_COOLDOWN_2_BUILDERS = 2.0;
+
+/** Catapult type */
+const CATAPULT_TYPE = 18 as StructureType;
+
+export const CATAPULT_COST = 15;
+const CATAPULT_HP = 20;
+const CATAPULT_DAMAGE = 15;
+const CATAPULT_RANGE = 20;
+const CATAPULT_RADIUS = 3;
+const CATAPULT_COOLDOWN = 8.0;
+const CATAPULT_COOLDOWN_2_BUILDERS = 4.0;
+
+/** Fire barrel constants */
+const FIRE_BARREL_COST = 5;
+const FIRE_BARREL_BURN_DPS = 2;
+const FIRE_BARREL_BURN_DURATION = 3;
+const FIRE_GROUND_PATCH_DURATION = 5;
+const FIRE_GROUND_PATCH_DPS = 2;
+const FIRE_GROUND_PATCH_RADIUS = 3;
+
+/** Per-siege weapon cooldown tracking by x position */
+const siegeCooldowns: Map<number, number> = new Map();
+
+/** Track if a siege weapon has fire barrel loaded */
+const fireBarrelLoaded: Set<number> = new Set();
+
+/** Ground fire patches: x -> { timer, radius } */
+interface FirePatch {
+  x: number;
+  timer: number;
+  radius: number;
+  dps: number;
+}
+const firePatches: FirePatch[] = [];
+
+/** Builder count near a siege weapon */
+function countBuildersNear(state: GameState, x: number, radius: number): number {
+  let count = 0;
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Builder) continue;
+    if (unit.hp <= 0) continue;
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - x) <= radius) count++;
+  }
+  return Math.min(count, 2); // cap at 2
+}
+
+/** Create a ballista at the given x position */
+export function createBallista(state: GameState, x: number): StructureData | null {
+  if (state.monarchCoins < BALLISTA_COST) return null;
+  state.monarchCoins -= BALLISTA_COST;
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const ballista: StructureData = {
+    eid,
+    type: BALLISTA_TYPE,
+    x,
+    hp: BALLISTA_HP,
+    maxHp: BALLISTA_HP,
+    level: 1,
+    assignedWorkers: [],
+  };
+
+  state.structures.set(x, ballista);
+  siegeCooldowns.set(x, BALLISTA_COOLDOWN);
+  return ballista;
+}
+
+/** Check if a structure is a ballista */
+export function isBallistaStructure(type: StructureType): boolean {
+  return type === BALLISTA_TYPE;
+}
+
+/** Check if a structure is a catapult */
+export function isCatapultStructure(type: StructureType): boolean {
+  return type === CATAPULT_TYPE;
+}
+
+/** Load a fire barrel into a catapult. Requires Iron Keep tier. 5 coins. */
+export function loadFireBarrel(state: GameState, x: number): boolean {
+  const structure = state.structures.get(x);
+  if (!structure || structure.type !== CATAPULT_TYPE) return false;
+  if (state.townCenterTier < TownCenterTier.IronKeep) return false;
+  if (state.monarchCoins < FIRE_BARREL_COST) return false;
+  if (fireBarrelLoaded.has(x)) return false;
+
+  state.monarchCoins -= FIRE_BARREL_COST;
+  fireBarrelLoaded.add(x);
+  state.messages.push('Fire barrel loaded into catapult!');
+  return true;
+}
+
+/**
+ * Auto-target priority: breeders > floaters > largest greedling group.
+ * Returns the x position of the best target, or null.
+ */
+export function getTargetPriority(state: GameState, weaponX: number, range: number): number | null {
+  if (state.greeds.length === 0) return null;
+
+  // Priority 1: Breeders in range
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0 || greed.type !== GreedType.Breeder) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - weaponX) <= range) return pos.x;
+  }
+
+  // Priority 2: Floaters in range
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0 || greed.type !== GreedType.Floater) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - weaponX) <= range) return pos.x;
+  }
+
+  // Priority 3: Largest greedling cluster in range
+  const positions: number[] = [];
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+    if (Math.abs(pos.x - weaponX) <= range) positions.push(pos.x);
+  }
+
+  if (positions.length === 0) return null;
+
+  let bestX = positions[0];
+  let bestCount = 0;
+  for (const px of positions) {
+    let count = 0;
+    for (const qx of positions) {
+      if (Math.abs(px - qx) <= CATAPULT_RADIUS) count++;
+    }
+    if (count > bestCount) {
+      bestCount = count;
+      bestX = px;
+    }
+  }
+
+  return bestX;
+}
+
+/** Fire a ballista at a target. Piercing: hits all greed in line. */
+export function fireBallista(state: GameState, weaponX: number): number {
+  const targetX = getTargetPriority(state, weaponX, BALLISTA_RANGE);
+  if (targetX === null) return 0;
+
+  const direction = targetX > weaponX ? 1 : -1;
+  let hitCount = 0;
+
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+
+    const dx = pos.x - weaponX;
+    if (dx * direction >= 0 && Math.abs(dx) <= BALLISTA_RANGE) {
+      greed.hp -= BALLISTA_DAMAGE;
+      hitCount++;
+    }
+  }
+
+  return hitCount;
+}
+
+/** Fire a catapult at a target. AoE: damages all greed in radius. */
+export function fireCatapult(state: GameState, weaponX: number): number {
+  const targetX = getTargetPriority(state, weaponX, CATAPULT_RANGE);
+  if (targetX === null) return 0;
+
+  let hitCount = 0;
+  const hasFire = fireBarrelLoaded.has(weaponX);
+
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+
+    if (Math.abs(pos.x - targetX) <= CATAPULT_RADIUS) {
+      greed.hp -= CATAPULT_DAMAGE;
+      if (hasFire) {
+        applyBurn(greed, FIRE_BARREL_BURN_DPS, FIRE_BARREL_BURN_DURATION);
+      }
+      hitCount++;
+    }
+  }
+
+  // Fire barrel: create ground fire patch
+  if (hasFire) {
+    fireBarrelLoaded.delete(weaponX);
+    firePatches.push({
+      x: targetX,
+      timer: FIRE_GROUND_PATCH_DURATION,
+      radius: FIRE_GROUND_PATCH_RADIUS,
+      dps: FIRE_GROUND_PATCH_DPS,
+    });
+  }
+
+  return hitCount;
+}
+
+/** Update ground fire patches: damage greeds walking through them */
+function updateFirePatches(state: GameState, dt: number): void {
+  for (let i = firePatches.length - 1; i >= 0; i--) {
+    const patch = firePatches[i];
+    patch.timer -= dt;
+
+    if (patch.timer <= 0) {
+      firePatches.splice(i, 1);
+      continue;
+    }
+
+    // Damage greeds in the fire patch
+    for (const greed of state.greeds) {
+      if (greed.hp <= 0) continue;
+      const pos = getPosition(state.world, greed.eid);
+      if (!pos) continue;
+      if (Math.abs(pos.x - patch.x) <= patch.radius) {
+        greed.hp -= patch.dps * dt;
+      }
+    }
+  }
+}
+
+/** Update all siege weapons. Call once per frame. */
+export function updateSiegeWeapons(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+
+  // Update fire patches regardless of time of day
+  updateFirePatches(state, dt);
+
+  if (state.timeOfDay !== TimeOfDay.Night) return;
+
+  for (const [x, structure] of state.structures) {
+    const isBallista = structure.type === BALLISTA_TYPE;
+    const isCatapult = structure.type === CATAPULT_TYPE;
+    if (!isBallista && !isCatapult) continue;
+
+    // Tick cooldown
+    const builders = countBuildersNear(state, x, 3);
+    if (builders === 0) continue; // need at least 1 builder to operate
+
+    const cooldown = (siegeCooldowns.get(x) ?? 0) - dt;
+    if (cooldown > 0) {
+      siegeCooldowns.set(x, cooldown);
+      continue;
+    }
+
+    if (isBallista) {
+      const hits = fireBallista(state, x);
+      if (hits > 0) {
+        state.messages.push(`Ballista pierces ${hits} greeds!`);
+      }
+      siegeCooldowns.set(x, builders >= 2 ? BALLISTA_COOLDOWN_2_BUILDERS : BALLISTA_COOLDOWN);
+    } else {
+      const hits = fireCatapult(state, x);
+      if (hits > 0) {
+        state.messages.push(`Catapult hits ${hits} greeds!`);
+      }
+      siegeCooldowns.set(x, builders >= 2 ? CATAPULT_COOLDOWN_2_BUILDERS : CATAPULT_COOLDOWN);
+    }
+  }
+}
+
+/** Update legacy ballista function (delegates to updateSiegeWeapons) */
+export function updateBallista(state: GameState, dt: number): void {
+  updateSiegeWeapons(state, dt);
+}

--- a/kingdom/structures/townCenter.ts
+++ b/kingdom/structures/townCenter.ts
@@ -1,0 +1,127 @@
+/**
+ * Town center upgrade system.
+ * Located at CAMP_CENTER_X (600). Upgrades unlock new technologies.
+ * 7 tiers from Campfire to Iron Keep.
+ *
+ * Tier 1 (Campfire): bow + hammer stands
+ * Tier 2 (Camp): second tool stand set
+ * Tier 3 (Village): scythe vendor (farmers), inner spike walls
+ * Tier 4 (Town Hall): banker, siege workshop
+ * Tier 5 (Stone Fort): stone walls, pike vendor, catapult station
+ * Tier 6 (Castle): shields (squires), gem keeper
+ * Tier 7 (Iron Keep): bomb, forge, iron walls
+ *
+ * Cooldown: tier * 10 seconds between upgrades.
+ * Town center HP: [0, 10, 20, 30, 50, 80, 120, 200] per tier.
+ * If town center HP reaches 0: game over.
+ */
+
+import {
+  type GameState,
+  StructureType,
+  TownCenterTier,
+  CAMP_CENTER_X,
+  GamePhase,
+  TOWN_CENTER_COSTS,
+  TOWN_CENTER_NAMES,
+} from '../types';
+
+const TOWN_CENTER_HP = [0, 10, 20, 30, 50, 80, 120, 200];
+
+export interface TownCenterUnlocks {
+  tierName: string;
+  unlocks: string[];
+}
+
+/** Get the current town center tier */
+export function getTownCenterTier(state: GameState): TownCenterTier {
+  return state.townCenterTier;
+}
+
+/** Check if the town center can be upgraded (enough coins and no cooldown) */
+export function canUpgradeTownCenter(state: GameState): boolean {
+  const tier = state.townCenterTier;
+  if (tier >= TownCenterTier.IronKeep) return false;
+  if (state.townCenterCooldown > 0) return false;
+  const cost = TOWN_CENTER_COSTS[tier + 1] ?? Infinity;
+  return state.monarchCoins >= cost;
+}
+
+/** Upgrade the town center. Deducts coins, increments tier, starts cooldown. */
+export function upgradeTownCenter(state: GameState): boolean {
+  if (!canUpgradeTownCenter(state)) return false;
+
+  const nextTier = state.townCenterTier + 1;
+  const cost = TOWN_CENTER_COSTS[nextTier];
+  if (cost === undefined) return false;
+
+  state.monarchCoins -= cost;
+  state.townCenterTier = nextTier;
+  state.townCenterCooldown = nextTier * 10;
+
+  // Update campfire structure HP at the main settlement
+  const campfire = state.structures.get(CAMP_CENTER_X);
+  if (campfire && campfire.type === StructureType.Campfire) {
+    const newHp = TOWN_CENTER_HP[nextTier] ?? 10;
+    campfire.maxHp = newHp;
+    campfire.hp = newHp;
+    campfire.level = nextTier;
+  }
+
+  const name = TOWN_CENTER_NAMES[nextTier] ?? `Tier ${nextTier}`;
+  state.messages.push(`Town Center upgraded to ${name}!`);
+
+  return true;
+}
+
+/** Update town center cooldown timer. Check for destruction game-over. */
+export function updateTownCenter(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+
+  if (state.townCenterCooldown > 0) {
+    state.townCenterCooldown = Math.max(0, state.townCenterCooldown - dt);
+  }
+
+  // Check town center destruction (only if it has been upgraded beyond default)
+  const campfire = state.structures.get(CAMP_CENTER_X);
+  if (campfire && campfire.type === StructureType.Campfire
+    && campfire.hp <= 0 && campfire.maxHp > 0 && campfire.maxHp < 999) {
+    state.phase = GamePhase.GameOver;
+    state.messages.push('The Town Center has been destroyed! The kingdom falls.');
+  }
+}
+
+/** Get what's unlocked at each tier */
+export function getTownCenterUnlocks(tier: number): TownCenterUnlocks {
+  const tierName = TOWN_CENTER_NAMES[tier] ?? 'Unknown';
+
+  switch (tier) {
+    case TownCenterTier.Campfire:
+      return { tierName, unlocks: ['Bow stand', 'Hammer stand'] };
+    case TownCenterTier.Camp:
+      return { tierName, unlocks: ['Second tool stand set'] };
+    case TownCenterTier.Village:
+      return { tierName, unlocks: ['Scythe vendor (farmers)', 'Inner spike walls'] };
+    case TownCenterTier.TownHall:
+      return { tierName, unlocks: ['Banker NPC', 'Siege workshop'] };
+    case TownCenterTier.StoneFort:
+      return { tierName, unlocks: ['Stone walls', 'Pike vendor', 'Catapult station'] };
+    case TownCenterTier.Castle:
+      return { tierName, unlocks: ['Shields (squires)', 'Gem keeper'] };
+    case TownCenterTier.IronKeep:
+      return { tierName, unlocks: ['Bomb', 'Forge', 'Iron walls'] };
+    default:
+      return { tierName, unlocks: [] };
+  }
+}
+
+/** Get the max HP for a given town center tier */
+export function getTownCenterHp(tier: number): number {
+  return TOWN_CENTER_HP[tier] ?? 0;
+}
+
+/** Handle coin drop at town center position. Returns true if upgrade was triggered. */
+export function handleCoinDropAtTownCenter(state: GameState, dropX: number): boolean {
+  if (Math.abs(dropX - CAMP_CENTER_X) > 2) return false;
+  return upgradeTownCenter(state);
+}

--- a/kingdom/structures/wall.ts
+++ b/kingdom/structures/wall.ts
@@ -1,0 +1,651 @@
+/**
+ * Wall, tower, and gate structure creation, upgrade, damage, visual state, and queries.
+ *
+ * 5-tier wall upgrade path: Spikes -> WallWood -> WallStone -> TallStone -> WallIron -> Tower
+ * Tower: gives archers +5 range and allows 2 archers.
+ * Gates: let friendly units pass but block greed. Auto-placed every 10 tiles.
+ * Wall chains: adjacent walls get +1 HP bonus per connected wall in the chain.
+ *
+ * Wall tiers:
+ *   | Tier | Type      | Cost | HP  | Requires             |
+ *   |------|-----------|------|-----|----------------------|
+ *   | 1    | Spikes    | 1    | 25  | Nothing              |
+ *   | 2    | WallWood  | 3    | 50  | Nothing              |
+ *   | 3    | WallStone | 6    | 200 | TownCenterTier >= 5  |
+ *   | 4    | TallStone | 9    | 300 | TownCenterTier >= 5  |
+ *   | 5    | WallIron  | 12   | 400 | TownCenterTier >= 7  |
+ */
+
+import { addEntity, setPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  StructureType,
+  TownCenterTier,
+  TowerTier,
+  TOWER_COSTS,
+  GROUND_Y,
+  CHAR_WALL,
+  CHAR_WALL_DAMAGED,
+  DamageType,
+  GreedType,
+  TimeOfDay,
+} from '../types';
+
+/** Tower extends StructureType without modifying the shared types file */
+export const TOWER_TYPE = 13 as StructureType;
+export const TOWER_COST = 15;
+export const TOWER_HP = 40;
+export const TOWER_ARCHER_RANGE_BONUS = 5;
+export const TOWER_ARCHER_SLOTS = 2;
+
+/** Gate: blocks greed but lets friendly units pass */
+export const GATE_TYPE = 15 as StructureType;
+const GATE_HP = 8;
+
+/** Auto-gate interval: place a gate every N tiles in a wall line */
+const AUTO_GATE_INTERVAL = 10;
+
+/** 5-tier wall HP values */
+const WALL_HP: Record<number, number> = {
+  [StructureType.Spikes]: 25,
+  [StructureType.WallWood]: 50,
+  [StructureType.WallStone]: 200,
+  [StructureType.TallStone]: 300,
+  [StructureType.WallIron]: 400,
+  [13]: TOWER_HP,
+  [15]: GATE_HP,
+};
+
+/** 5-tier wall build costs */
+const WALL_BUILD_COSTS: Record<number, number> = {
+  [StructureType.Spikes]: 1,
+  [StructureType.WallWood]: 3,
+  [StructureType.WallStone]: 6,
+  [StructureType.TallStone]: 9,
+  [StructureType.WallIron]: 12,
+};
+
+/** Ordered wall tier upgrade path (Spikes through WallIron) */
+const WALL_TIER_ORDER: StructureType[] = [
+  StructureType.Spikes,
+  StructureType.WallWood,
+  StructureType.WallStone,
+  StructureType.TallStone,
+  StructureType.WallIron,
+];
+
+/** Town center tier required for upgrading TO a given wall type */
+const WALL_TIER_REQUIREMENTS: Partial<Record<number, number>> = {
+  [StructureType.WallStone]: TownCenterTier.StoneFort,
+  [StructureType.TallStone]: TownCenterTier.StoneFort,
+  [StructureType.WallIron]: TownCenterTier.IronKeep,
+};
+
+/** Builder repair rate: 1 hp per 3 seconds */
+export const WALL_REPAIR_RATE = 1 / 3;
+
+/** Track base maxHp (before chain bonus) per wall x position */
+const wallBaseMaxHp: Map<number, number> = new Map();
+
+/** Get the tier number (1-5) for a wall StructureType, or 0 if not a wall */
+export function getWallTier(type: StructureType): number {
+  const index = WALL_TIER_ORDER.indexOf(type);
+  return index >= 0 ? index + 1 : 0;
+}
+
+/** Get the next wall tier StructureType, or null if at max */
+export function getNextWallTier(type: StructureType): StructureType | null {
+  const index = WALL_TIER_ORDER.indexOf(type);
+  if (index < 0 || index >= WALL_TIER_ORDER.length - 1) return null;
+  return WALL_TIER_ORDER[index + 1];
+}
+
+/** Get the coin cost to upgrade FROM the current wall type to the next tier */
+export function getWallUpgradeCost(currentType: StructureType): number {
+  const next = getNextWallTier(currentType);
+  if (next === null) return 0;
+  return WALL_BUILD_COSTS[next] ?? 0;
+}
+
+/** Create a wall at the given x position with the specified tier */
+export function createWall(state: GameState, x: number, tier: StructureType): StructureData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const hp = WALL_HP[tier] ?? 25;
+  const wall: StructureData = {
+    eid,
+    type: tier,
+    x,
+    hp,
+    maxHp: hp,
+    level: getWallTier(tier),
+    assignedWorkers: [],
+    towerTier: TowerTier.None,
+    isRoofed: false,
+  };
+
+  state.structures.set(x, wall);
+  wallBaseMaxHp.set(x, hp);
+
+  // Recalculate chain bonuses for the affected chain
+  applyWallChainBonuses(state);
+
+  return wall;
+}
+
+/** Create a gate at the given x position */
+export function createGate(state: GameState, x: number): StructureData {
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const gate: StructureData = {
+    eid,
+    type: GATE_TYPE,
+    x,
+    hp: GATE_HP,
+    maxHp: GATE_HP,
+    level: 1,
+    assignedWorkers: [],
+    towerTier: TowerTier.None,
+    isRoofed: false,
+  };
+
+  state.structures.set(x, gate);
+  wallBaseMaxHp.set(x, GATE_HP);
+
+  return gate;
+}
+
+/**
+ * Create a tower at the given x position.
+ * Towers are the final upgrade beyond iron walls.
+ * Returns null if not enough coins.
+ */
+export function createTower(state: GameState, x: number): StructureData | null {
+  if (state.monarchCoins < TOWER_COST) return null;
+
+  state.structures.delete(x);
+  wallBaseMaxHp.delete(x);
+
+  state.monarchCoins -= TOWER_COST;
+
+  const eid = addEntity(state.world);
+  setPosition(state.world, eid, x, GROUND_Y);
+
+  const tower: StructureData = {
+    eid,
+    type: TOWER_TYPE,
+    x,
+    hp: TOWER_HP,
+    maxHp: TOWER_HP,
+    level: 6,
+    assignedWorkers: [],
+    towerTier: TowerTier.RockPlatform,
+    isRoofed: false,
+  };
+
+  state.structures.set(x, tower);
+  wallBaseMaxHp.set(x, TOWER_HP);
+
+  applyWallChainBonuses(state);
+
+  return tower;
+}
+
+/**
+ * Upgrade a tower to the next tier.
+ * Uses TOWER_COSTS from types.ts.
+ * Tier 3 (Stone Tower) requires TownCenterTier >= 5.
+ * Tier 5 (Roofed) requires TownCenterTier >= 7.
+ * Returns true if upgraded.
+ */
+export function upgradeTower(state: GameState, x: number): boolean {
+  const tower = state.structures.get(x);
+  if (!tower || !isTowerStructure(tower.type)) return false;
+
+  const currentTier = tower.towerTier ?? TowerTier.None;
+  const nextTier = currentTier + 1;
+
+  if (nextTier > TowerTier.QuadrupletTower) return false;
+
+  // Check town center requirements
+  if (nextTier >= TowerTier.StoneTower && state.townCenterTier < TownCenterTier.StoneFort) return false;
+  if (nextTier >= TowerTier.RoofedTriplet && state.townCenterTier < TownCenterTier.IronKeep) return false;
+
+  const cost = TOWER_COSTS[nextTier];
+  if (cost === undefined || state.monarchCoins < cost) return false;
+
+  state.monarchCoins -= cost;
+  tower.towerTier = nextTier;
+  tower.level = 6 + nextTier;
+  tower.isRoofed = nextTier >= TowerTier.RoofedTriplet;
+
+  // Increase tower HP with upgrades
+  const hpBonus = nextTier * 10;
+  const newMaxHp = TOWER_HP + hpBonus;
+  tower.maxHp = newMaxHp;
+  tower.hp = newMaxHp;
+  wallBaseMaxHp.set(x, newMaxHp);
+
+  applyWallChainBonuses(state);
+
+  return true;
+}
+
+/**
+ * Upgrade a wall through the 5-tier path.
+ * Checks town center tier requirements for stone+ tiers.
+ * Returns true if upgraded.
+ */
+export function upgradeWall(state: GameState, x: number): boolean {
+  const wall = state.structures.get(x);
+  if (!wall) return false;
+
+  const next = getNextWallTier(wall.type);
+  if (next === null) return false;
+
+  // Check town center tier requirement
+  const requiredTier = WALL_TIER_REQUIREMENTS[next];
+  if (requiredTier !== undefined) {
+    if (state.townCenterTier < requiredTier) return false;
+  }
+
+  const nextHp = WALL_HP[next] ?? 50;
+  const currentIndex = WALL_TIER_ORDER.indexOf(wall.type);
+
+  wall.type = next;
+  wall.maxHp = nextHp;
+  wall.hp = nextHp;
+  wall.level = currentIndex + 2;
+
+  wallBaseMaxHp.set(x, nextHp);
+  applyWallChainBonuses(state);
+
+  return true;
+}
+
+/** Apply damage to a wall, tower, or gate. Destroys it if hp drops to 0. */
+export function damageWall(state: GameState, x: number, dmg: number): number {
+  const wall = state.structures.get(x);
+  if (!wall) return 0;
+
+  wall.hp -= dmg;
+  if (wall.hp <= 0) {
+    wall.hp = 0;
+    state.structures.delete(x);
+    wallBaseMaxHp.delete(x);
+    applyWallChainBonuses(state);
+    return 0;
+  }
+  return wall.hp;
+}
+
+/** Repair a wall/tower/gate by the given hp amount. Clamps to maxHp. */
+export function repairWall(state: GameState, x: number, amount: number): number {
+  const wall = state.structures.get(x);
+  if (!wall || (!isWallStructure(wall.type) && !isTowerStructure(wall.type) && !isGateStructure(wall.type))) return 0;
+
+  wall.hp = Math.min(wall.maxHp, wall.hp + amount);
+  return wall.hp;
+}
+
+/** Get wall/tower/gate health as a 0-1 ratio */
+export function getWallHealth(state: GameState, x: number): number {
+  const wall = state.structures.get(x);
+  if (!wall) return 0;
+  if (!isWallStructure(wall.type) && !isTowerStructure(wall.type) && !isGateStructure(wall.type)) return 0;
+  if (wall.maxHp <= 0) return 0;
+  return wall.hp / wall.maxHp;
+}
+
+/** Get the display character for a wall based on damage state */
+export function getWallChar(state: GameState, x: number): string {
+  const health = getWallHealth(state, x);
+  if (health <= 0) return '';
+  return health < 0.5 ? CHAR_WALL_DAMAGED : CHAR_WALL;
+}
+
+/** Get the outermost wall/tower/gate positions */
+export function getOutermostWalls(state: GameState): { left: number | null; right: number | null } {
+  let left: number | null = null;
+  let right: number | null = null;
+
+  for (const [x, structure] of state.structures) {
+    if (!isDefensiveStructure(structure.type)) continue;
+    if (left === null || x < left) left = x;
+    if (right === null || x > right) right = x;
+  }
+
+  return { left, right };
+}
+
+/** Find a wall/tower/gate at a specific x position, or null */
+export function getWallAt(state: GameState, x: number): StructureData | null {
+  const structure = state.structures.get(x);
+  if (structure && isDefensiveStructure(structure.type)) {
+    return structure;
+  }
+  return null;
+}
+
+/** Find a tower at a specific x position, or null */
+export function getTowerAt(state: GameState, x: number): StructureData | null {
+  const structure = state.structures.get(x);
+  if (structure && isTowerStructure(structure.type)) {
+    return structure;
+  }
+  return null;
+}
+
+/** Check if a structure type is a wall (spikes/wood/stone/tall stone/iron, not tower or gate) */
+export function isWallStructure(type: StructureType): boolean {
+  return type === StructureType.Spikes
+    || type === StructureType.WallWood
+    || type === StructureType.WallStone
+    || type === StructureType.TallStone
+    || type === StructureType.WallIron;
+}
+
+/** Check if a structure type is a tower */
+export function isTowerStructure(type: StructureType): boolean {
+  return type === TOWER_TYPE;
+}
+
+/** Check if a structure type is a gate */
+export function isGateStructure(type: StructureType): boolean {
+  return type === GATE_TYPE;
+}
+
+/** Check if a structure type is any defensive structure (wall, tower, or gate) */
+export function isDefensiveStructure(type: StructureType): boolean {
+  return isWallStructure(type) || isTowerStructure(type) || isGateStructure(type);
+}
+
+/**
+ * Check if a wall at position x should be auto-converted to a gate.
+ * Gates are placed every AUTO_GATE_INTERVAL tiles relative to the nearest
+ * settlement center, so builders and archers can move through.
+ */
+export function shouldAutoGate(x: number, settlementX: number): boolean {
+  const offset = Math.abs(x - settlementX);
+  return offset > 0 && offset % AUTO_GATE_INTERVAL === 0;
+}
+
+/**
+ * Get the length of the wall chain containing position x.
+ * A chain is a contiguous run of walls/towers/gates at adjacent x positions.
+ */
+export function getWallChainLength(state: GameState, x: number): number {
+  const s = state.structures.get(x);
+  if (!s || !isDefensiveStructure(s.type)) return 0;
+
+  let length = 1;
+
+  // Scan left
+  let lx = x - 1;
+  while (true) {
+    const ls = state.structures.get(lx);
+    if (!ls || !isDefensiveStructure(ls.type)) break;
+    length++;
+    lx--;
+  }
+
+  // Scan right
+  let rx = x + 1;
+  while (true) {
+    const rs = state.structures.get(rx);
+    if (!rs || !isDefensiveStructure(rs.type)) break;
+    length++;
+    rx++;
+  }
+
+  return length;
+}
+
+/**
+ * Recalculate wall chain HP bonuses for all walls/towers/gates.
+ * Each wall in a chain of length N gets +N bonus maxHp.
+ * Call after creating or destroying any defensive structure.
+ */
+export function applyWallChainBonuses(state: GameState): void {
+  for (const [x, structure] of state.structures) {
+    if (!isDefensiveStructure(structure.type)) continue;
+
+    const baseHp = wallBaseMaxHp.get(x) ?? structure.maxHp;
+    const chainLen = getWallChainLength(state, x);
+    const newMaxHp = baseHp + chainLen;
+
+    // Only increase hp by the delta if maxHp grew
+    const delta = newMaxHp - structure.maxHp;
+    structure.maxHp = newMaxHp;
+    if (delta > 0) {
+      structure.hp += delta;
+    } else if (structure.hp > structure.maxHp) {
+      structure.hp = structure.maxHp;
+    }
+  }
+}
+
+// ─── Special Tower Conversions ──────────────────────────────────────
+
+/** Converted tower type constants (hermit-triggered conversions) */
+export const BALLISTA_TOWER_TYPE = 19 as StructureType;
+export const FIRE_TOWER_TYPE = 20 as StructureType;
+export const BAKERY_TOWER_TYPE = 21 as StructureType;
+export const KNIGHT_TOWER_TYPE = 22 as StructureType;
+export const BERSERKER_TOWER_TYPE = 23 as StructureType;
+
+export enum ConvertedTowerKind {
+  Ballista = 19,
+  Fire = 20,
+  Bakery = 21,
+  Knight = 22,
+  Berserker = 23,
+}
+
+/** Conversion costs */
+const CONVERSION_COSTS: Record<number, number> = {
+  [ConvertedTowerKind.Ballista]: 6,
+  [ConvertedTowerKind.Fire]: 8,
+  [ConvertedTowerKind.Bakery]: 6,
+  [ConvertedTowerKind.Knight]: 6,
+  [ConvertedTowerKind.Berserker]: 6,
+};
+
+/** Minimum tower tier required for conversion */
+const CONVERSION_MIN_TIER = TowerTier.StoneTower; // tier 3+
+
+/** Ballista tower stats */
+export const BALLISTA_TOWER_RANGE = 20;
+export const BALLISTA_TOWER_DAMAGE = 5;
+export const BALLISTA_TOWER_RELOAD = 4.0;
+
+/** Fire tower stats */
+export const FIRE_TOWER_RANGE = 15;
+export const FIRE_TOWER_BURN_DPS = 2;
+export const FIRE_TOWER_BURN_DURATION = 3.0;
+export const FIRE_TOWER_AOE = 3;
+
+/** Production tower output tracking */
+const towerProductionTimers: Map<number, number> = new Map();
+const BAKERY_BREAD_PER_DAY = 7;
+const KNIGHT_SHIELDS_PER_DAY = 1;
+const BERSERKER_POTIONS_PER_DAY = 1;
+
+/** Potion buff duration (30 seconds of 2x damage + 2x speed) */
+export const POTION_BUFF_DURATION = 30.0;
+
+/** Per-tower output stockpile (bread loaves, shields, or potions) */
+const towerOutputStock: Map<number, number> = new Map();
+
+/** Check if a structure type is a converted tower */
+export function isConvertedTower(type: StructureType): boolean {
+  const t = type as number;
+  return t >= 19 && t <= 23;
+}
+
+/**
+ * Convert an existing tower to a special tower type.
+ * Requires tower tier >= 3 and enough coins.
+ * Converted towers are locked at their current tier.
+ */
+export function convertTower(
+  state: GameState,
+  towerX: number,
+  conversionType: ConvertedTowerKind,
+): boolean {
+  const tower = state.structures.get(towerX);
+  if (!tower || !isTowerStructure(tower.type)) return false;
+
+  const currentTier = tower.towerTier ?? TowerTier.None;
+  if (currentTier < CONVERSION_MIN_TIER) return false;
+
+  const cost = CONVERSION_COSTS[conversionType];
+  if (cost === undefined || state.monarchCoins < cost) return false;
+
+  state.monarchCoins -= cost;
+
+  tower.type = conversionType as unknown as StructureType;
+  tower.convertedTowerType = conversionType;
+
+  // Initialize production timer for economic towers
+  if (conversionType === ConvertedTowerKind.Bakery
+    || conversionType === ConvertedTowerKind.Knight
+    || conversionType === ConvertedTowerKind.Berserker) {
+    towerProductionTimers.set(towerX, 0);
+    towerOutputStock.set(towerX, 0);
+  }
+
+  const names: Record<number, string> = {
+    [ConvertedTowerKind.Ballista]: 'Ballista Tower',
+    [ConvertedTowerKind.Fire]: 'Fire Tower',
+    [ConvertedTowerKind.Bakery]: 'Bakery Tower',
+    [ConvertedTowerKind.Knight]: 'Knight Tower',
+    [ConvertedTowerKind.Berserker]: 'Berserker Tower',
+  };
+
+  state.messages.push(`Tower converted to ${names[conversionType]}!`);
+  return true;
+}
+
+/**
+ * Update production towers (bakery, knight, berserker).
+ * Called once per frame during day. Produces output at dawn.
+ */
+export function updateConvertedTowers(state: GameState, _dt: number, isDawn: boolean): void {
+  if (!isDawn) return;
+
+  for (const [x, structure] of state.structures) {
+    if (!isConvertedTower(structure.type)) continue;
+
+    const kind = structure.type as number as ConvertedTowerKind;
+
+    switch (kind) {
+      case ConvertedTowerKind.Bakery: {
+        const stock = (towerOutputStock.get(x) ?? 0) + BAKERY_BREAD_PER_DAY;
+        towerOutputStock.set(x, stock);
+        state.messages.push(`Bakery Tower produces ${BAKERY_BREAD_PER_DAY} bread loaves.`);
+        break;
+      }
+      case ConvertedTowerKind.Knight: {
+        const stock = (towerOutputStock.get(x) ?? 0) + KNIGHT_SHIELDS_PER_DAY;
+        towerOutputStock.set(x, stock);
+        state.messages.push('Knight Tower produces a shield.');
+        break;
+      }
+      case ConvertedTowerKind.Berserker: {
+        const stock = (towerOutputStock.get(x) ?? 0) + BERSERKER_POTIONS_PER_DAY;
+        towerOutputStock.set(x, stock);
+        state.messages.push('Berserker Tower brews a potion.');
+        break;
+      }
+    }
+  }
+}
+
+/** Get the current output stock for a converted tower */
+export function getConvertedTowerOutput(x: number): number {
+  return towerOutputStock.get(x) ?? 0;
+}
+
+/** Consume one unit of output from a converted tower */
+export function consumeTowerOutput(x: number): boolean {
+  const stock = towerOutputStock.get(x) ?? 0;
+  if (stock <= 0) return false;
+  towerOutputStock.set(x, stock - 1);
+  return true;
+}
+
+/** Get the DamageType a converted tower uses (for combat system) */
+export function getConvertedTowerDamageType(type: StructureType): DamageType {
+  const kind = type as number;
+  if (kind === ConvertedTowerKind.Ballista) return DamageType.Piercing;
+  if (kind === ConvertedTowerKind.Fire) return DamageType.Burn;
+  return DamageType.Normal;
+}
+
+// ─── Wall Damage Mechanics (Phase 9) ─────────────────────────────
+
+/** Get wall damage per second for a given greed type */
+export function getGreedWallDamage(type: GreedType): number {
+  switch (type) {
+    case GreedType.Basic: return 1;         // 1 damage, 1 attack/second
+    case GreedType.Masked: return 2;        // 2 damage, 1 attack/second
+    case GreedType.Breeder: return 1.25;    // 5 damage per 4-second punch
+    case GreedType.CrownStealer: return 0;  // bypasses walls
+    case GreedType.Floater: return 0;       // flies over walls
+    case GreedType.PlagueCrawler: return 0; // climbs over walls
+    default: return 1;
+  }
+}
+
+/** Get gate HP for a given wall tier (50% of wall HP) */
+export function getGateHpForTier(wallType: StructureType): number {
+  const wallHp = WALL_HP[wallType] ?? 25;
+  return Math.floor(wallHp * 0.5);
+}
+
+/** Lock all gates (called at dusk) */
+export function lockGatesAtDusk(state: GameState): void {
+  for (const [, structure] of state.structures) {
+    if (structure.type === GATE_TYPE) {
+      structure.gateLocked = true;
+    }
+  }
+}
+
+/** Unlock all gates (called at dawn) */
+export function unlockGatesAtDawn(state: GameState): void {
+  for (const [, structure] of state.structures) {
+    if (structure.type === GATE_TYPE) {
+      structure.gateLocked = false;
+    }
+  }
+}
+
+/** Check if gate at position x is locked */
+export function isGateLocked(state: GameState, x: number): boolean {
+  const structure = state.structures.get(x);
+  if (!structure || structure.type !== GATE_TYPE) return false;
+  return structure.gateLocked === true;
+}
+
+/** Get damage multiplier for a structure (locked gates take 50% less damage) */
+export function getWallDamageReduction(state: GameState, x: number): number {
+  const structure = state.structures.get(x);
+  if (!structure) return 1;
+  if (structure.type === GATE_TYPE && structure.gateLocked) return 0.5;
+  return 1;
+}
+
+/** Update gate states based on time of day transitions */
+export function updateGateStates(state: GameState, prevTime: TimeOfDay, newTime: TimeOfDay): void {
+  if (prevTime !== TimeOfDay.Dusk && newTime === TimeOfDay.Dusk) {
+    lockGatesAtDusk(state);
+  }
+  if (prevTime !== TimeOfDay.Dawn && newTime === TimeOfDay.Dawn) {
+    unlockGatesAtDawn(state);
+  }
+}

--- a/kingdom/systems/ai.ts
+++ b/kingdom/systems/ai.ts
@@ -1,0 +1,337 @@
+/**
+ * AI system - dispatches unit updates based on role and handles global state transitions.
+ * Integrates animal system, dog companion, manages dusk retreat, night positioning,
+ * panic state when walls on one side are all destroyed,
+ * emergency wall building when dusk arrives with no defenses,
+ * crown defense (knights rush to dropped crown),
+ * and dog bark alertness bonus for archers.
+ */
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  UnitRole,
+  AIState,
+  TimeOfDay,
+  GreedType,
+  StructureType,
+  WeatherType,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+  clamp,
+  distance,
+} from '../types';
+import { updateMonarch } from '../entities/monarch';
+import { updateVagrant, tickVagrantSpawns, updateVagrantSpawning } from '../entities/villager';
+import { updateBuilder, resetBuilderAssignments } from '../entities/builder';
+import { updateArcher, fillTowerSlots, repositionNightArchers } from '../entities/archer';
+import { updateFarmer } from '../entities/farmer';
+import { updateKnight, updateSquire, updateAssault, regenerateKnightShields } from '../entities/knight';
+import { updatePikeman } from '../entities/pikeman';
+import { updateAnimals, updateDenSpawning } from '../entities/animals';
+import { updateBanker } from '../entities/banker';
+import { updateMerchant } from '../entities/merchant';
+import { updateDog, isDogBarking, getDogBarkDirection, getDogX } from '../entities/dog';
+import { updateHermits } from '../entities/hermit';
+import { updateStatueBlessings } from '../entities/statue';
+import { updateMount, updateMountAbility, triggerMountPanic } from '../entities/mount';
+import { placeWallBlueprint, applyDawnBonus, updateBread, updateDroppedTools } from '../game/economy';
+import { applyBankerInterest } from '../entities/banker';
+
+let previousTimeOfDay: TimeOfDay | null = null;
+
+// Dog bark archer range bonus
+const DOG_BARK_RANGE_BONUS = 2;
+
+export function updateAI(state: GameState, dt: number): void {
+  // Apply weather slowdown
+  const effectiveDt = state.weather === WeatherType.Rain ? dt * 0.9 : dt;
+
+  // Handle global state transitions when time of day changes
+  if (previousTimeOfDay !== null && previousTimeOfDay !== state.timeOfDay) {
+    onTimeOfDayChanged(state, previousTimeOfDay, state.timeOfDay);
+  }
+  previousTimeOfDay = state.timeOfDay;
+
+  // Reset per-frame builder assignments
+  resetBuilderAssignments();
+
+  // 1. Update monarch first (player input, crown recovery)
+  updateMonarch(state, effectiveDt);
+
+  // 2. Update mount (stamina, ability cooldown, panic)
+  updateMount(state, effectiveDt);
+  updateMountAbility(state, effectiveDt);
+
+  // Mount fear: check for breeder greed nearby
+  checkMountFearTriggers(state);
+
+  // 3. Update dog companion
+  if (state.hasDog) {
+    updateDog(state, effectiveDt);
+  }
+
+  // Update non-unit systems
+  updateAnimals(state, effectiveDt);
+  updateDenSpawning(state, effectiveDt);
+  updateBanker(state, effectiveDt);
+  updateMerchant(state, effectiveDt);
+  updateHermits(state, effectiveDt);
+  updateStatueBlessings(effectiveDt);
+  updateBread(effectiveDt);
+  updateDroppedTools(effectiveDt);
+
+  // Vagrant camp spawning
+  updateVagrantSpawning(state, effectiveDt);
+  tickVagrantSpawns(state, effectiveDt);
+
+  // Portal assault
+  if (state.portalAssaultActive) {
+    updateAssault(state, effectiveDt);
+  }
+
+  // Periodically fill tower slots with archers
+  fillTowerSlots(state);
+
+  // Night: reposition archers evenly
+  if (state.timeOfDay === TimeOfDay.Night) {
+    repositionNightArchers(state);
+  }
+
+  // Check for panic state
+  checkPanicState(state);
+
+  // Crown defense handled by knight module's getKnightMode now
+
+  // 4-11. Update all units in priority order
+  for (const unit of state.units) {
+    switch (unit.role) {
+      case UnitRole.Archer:
+        updateArcher(state, unit, effectiveDt);
+        break;
+      case UnitRole.Builder:
+        updateBuilder(state, unit, effectiveDt);
+        break;
+      case UnitRole.Farmer:
+        updateFarmer(state, unit, effectiveDt);
+        break;
+      case UnitRole.Knight:
+        updateKnight(state, unit, effectiveDt);
+        break;
+      case UnitRole.Squire:
+        updateSquire(state, unit, effectiveDt);
+        break;
+      case UnitRole.Pikeman:
+        updatePikeman(state, unit, effectiveDt);
+        break;
+      case UnitRole.Vagrant:
+        updateVagrant(state, unit, effectiveDt);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+/** Check if any breeder greed is near the mount and trigger panic. */
+function checkMountFearTriggers(state: GameState): void {
+  for (const greed of state.greeds) {
+    if (greed.type !== GreedType.Breeder) continue;
+    const gPos = getPosition(state.world, greed.eid);
+    if (!gPos) continue;
+    triggerMountPanic(state, gPos.x);
+  }
+}
+
+/**
+ * Get the dog bark range bonus for archers on the barking side.
+ * Returns bonus range if dog is barking toward the archer's side.
+ */
+export function getDogBarkArcherBonus(archerX: number): number {
+  if (!isDogBarking()) return 0;
+
+  const barkDir = getDogBarkDirection();
+  const dogPosition = getDogX();
+  const archerOnRight = archerX >= dogPosition;
+
+  // Bonus only for archers on the same side as the bark
+  if (barkDir === 1 && archerOnRight) return DOG_BARK_RANGE_BONUS;
+  if (barkDir === -1 && !archerOnRight) return DOG_BARK_RANGE_BONUS;
+  return 0;
+}
+
+function onTimeOfDayChanged(
+  state: GameState,
+  _from: TimeOfDay,
+  to: TimeOfDay,
+): void {
+  if (to === TimeOfDay.Dusk) {
+    for (const unit of state.units) {
+      if (unit.role === UnitRole.Monarch) continue;
+      if (unit.role === UnitRole.Vagrant) continue;
+
+      unit.aiState = AIState.Retreating;
+
+      const pos = getPosition(state.world, unit.eid);
+      if (!pos) continue;
+
+      const wallX = findNearestWallOnSide(state, pos.x);
+      const towardsCamp = pos.x > CAMP_CENTER_X ? -1 : 1;
+      unit.targetX = wallX + towardsCamp * 2;
+    }
+
+    // Emergency: if no walls on a side, place emergency wall blueprints
+    triggerEmergencyWalls(state);
+
+    state.messages.push('Dusk falls, workers retreat!');
+  }
+
+  if (to === TimeOfDay.Night) {
+    for (const unit of state.units) {
+      if (unit.role === UnitRole.Archer || unit.role === UnitRole.Knight
+        || unit.role === UnitRole.Pikeman || unit.role === UnitRole.Squire) {
+        const pos = getPosition(state.world, unit.eid);
+        if (!pos) continue;
+        const wallX = findNearestWallOnSide(state, pos.x);
+        unit.targetX = wallX;
+        unit.aiState = AIState.MovingTo;
+      }
+    }
+    state.messages.push('Night has come. Defend the kingdom!');
+  }
+
+  if (to === TimeOfDay.Dawn) {
+    for (const unit of state.units) {
+      if (unit.role === UnitRole.Monarch) continue;
+      if (unit.role === UnitRole.Vagrant) continue;
+      unit.aiState = AIState.Idle;
+    }
+
+    // Dawn bonus: drop coins near town center
+    applyDawnBonus(state);
+
+    // Banker interest at dawn
+    applyBankerInterest(state);
+
+    // Knight shield regeneration at dawn
+    regenerateKnightShields(state);
+
+    state.messages.push('A new dawn breaks.');
+  }
+}
+
+/**
+ * Emergency wall placement: when dusk arrives and a side has no walls,
+ * place wall blueprints near camp center on the unprotected side(s).
+ * Builders will rush to build them.
+ */
+function triggerEmergencyWalls(state: GameState): void {
+  const hasLeft = hasStandingWallOnSide(state, false);
+  const hasRight = hasStandingWallOnSide(state, true);
+
+  if (!hasLeft) {
+    // Place 2 emergency walls on the left side
+    const wall1X = CAMP_CENTER_X - 5;
+    const wall2X = CAMP_CENTER_X - 10;
+    if (placeWallBlueprint(state, wall1X)) {
+      state.messages.push('Emergency wall blueprint placed on left!');
+    }
+    if (placeWallBlueprint(state, wall2X)) {
+      state.messages.push('Emergency wall blueprint placed on left!');
+    }
+  }
+
+  if (!hasRight) {
+    // Place 2 emergency walls on the right side
+    const wall1X = CAMP_CENTER_X + 5;
+    const wall2X = CAMP_CENTER_X + 10;
+    if (placeWallBlueprint(state, wall1X)) {
+      state.messages.push('Emergency wall blueprint placed on right!');
+    }
+    if (placeWallBlueprint(state, wall2X)) {
+      state.messages.push('Emergency wall blueprint placed on right!');
+    }
+  }
+}
+
+/**
+ * Panic state: if all walls on one side are destroyed,
+ * all units on that side flee to the other side.
+ */
+function checkPanicState(state: GameState): void {
+  // Only check during night when walls matter
+  if (state.timeOfDay !== TimeOfDay.Night) return;
+
+  const hasLeftWall = hasStandingWallOnSide(state, false);
+  const hasRightWall = hasStandingWallOnSide(state, true);
+
+  // If both sides have walls or both sides are gone, no directional panic
+  if (hasLeftWall === hasRightWall) return;
+
+  // One side is breached
+  const breachedSideIsRight = !hasRightWall;
+  const safeSide = breachedSideIsRight ? false : true; // left is safe if right is breached
+
+  for (const unit of state.units) {
+    if (unit.role === UnitRole.Monarch) continue;
+    if (unit.role === UnitRole.Vagrant) continue;
+    if (unit.aiState === AIState.Fleeing) continue; // already panicking
+
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+
+    // Check if unit is on the breached side
+    const unitOnRight = pos.x >= CAMP_CENTER_X;
+    if (unitOnRight === breachedSideIsRight) {
+      unit.aiState = AIState.Fleeing;
+      // Flee to the safe side's wall or camp center
+      const safeWallX = findNearestWallOnSideExplicit(state, safeSide);
+      const towardsCamp = breachedSideIsRight ? -1 : 1;
+      unit.targetX = clamp(safeWallX + towardsCamp * 3, 0, MAP_WIDTH - 1);
+    }
+  }
+}
+
+function hasStandingWallOnSide(state: GameState, rightSide: boolean): boolean {
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight === rightSide) return true;
+  }
+  return false;
+}
+
+function findNearestWallOnSide(state: GameState, fromX: number): number {
+  const onRightSide = fromX >= CAMP_CENTER_X;
+  return findNearestWallOnSideExplicit(state, onRightSide);
+}
+
+function findNearestWallOnSideExplicit(state: GameState, rightSide: boolean): number {
+  let bestX = CAMP_CENTER_X;
+  let bestDist = Infinity;
+  // Use camp center as reference point for "nearest"
+  const refX = rightSide ? CAMP_CENTER_X + 10 : CAMP_CENTER_X - 10;
+
+  for (const [, struct] of state.structures) {
+    const isWall = struct.type === StructureType.WallWood
+      || struct.type === StructureType.WallStone
+      || struct.type === StructureType.WallIron;
+    if (!isWall) continue;
+    if (struct.hp <= 0) continue;
+
+    const wallOnRight = struct.x >= CAMP_CENTER_X;
+    if (wallOnRight !== rightSide) continue;
+
+    const d = distance(refX, struct.x);
+    if (d < bestDist) {
+      bestDist = d;
+      bestX = struct.x;
+    }
+  }
+
+  return bestX;
+}

--- a/kingdom/systems/combat.ts
+++ b/kingdom/systems/combat.ts
@@ -1,0 +1,491 @@
+/**
+ * Combat system: projectiles, damage, coin drops, monarch coin pickup.
+ *
+ * Performance: only processes entities within 50 tiles of the camera.
+ * Friendly fire prevention: projectiles only collide with greeds, never units.
+ * Masked greeds: mask handled by greed.ts onGreedDamaged.
+ * Combo: 3 arrows hitting the same greed within 1 second deals bonus damage.
+ * Archers at different settlements defend independently.
+ *
+ * Damage types:
+ *   Normal: standard arrow damage
+ *   Piercing: ballista bolt hits all greeds in a line
+ *   Burn: fire tower sets greed on fire (DPS over time)
+ *   AoE: catapult/pike hits all in radius
+ *
+ * Pike thrust: pikemen hit all greed within 1.5 tiles, 3 damage, 2s cooldown.
+ * Mounted combat: monarch on bear can instakill 1 greed (8s cooldown).
+ */
+
+import { getPosition, removeEntity } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  type GreedData,
+  GreedType,
+  GamePhase,
+  DamageType,
+  UnitRole,
+  GROUND_Y,
+  MAX_COINS,
+  MountType,
+} from '../types';
+import { getActiveBuff, ShrineBuffType, updateShrineBuff } from '../structures/shrine';
+import { applyKnockback, cleanupGreedState, onGreedDamaged, applyPlagueCrawlerDeathPoison } from '../entities/greed';
+import { TOWER_TYPE } from '../structures/wall';
+
+/** A coin dropped on the ground by a dead greed */
+export interface DroppedCoin {
+  x: number;
+  y: number;
+}
+
+const ARROW_LIFETIME = 0.5;
+const CRIT_CHANCE = 0.10;
+const CRIT_MULTIPLIER = 2;
+const COIN_PICKUP_RANGE = 1.5;
+const COMBO_WINDOW = 1.0;
+const COMBO_THRESHOLD = 3;
+const COMBO_BONUS = 2;
+const CAMERA_CULL_RANGE = 50;
+
+/** Pike thrust constants */
+const PIKE_DAMAGE = 3;
+const PIKE_RANGE = 1.5;
+const PIKE_COOLDOWN = 2.0;
+
+/** Bear combat constants */
+const BEAR_ATTACK_COOLDOWN = 8.0;
+const BEAR_ATTACK_RANGE = 2.0;
+
+/** Module-level tracking */
+const projectileAges: Map<number, number> = new Map();
+const droppedCoins: DroppedCoin[] = [];
+
+/** Combo tracking: greed eid -> array of hit timestamps */
+const greedHitLog: Map<number, number[]> = new Map();
+
+/** Pikeman attack cooldowns */
+const pikemanCooldowns: Map<number, number> = new Map();
+
+/** Get all coins currently on the ground */
+export function getDroppedCoins(): readonly DroppedCoin[] {
+  return droppedCoins;
+}
+
+/** Check if a projectile's owner is stationed at a tower */
+function isFromTower(state: GameState, ownerEid: Entity): boolean {
+  const pos = getPosition(state.world, ownerEid);
+  if (!pos) return false;
+  const x = Math.round(pos.x);
+  for (const offset of [-1, 0, 1]) {
+    const s = state.structures.get(x + offset);
+    if (s && s.type === TOWER_TYPE) return true;
+  }
+  return false;
+}
+
+/** Calculate effective damage (mask is handled by onGreedDamaged) */
+function calculateArrowDamage(
+  baseDmg: number,
+  _greedType: GreedType,
+  _fromTower: boolean,
+): number {
+  return baseDmg;
+}
+
+/** Record a hit for the combo system. Returns bonus damage if combo triggered. */
+function recordComboHit(greedEid: number, timestamp: number): number {
+  let hits = greedHitLog.get(greedEid);
+  if (!hits) {
+    hits = [];
+    greedHitLog.set(greedEid, hits);
+  }
+
+  hits.push(timestamp);
+
+  const cutoff = timestamp - COMBO_WINDOW;
+  while (hits.length > 0 && hits[0] < cutoff) {
+    hits.shift();
+  }
+
+  if (hits.length >= COMBO_THRESHOLD) {
+    hits.length = 0;
+    return COMBO_BONUS;
+  }
+
+  return 0;
+}
+
+/** Check if an x position is within camera cull range */
+function isInCullRange(x: number, cameraX: number, viewWidth: number): boolean {
+  const center = cameraX + viewWidth / 2;
+  return Math.abs(x - center) <= CAMERA_CULL_RANGE;
+}
+
+/**
+ * Apply burn damage to a greed.
+ * Sets burnTimer and burnDps on the greed entity.
+ */
+export function applyBurn(greed: GreedData, dps: number, duration: number): void {
+  greed.burnTimer = duration;
+  greed.burnDps = dps;
+}
+
+/**
+ * Apply piercing damage: hits all greeds along a line (same x direction).
+ * Returns the number of greeds hit.
+ */
+export function applyPiercing(
+  state: GameState,
+  startX: number,
+  vx: number,
+  damage: number,
+  range: number,
+): number {
+  const direction = vx > 0 ? 1 : -1;
+  let hitCount = 0;
+
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+
+    const dx = pos.x - startX;
+    // Only hit greeds in the projectile direction and within range
+    if (dx * direction >= 0 && Math.abs(dx) <= range) {
+      greed.hp -= damage;
+      hitCount++;
+    }
+  }
+
+  return hitCount;
+}
+
+/**
+ * Apply AoE damage to all greeds within radius of a target position.
+ * Returns the number of greeds hit.
+ */
+export function applyAoE(
+  state: GameState,
+  targetX: number,
+  damage: number,
+  radius: number,
+): number {
+  let hitCount = 0;
+
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const pos = getPosition(state.world, greed.eid);
+    if (!pos) continue;
+
+    if (Math.abs(pos.x - targetX) <= radius) {
+      greed.hp -= damage;
+      hitCount++;
+    }
+  }
+
+  return hitCount;
+}
+
+/** Process all combat interactions for one frame */
+export function updateCombat(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+
+  updateShrineBuff(dt);
+
+  const buff = getActiveBuff();
+  const arrowDmgMultiplier = buff?.type === ShrineBuffType.ArcherDamage ? buff.multiplier : 1;
+
+  updateProjectiles(state, dt, arrowDmgMultiplier);
+  updateBurnDamage(state, dt);
+  updatePoisonDamage(state, dt);
+  updatePikemanCombat(state, dt);
+  updateBearCombat(state, dt);
+  updateMonarchCoinPickup(state);
+  cleanupDeadGreeds(state);
+}
+
+/** Update burn damage on all greeds */
+function updateBurnDamage(state: GameState, dt: number): void {
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    if (!greed.burnTimer || greed.burnTimer <= 0) continue;
+
+    const dps = greed.burnDps ?? 0;
+    greed.hp -= dps * dt;
+    greed.burnTimer -= dt;
+
+    if (greed.burnTimer <= 0) {
+      greed.burnTimer = 0;
+      greed.burnDps = 0;
+    }
+  }
+}
+
+/** Update poison damage on units (from plague crawlers) */
+function updatePoisonDamage(state: GameState, dt: number): void {
+  for (const unit of state.units) {
+    if (unit.hp <= 0) continue;
+    if (!unit.poisonTimer || unit.poisonTimer <= 0) continue;
+
+    const dps = unit.poisonDps ?? 0;
+    unit.hp -= dps * dt;
+    unit.poisonTimer -= dt;
+
+    if (unit.poisonTimer <= 0) {
+      unit.poisonTimer = 0;
+      unit.poisonDps = 0;
+    }
+  }
+}
+
+/** Update pikeman thrust attacks */
+function updatePikemanCombat(state: GameState, dt: number): void {
+  // Tick down all cooldowns
+  for (const [eid, cd] of pikemanCooldowns) {
+    const next = cd - dt;
+    if (next <= 0) {
+      pikemanCooldowns.delete(eid);
+    } else {
+      pikemanCooldowns.set(eid, next);
+    }
+  }
+
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Pikeman) continue;
+    if (unit.hp <= 0) continue;
+
+    // Check cooldown
+    if (pikemanCooldowns.has(unit.eid)) continue;
+
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+
+    // Check for greeds in range
+    let hitAny = false;
+    for (const greed of state.greeds) {
+      if (greed.hp <= 0) continue;
+      const greedPos = getPosition(state.world, greed.eid);
+      if (!greedPos) continue;
+
+      if (Math.abs(greedPos.x - pos.x) <= PIKE_RANGE) {
+        greed.hp -= PIKE_DAMAGE;
+        hitAny = true;
+      }
+    }
+
+    if (hitAny) {
+      pikemanCooldowns.set(unit.eid, PIKE_COOLDOWN);
+    }
+  }
+}
+
+/** Update mounted bear combat (monarch on bear instakill) */
+function updateBearCombat(state: GameState, dt: number): void {
+  if (state.mountType !== MountType.Horse) return; // bear uses Horse slot for now
+
+  // Tick cooldown
+  state.bearAttackCooldown = Math.max(0, state.bearAttackCooldown - dt);
+  if (state.bearAttackCooldown > 0) return;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  // Find nearest greed in range
+  for (const greed of state.greeds) {
+    if (greed.hp <= 0) continue;
+    const greedPos = getPosition(state.world, greed.eid);
+    if (!greedPos) continue;
+
+    if (Math.abs(greedPos.x - monarchPos.x) <= BEAR_ATTACK_RANGE) {
+      greed.hp = 0; // instakill
+      state.bearAttackCooldown = BEAR_ATTACK_COOLDOWN;
+      state.messages.push('Bear mauls a greed!');
+      return;
+    }
+  }
+}
+
+function updateProjectiles(state: GameState, dt: number, dmgMultiplier: number): void {
+  const deadIndices: number[] = [];
+
+  for (let i = 0; i < state.projectiles.length; i++) {
+    const proj = state.projectiles[i];
+
+    // Move the projectile
+    proj.x += proj.vx * dt;
+
+    // Age the projectile
+    const age = (projectileAges.get(proj.eid) ?? 0) + dt;
+    projectileAges.set(proj.eid, age);
+
+    // Lifetime expiry
+    if (age >= ARROW_LIFETIME) {
+      deadIndices.push(i);
+      continue;
+    }
+
+    // Camera cull: skip collision checks for far-away projectiles
+    if (!isInCullRange(proj.x, state.cameraX, state.viewWidth)) {
+      if (proj.x < state.cameraX - CAMERA_CULL_RANGE || proj.x > state.cameraX + state.viewWidth + CAMERA_CULL_RANGE) {
+        deadIndices.push(i);
+      }
+      continue;
+    }
+
+    const damageType = proj.damageType ?? DamageType.Normal;
+
+    // Piercing projectiles hit all greeds in a line
+    if (damageType === DamageType.Piercing) {
+      const range = proj.aoeRadius ?? 20;
+      const hits = applyPiercing(state, proj.x, proj.vx, proj.damage * dmgMultiplier, range);
+      if (hits > 0) {
+        deadIndices.push(i);
+      }
+      continue;
+    }
+
+    // AoE projectiles damage all in radius on first hit
+    if (damageType === DamageType.AoE) {
+      const radius = proj.aoeRadius ?? 3;
+      for (const greed of state.greeds) {
+        if (greed.hp <= 0) continue;
+        const greedPos = getPosition(state.world, greed.eid);
+        if (!greedPos) continue;
+        if (Math.abs(proj.x - greedPos.x) < 1.0) {
+          applyAoE(state, greedPos.x, proj.damage * dmgMultiplier, radius);
+          deadIndices.push(i);
+          break;
+        }
+      }
+      continue;
+    }
+
+    // Normal collision check (including burn on contact)
+    let hit = false;
+    for (const greed of state.greeds) {
+      if (greed.hp <= 0) continue;
+
+      const greedPos = getPosition(state.world, greed.eid);
+      if (!greedPos) continue;
+
+      if (!isInCullRange(greedPos.x, state.cameraX, state.viewWidth)) continue;
+
+      const dist = Math.abs(proj.x - greedPos.x);
+      if (dist < 1.0) {
+        const fromTower = isFromTower(state, proj.owner);
+
+        const isCrit = Math.random() < CRIT_CHANCE;
+        const critMult = isCrit ? CRIT_MULTIPLIER : 1;
+
+        const rawDmg = proj.damage * dmgMultiplier * critMult;
+        const armorDmg = calculateArrowDamage(rawDmg, greed.type, fromTower);
+        const comboBonus = recordComboHit(greed.eid, state.totalElapsed);
+
+        // onGreedDamaged handles mask absorption; returns 0 if mask absorbed
+        const maskMult = onGreedDamaged(state, greed, proj.vx, fromTower);
+        const totalDmg = (armorDmg + comboBonus) * maskMult;
+
+        greed.hp -= totalDmg;
+
+        // Apply burn if this is a burn projectile
+        if (damageType === DamageType.Burn && proj.burnDps && proj.burnDuration) {
+          applyBurn(greed, proj.burnDps, proj.burnDuration);
+        }
+
+        applyKnockback(state, greed.eid, proj.vx);
+
+        hit = true;
+        break;
+      }
+    }
+
+    if (hit) {
+      deadIndices.push(i);
+      continue;
+    }
+
+    // Remove projectiles far off-screen
+    if (proj.x < state.cameraX - CAMERA_CULL_RANGE || proj.x > state.cameraX + state.viewWidth + CAMERA_CULL_RANGE) {
+      deadIndices.push(i);
+    }
+  }
+
+  // Remove dead projectiles in reverse order
+  for (let i = deadIndices.length - 1; i >= 0; i--) {
+    const idx = deadIndices[i];
+    const proj = state.projectiles[idx];
+    projectileAges.delete(proj.eid);
+    removeEntity(state.world, proj.eid);
+    state.projectiles.splice(idx, 1);
+  }
+}
+
+/** Monarch picks up dropped coins by walking over them */
+function updateMonarchCoinPickup(state: GameState): void {
+  if (droppedCoins.length === 0) return;
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  for (let i = droppedCoins.length - 1; i >= 0; i--) {
+    const coin = droppedCoins[i];
+    const dist = Math.abs(coin.x - monarchPos.x);
+    if (dist < COIN_PICKUP_RANGE) {
+      if (state.monarchCoins < MAX_COINS) {
+        state.monarchCoins += 1;
+      }
+      droppedCoins.splice(i, 1);
+    }
+  }
+}
+
+/** Remove dead greeds and drop coins at their death positions */
+function cleanupDeadGreeds(state: GameState): void {
+  for (let i = state.greeds.length - 1; i >= 0; i--) {
+    const greed = state.greeds[i];
+    if (greed.hp > 0) continue;
+
+    const deathPos = getPosition(state.world, greed.eid);
+
+    // Drop coins at death
+    if (deathPos) {
+      droppedCoins.push({ x: deathPos.x, y: GROUND_Y - 1 });
+    }
+
+    if (greed.carryingCoins > 0 && deathPos) {
+      for (let c = 0; c < greed.carryingCoins; c++) {
+        droppedCoins.push({
+          x: deathPos.x + (Math.random() - 0.5) * 2,
+          y: GROUND_Y - 1,
+        });
+      }
+    }
+
+    // PlagueCrawler: poison nearby units on death
+    if (greed.type === GreedType.PlagueCrawler && greed.poisonOnDeath && deathPos) {
+      applyPlagueCrawlerDeathPoison(state, deathPos.x);
+    }
+
+    // Floater: drop carried unit at current position (alive)
+    if (greed.type === GreedType.Floater && greed.isCarrying && greed.floaterTarget != null) {
+      greed.floaterTarget = null;
+      greed.isCarrying = false;
+    }
+
+    // Crown stealer: drop crown if carrying
+    if (greed.type === GreedType.CrownStealer && greed.hasCrown && deathPos) {
+      state.crownDropped = true;
+      state.crownX = deathPos.x;
+      state.crownY = GROUND_Y - 1;
+      state.messages.push('Crown dropped! Recover it quickly!');
+    }
+
+    greedHitLog.delete(greed.eid);
+
+    cleanupGreedState(greed.eid);
+    removeEntity(state.world, greed.eid);
+    state.greeds.splice(i, 1);
+  }
+}

--- a/kingdom/systems/construction.ts
+++ b/kingdom/systems/construction.ts
@@ -1,0 +1,526 @@
+/**
+ * Construction system: builders choose closest tasks with priority ordering,
+ * auto-protection blueprints, and auto-gate placement.
+ *
+ * Auto-protection: when the monarch first visits a settlement (within 10 tiles),
+ * wall blueprints are placed 15 tiles left and right of the campfire.
+ * Builders auto-queue: walls first, then farms.
+ *
+ * Priority order (Phase 8):
+ *   1. Repair town center (critical)
+ *   2. Repair damaged walls (structural)
+ *   3. Build queued walls/towers (expansion)
+ *   4. Upgrade town center (progression)
+ *   5. Upgrade towers (improvement)
+ *   6. Upgrade farms (economic)
+ *   7. Boat restoration (when active)
+ *   8. Cut trees (idle work)
+ *
+ * Max 2 builders per task to prevent overcrowding.
+ *
+ * Build times: Walls/Gates: 5s, Farms: 8s, Upgrades/other: 10s, Hull pieces: 5s.
+ *
+ * Town center integration: updateTownCenter runs each frame for cooldown.
+ * Catapult builders are skipped (managed by catapult.ts).
+ */
+
+import { getPosition } from 'blecsd';
+import {
+  type GameState,
+  type StructureData,
+  AIState,
+  UnitRole,
+  StructureType,
+  GamePhase,
+  TowerTier,
+  TownCenterTier,
+  TOWER_COSTS,
+} from '../types';
+import { getActiveBuff, ShrineBuffType } from '../structures/shrine';
+import {
+  isWallStructure,
+  isTowerStructure,
+  isGateStructure,
+  createWall,
+  createGate,
+  shouldAutoGate,
+  upgradeTower,
+  WALL_REPAIR_RATE,
+  TOWER_TYPE,
+  isConvertedTower,
+} from '../structures/wall';
+import {
+  SETTLEMENT_POSITIONS,
+  getNearestSettlement,
+} from '../structures/portal';
+import { updateTownCenter } from '../structures/townCenter';
+import { isCatapultBuilder } from '../structures/catapult';
+import { isBombBuilder } from '../structures/bomb';
+import { isFarmStructure, getFarmUpgradeCost } from '../structures/farm';
+import { isBoatBuilder, getShipX } from '../structures/ship';
+
+/** Per-structure build progress tracked by x position (0-100) */
+const buildProgress: Map<number, number> = new Map();
+
+/** Blueprint positions: virtual structures waiting to be built */
+const blueprints: Set<number> = new Set();
+
+/** Settlements the monarch has already visited (auto-protection triggered) */
+const visitedSettlements: Set<number> = new Set();
+
+/** Distance threshold for "visiting" a settlement */
+const VISIT_RADIUS = 10;
+
+/** Wall blueprint offset from settlement campfire */
+const DEFENSE_OFFSET = 15;
+
+/** Build times in seconds per structure type */
+const BUILD_TIME_WALL = 5.0;
+const BUILD_TIME_FARM = 8.0;
+const BUILD_TIME_UPGRADE = 10.0;
+const BUILD_TIME_HULL_PIECE = 5.0;
+
+/** Max builders per task to prevent overcrowding */
+const MAX_BUILDERS_PER_TASK = 2;
+
+/** Builder assignment tracking: task x -> count of builders assigned */
+const taskBuilderCount: Map<number, number> = new Map();
+
+enum TaskPriority {
+  RepairTownCenter = 0,
+  RepairWall = 1,
+  BuildBlueprint = 2,
+  UpgradeTownCenter = 3,
+  UpgradeTower = 4,
+  UpgradeFarm = 5,
+  BoatRestoration = 6,
+  CutTrees = 7,
+}
+
+interface BuildTask {
+  x: number;
+  structure: StructureData | null; // null for blueprints
+  priority: TaskPriority;
+  distance: number;
+  buildTime: number;
+  isBlueprint: boolean;
+}
+
+/** Get build progress percentage for a structure at position x (0-100) */
+export function getBuildProgress(x: number): number {
+  return buildProgress.get(x) ?? 0;
+}
+
+/** Get all current blueprint positions */
+export function getBlueprints(): ReadonlySet<number> {
+  return blueprints;
+}
+
+/** Add a blueprint at position x */
+export function addBlueprint(x: number): void {
+  blueprints.add(x);
+}
+
+/** Remove a blueprint at position x */
+export function removeBlueprint(x: number): void {
+  blueprints.delete(x);
+  buildProgress.delete(x);
+}
+
+/**
+ * Analyze the map and create wall blueprints for a settlement.
+ * Places walls 15 tiles left and right of the settlement campfire.
+ * Auto-gates every 10 tiles.
+ */
+function planSettlementDefenses(state: GameState, settlementX: number): void {
+  const leftStart = settlementX - DEFENSE_OFFSET;
+  const rightStart = settlementX + DEFENSE_OFFSET;
+
+  for (const x of [leftStart, rightStart]) {
+    // Don't place blueprints where structures already exist
+    if (state.structures.has(x)) continue;
+    if (blueprints.has(x)) continue;
+
+    blueprints.add(x);
+    buildProgress.set(x, 0);
+  }
+}
+
+/**
+ * Check if the monarch is visiting any new settlements.
+ * If so, trigger auto-protection blueprint placement.
+ */
+function checkSettlementVisits(state: GameState): void {
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  for (const sx of SETTLEMENT_POSITIONS) {
+    if (visitedSettlements.has(sx)) continue;
+
+    if (Math.abs(monarchPos.x - sx) <= VISIT_RADIUS) {
+      visitedSettlements.add(sx);
+      planSettlementDefenses(state, sx);
+      state.messages.push(`Settlement discovered! Auto-defense blueprints placed.`);
+    }
+  }
+}
+
+/**
+ * Complete a blueprint: convert it into a real wall or gate.
+ * Auto-gate: if the position is at a gate interval from the nearest
+ * settlement, build a gate instead of a wall.
+ */
+function completeBlueprint(state: GameState, x: number): void {
+  blueprints.delete(x);
+  buildProgress.delete(x);
+
+  const nearestSettlement = getNearestSettlement(x);
+
+  if (shouldAutoGate(x, nearestSettlement)) {
+    createGate(state, x);
+  } else {
+    createWall(state, x, StructureType.WallWood);
+  }
+}
+
+/** Process all builder construction work for one frame */
+export function updateConstruction(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+
+  // Update town center cooldown and destruction check
+  updateTownCenter(state, dt);
+
+  // Check for new settlement visits
+  checkSettlementVisits(state);
+
+  const buff = getActiveBuff();
+  const speedMultiplier = buff?.type === ShrineBuffType.BuilderSpeed ? buff.multiplier : 1;
+  const effectiveDt = dt * speedMultiplier;
+
+  // Reset builder counts each frame
+  taskBuilderCount.clear();
+
+  for (const unit of state.units) {
+    if (unit.role !== UnitRole.Builder) continue;
+    if (unit.aiState !== AIState.Working) continue;
+
+    // Skip builders assigned to catapults, bombs, or boat push
+    if (isCatapultBuilder(unit.eid)) continue;
+    if (isBombBuilder(unit.eid)) continue;
+    if (isBoatBuilder(unit.eid)) continue;
+
+    const unitPos = getPosition(state.world, unit.eid);
+    if (!unitPos) continue;
+
+    const task = findBestTask(state, unitPos.x);
+    if (!task) {
+      unit.aiState = AIState.Idle;
+      continue;
+    }
+
+    const x = task.x;
+
+    // Enforce max builders per task
+    const currentCount = taskBuilderCount.get(x) ?? 0;
+    if (currentCount >= MAX_BUILDERS_PER_TASK) {
+      // Try to find another task (builder will idle if none available)
+      unit.aiState = AIState.Idle;
+      continue;
+    }
+    taskBuilderCount.set(x, currentCount + 1);
+
+    // Check if builder is close enough to work
+    const dist = Math.abs(unitPos.x - x);
+    if (dist > 2) {
+      unit.targetX = x;
+      continue;
+    }
+
+    if ((task.priority === TaskPriority.RepairWall || task.priority === TaskPriority.RepairTownCenter) && task.structure) {
+      // Repair: use wall repair rate
+      const structure = task.structure;
+      structure.hp = Math.min(
+        structure.maxHp,
+        structure.hp + WALL_REPAIR_RATE * effectiveDt
+      );
+
+      const pct = (structure.hp / structure.maxHp) * 100;
+      buildProgress.set(x, pct);
+
+      if (structure.hp >= structure.maxHp) {
+        buildProgress.delete(x);
+        unit.aiState = AIState.Idle;
+      }
+    } else if (task.priority === TaskPriority.BoatRestoration) {
+      // Boat hull piece installation: 5s per piece
+      const current = buildProgress.get(x) ?? 0;
+      const increment = (effectiveDt / BUILD_TIME_HULL_PIECE) * 100;
+      const next = Math.min(100, current + increment);
+      buildProgress.set(x, next);
+
+      if (next >= 100) {
+        buildProgress.delete(x);
+        // Hull piece completion is handled by ship.ts addHullPiece
+        unit.aiState = AIState.Idle;
+      }
+    } else {
+      // Blueprint, new construction, or upgrade: advance build timer
+      const current = buildProgress.get(x) ?? 0;
+      const increment = (effectiveDt / task.buildTime) * 100;
+      const next = Math.min(100, current + increment);
+      buildProgress.set(x, next);
+
+      if (next >= 100) {
+        if (task.isBlueprint) {
+          completeBlueprint(state, x);
+        } else if (task.priority === TaskPriority.UpgradeTower && task.structure && isTowerStructure(task.structure.type)) {
+          buildProgress.delete(x);
+          upgradeTower(state, x);
+        } else {
+          buildProgress.delete(x);
+          // Set structure to full HP on build completion
+          if (task.structure) {
+            task.structure.hp = task.structure.maxHp;
+          }
+        }
+        unit.aiState = AIState.Idle;
+      }
+    }
+  }
+}
+
+/** Find the best task for a builder, sorted by priority then distance */
+function findBestTask(state: GameState, builderX: number): BuildTask | null {
+  const tasks: BuildTask[] = [];
+
+  // Priority 0: Repair town center (critical)
+  for (const [, structure] of state.structures) {
+    if (structure.type !== StructureType.Campfire) continue;
+    // Only repair upgraded campfires (maxHp < 999 means it was upgraded via town center)
+    if (structure.maxHp >= 999) continue;
+    if (structure.hp >= structure.maxHp || structure.hp <= 0) continue;
+
+    const dist = Math.abs(builderX - structure.x);
+    tasks.push({
+      x: structure.x,
+      structure,
+      priority: TaskPriority.RepairTownCenter,
+      distance: dist,
+      buildTime: BUILD_TIME_WALL,
+      isBlueprint: false,
+    });
+  }
+
+  // Priority 2: Build blueprints (expansion)
+  for (const bx of blueprints) {
+    const dist = Math.abs(builderX - bx);
+    tasks.push({
+      x: bx,
+      structure: null,
+      priority: TaskPriority.BuildBlueprint,
+      distance: dist,
+      buildTime: BUILD_TIME_WALL,
+      isBlueprint: true,
+    });
+  }
+
+  // Check existing structures
+  for (const [, structure] of state.structures) {
+    if (structure.type === StructureType.Portal
+      || structure.type === StructureType.Campfire) {
+      continue;
+    }
+
+    const dist = Math.abs(builderX - structure.x);
+    const isWall = isWallStructure(structure.type);
+    const isTower = isTowerStructure(structure.type);
+    const isGate = isGateStructure(structure.type);
+    const isFarm = isFarmStructure(structure.type);
+
+    // Priority 1: Repair damaged walls/towers/gates (structural)
+    if ((isWall || isTower || isGate) && structure.hp < structure.maxHp && structure.hp > 0) {
+      tasks.push({
+        x: structure.x,
+        structure,
+        priority: TaskPriority.RepairWall,
+        distance: dist,
+        buildTime: BUILD_TIME_WALL,
+        isBlueprint: false,
+      });
+      continue;
+    }
+
+    // Priority 2: Structures placed with hp:0 need building (expansion)
+    if (structure.hp === 0 && structure.maxHp > 0) {
+      const buildTime = getBuildTimeForType(structure.type);
+      tasks.push({
+        x: structure.x,
+        structure,
+        priority: TaskPriority.BuildBlueprint,
+        distance: dist,
+        buildTime,
+        isBlueprint: false,
+      });
+      continue;
+    }
+
+    // Priority 4: Tower upgrades (tower with towerTier < max and pending upgrade progress)
+    // Skip converted towers (they cannot be further upgraded)
+    if (isTower && !isConvertedTower(structure.type) && (structure.towerTier ?? TowerTier.None) < TowerTier.QuadrupletTower) {
+      const upgProgress = buildProgress.get(structure.x) ?? 0;
+      if (upgProgress > 0 && upgProgress < 100) {
+        tasks.push({
+          x: structure.x,
+          structure,
+          priority: TaskPriority.UpgradeTower,
+          distance: dist,
+          buildTime: BUILD_TIME_UPGRADE,
+          isBlueprint: false,
+        });
+        continue;
+      }
+    }
+
+    // Priority 5: Farm upgrades (economic)
+    if (isFarm && (structure.farmTier ?? 1) < 2) {
+      const upgCost = getFarmUpgradeCost(structure.farmTier ?? 1);
+      if (upgCost > 0) {
+        const upgProgress = buildProgress.get(structure.x) ?? 0;
+        if (upgProgress > 0 && upgProgress < 100) {
+          tasks.push({
+            x: structure.x,
+            structure,
+            priority: TaskPriority.UpgradeFarm,
+            distance: dist,
+            buildTime: BUILD_TIME_FARM,
+            isBlueprint: false,
+          });
+          continue;
+        }
+      }
+    }
+
+    // In-progress construction (uses the structure's natural priority)
+    const progress = buildProgress.get(structure.x) ?? 0;
+    if (progress > 0 && progress < 100) {
+      const buildTime = getBuildTimeForType(structure.type);
+      tasks.push({
+        x: structure.x,
+        structure,
+        priority: TaskPriority.BuildBlueprint,
+        distance: dist,
+        buildTime,
+        isBlueprint: false,
+      });
+      continue;
+    }
+  }
+
+  // Priority 6: Boat restoration (when active)
+  if (state.boatState === 'restoring') {
+    const boatX = getShipX();
+    const dist = Math.abs(builderX - boatX);
+    tasks.push({
+      x: boatX,
+      structure: null,
+      priority: TaskPriority.BoatRestoration,
+      distance: dist,
+      buildTime: BUILD_TIME_HULL_PIECE,
+      isBlueprint: false,
+    });
+  }
+
+  if (tasks.length === 0) return null;
+
+  // Filter out tasks that already have max builders assigned
+  const available = tasks.filter(t => {
+    const count = taskBuilderCount.get(t.x) ?? 0;
+    return count < MAX_BUILDERS_PER_TASK;
+  });
+
+  if (available.length === 0) return null;
+
+  // Sort: priority first (lower = better), then distance (closer = better)
+  available.sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+    return a.distance - b.distance;
+  });
+
+  return available[0];
+}
+
+/**
+ * Start a tower upgrade at position x.
+ * Called when the monarch drops a coin on a tower.
+ * Deducts the cost and sets build progress to trigger builder work.
+ */
+export function startTowerUpgrade(state: GameState, x: number): boolean {
+  const tower = state.structures.get(x);
+  if (!tower || !isTowerStructure(tower.type)) return false;
+  if ((tower.towerTier ?? TowerTier.None) >= TowerTier.QuadrupletTower) return false;
+
+  const nextTier = (tower.towerTier ?? TowerTier.None) + 1;
+  const cost = TOWER_COSTS[nextTier];
+  if (cost === undefined || state.monarchCoins < cost) return false;
+
+  // Check town center requirements
+  if (nextTier >= TowerTier.StoneTower && state.townCenterTier < TownCenterTier.StoneFort) return false;
+  if (nextTier >= TowerTier.RoofedTriplet && state.townCenterTier < TownCenterTier.IronKeep) return false;
+
+  // Set build progress to trigger builder to walk to tower
+  buildProgress.set(x, 1);
+  return true;
+}
+
+/**
+ * Get the numeric priority for a task type string.
+ * Lower numbers = higher priority.
+ * Exported for external systems that need to understand builder priority ordering.
+ */
+export function getConstructionPriority(taskType: string): number {
+  switch (taskType) {
+    case 'repairTownCenter': return TaskPriority.RepairTownCenter;
+    case 'repairWall': return TaskPriority.RepairWall;
+    case 'buildWall':
+    case 'buildTower':
+    case 'buildBlueprint': return TaskPriority.BuildBlueprint;
+    case 'upgradeTownCenter': return TaskPriority.UpgradeTownCenter;
+    case 'upgradeTower':
+    case 'convertTower': return TaskPriority.UpgradeTower;
+    case 'upgradeFarm': return TaskPriority.UpgradeFarm;
+    case 'boatRestoration': return TaskPriority.BoatRestoration;
+    case 'cutTrees': return TaskPriority.CutTrees;
+    default: return TaskPriority.CutTrees;
+  }
+}
+
+/**
+ * Start a farm upgrade at position x.
+ * Called when the monarch drops a coin on a farm.
+ * Sets build progress to trigger builder work.
+ */
+export function startFarmUpgrade(state: GameState, x: number): boolean {
+  const farm = state.structures.get(x);
+  if (!farm || !isFarmStructure(farm.type)) return false;
+  if ((farm.farmTier ?? 1) >= 2) return false;
+
+  const cost = getFarmUpgradeCost(farm.farmTier ?? 1);
+  if (cost <= 0 || state.monarchCoins < cost) return false;
+
+  // Set build progress to trigger builder to walk to farm
+  buildProgress.set(x, 1);
+  return true;
+}
+
+function getBuildTimeForType(type: StructureType): number {
+  if (isWallStructure(type) || isTowerStructure(type) || isGateStructure(type)) return BUILD_TIME_WALL;
+
+  if (isFarmStructure(type)) return BUILD_TIME_FARM;
+
+  switch (type) {
+    case StructureType.Ship:
+      return BUILD_TIME_HULL_PIECE;
+    default:
+      return BUILD_TIME_UPGRADE;
+  }
+}

--- a/kingdom/systems/decay.ts
+++ b/kingdom/systems/decay.ts
@@ -1,0 +1,143 @@
+/**
+ * Decay system: walls deteriorate when the monarch leaves an island.
+ *
+ * Decay rates per wall tier (days until removal):
+ *   Spikes: 2 days
+ *   WallWood: 4 days
+ *   WallStone: 8 days
+ *   TallStone: 12 days
+ *   WallIron: 20 days
+ *
+ * Lighthouse adds protection days (additive).
+ * Walls decay from outermost to innermost.
+ * Completed islands (all portals destroyed) do NOT decay.
+ * Banker coins persist through decay. Gems never decay.
+ */
+
+import {
+  type GameState,
+  StructureType,
+} from '../types';
+import {
+  isWallStructure,
+  isTowerStructure,
+  isGateStructure,
+  isDefensiveStructure,
+} from '../structures/wall';
+import { isPortalCleared, PORTAL_POSITIONS_WORLD } from '../structures/portal';
+
+/** Decay rates in days per wall tier */
+const DECAY_RATES: Partial<Record<number, number>> = {
+  [StructureType.Spikes]: 2,
+  [StructureType.WallWood]: 4,
+  [StructureType.WallStone]: 8,
+  [StructureType.TallStone]: 12,
+  [StructureType.WallIron]: 20,
+};
+
+/** Tower decay rate (iron-tier equivalent) */
+const TOWER_DECAY_RATE = 20;
+
+/** Gate decay rate (wood-tier equivalent) */
+const GATE_DECAY_RATE = 4;
+
+/** Per-island last visit day tracking */
+const islandLastVisit: Map<number, number> = new Map();
+
+/** Get the decay rate in days for a wall type */
+export function getDecayRate(type: StructureType): number {
+  if (isTowerStructure(type)) return TOWER_DECAY_RATE;
+  if (isGateStructure(type)) return GATE_DECAY_RATE;
+  return DECAY_RATES[type] ?? 4;
+}
+
+/** Record when the monarch leaves an island */
+export function recordIslandDeparture(islandIndex: number, dayCount: number): void {
+  islandLastVisit.set(islandIndex, dayCount);
+}
+
+/** Get the last visit day for an island, or 0 if never visited */
+export function getLastVisitDay(islandIndex: number): number {
+  return islandLastVisit.get(islandIndex) ?? 0;
+}
+
+/**
+ * Check if an island is completed (all portals destroyed).
+ * Completed islands do NOT decay.
+ */
+function isIslandCompleted(_islandIndex: number): boolean {
+  // Check if all portal positions are cleared
+  for (const px of PORTAL_POSITIONS_WORLD) {
+    if (!isPortalCleared(px)) return false;
+  }
+  return true;
+}
+
+/**
+ * Apply accumulated decay to an island's structures when the monarch returns.
+ * Walls that exceed their decay threshold are removed.
+ * Outermost walls decay first.
+ *
+ * @param state - Current game state (structures will be modified)
+ * @param daysAway - Number of days the monarch was away
+ * @param lighthouseProtection - Additional protection days from lighthouse
+ */
+export function applyDecay(
+  state: GameState,
+  daysAway: number,
+  lighthouseProtection: number,
+): void {
+  // Completed islands don't decay
+  if (isIslandCompleted(state.islandIndex)) return;
+
+  const effectiveDaysAway = Math.max(0, daysAway - lighthouseProtection);
+  if (effectiveDaysAway <= 0) return;
+
+  // Collect all defensive structures and sort by distance from center (outermost first)
+  const centerX = 600;
+  const defensiveStructures: { x: number; type: StructureType }[] = [];
+
+  for (const [x, structure] of state.structures) {
+    if (!isDefensiveStructure(structure.type)) continue;
+    defensiveStructures.push({ x, type: structure.type });
+  }
+
+  // Sort outermost first (furthest from center)
+  defensiveStructures.sort((a, b) =>
+    Math.abs(b.x - centerX) - Math.abs(a.x - centerX)
+  );
+
+  // Remove walls that exceed their decay threshold
+  const toRemove: number[] = [];
+  for (const { x, type } of defensiveStructures) {
+    const decayDays = getDecayRate(type);
+    if (effectiveDaysAway >= decayDays) {
+      toRemove.push(x);
+    }
+  }
+
+  for (const x of toRemove) {
+    state.structures.delete(x);
+  }
+
+  if (toRemove.length > 0) {
+    state.messages.push(`${toRemove.length} structures decayed while you were away.`);
+  }
+}
+
+/**
+ * Apply decay when returning to an island.
+ * Call this when the monarch arrives at a previously visited island.
+ */
+export function applyDecayOnReturn(
+  state: GameState,
+  lighthouseProtection: number,
+): void {
+  const lastVisit = getLastVisitDay(state.islandIndex);
+  if (lastVisit <= 0) return;
+
+  const daysAway = state.dayCount - lastVisit;
+  if (daysAway <= 0) return;
+
+  applyDecay(state, daysAway, lighthouseProtection);
+}

--- a/kingdom/systems/gems.ts
+++ b/kingdom/systems/gems.ts
@@ -1,0 +1,43 @@
+/**
+ * Gem currency system: secondary currency that persists across islands.
+ * Gems are earned from portal destruction and gem chests.
+ * Used for unlocking mounts, statues, and hermits.
+ */
+
+import type { GameState } from '../types';
+
+const DEFAULT_GEM_CAPACITY = 10;
+
+/** Add gems to the player's gem count, capped at capacity */
+export function addGems(state: GameState, amount: number): void {
+  const capacity = state.gemCapacity ?? DEFAULT_GEM_CAPACITY;
+  state.gems = Math.min(state.gems + amount, capacity);
+}
+
+/** Spend gems. Returns true if the player had enough gems. */
+export function spendGems(state: GameState, amount: number): boolean {
+  if (state.gems < amount) return false;
+  state.gems -= amount;
+  return true;
+}
+
+/** Get current gem count */
+export function getGems(state: GameState): number {
+  return state.gems;
+}
+
+/** Check if player can afford a gem cost */
+export function canAffordGems(state: GameState, cost: number): boolean {
+  return state.gems >= cost;
+}
+
+/**
+ * Drop gems when a portal is destroyed.
+ * Small portals drop 1-2 gems.
+ * Returns the number of gems dropped.
+ */
+export function dropGemsOnPortalDestruction(state: GameState, _portalX: number): number {
+  const amount = 1 + Math.floor(Math.random() * 2); // 1-2
+  addGems(state, amount);
+  return amount;
+}

--- a/kingdom/systems/movement.ts
+++ b/kingdom/systems/movement.ts
@@ -1,0 +1,104 @@
+/**
+ * Movement system - applies velocity to positions, handles bounds,
+ * projectiles, collision avoidance, and animal movement.
+ */
+import { getPosition, setPosition, getVelocity, removeEntity } from 'blecsd';
+import type { Entity } from 'blecsd';
+import {
+  type GameState,
+  MAP_WIDTH,
+  clamp,
+} from '../types';
+import { getAnimals } from '../entities/animals';
+
+const MIN_UNIT_SPACING = 1.0;
+
+export function updateMovement(state: GameState, dt: number): void {
+  // Update unit positions from velocity
+  for (const unit of state.units) {
+    const pos = getPosition(state.world, unit.eid);
+    const vel = getVelocity(state.world, unit.eid);
+    if (!pos || !vel) continue;
+
+    if (vel.x === 0 && vel.y === 0) continue;
+
+    const newX = clamp(pos.x + vel.x * dt, 0, MAP_WIDTH - 1);
+    setPosition(state.world, unit.eid, newX, pos.y);
+  }
+
+  // Update monarch position from velocity
+  {
+    const pos = getPosition(state.world, state.monarch.eid);
+    const vel = getVelocity(state.world, state.monarch.eid);
+    if (pos && vel && (vel.x !== 0 || vel.y !== 0)) {
+      const newX = clamp(pos.x + vel.x * dt, 0, MAP_WIDTH - 1);
+      setPosition(state.world, state.monarch.eid, newX, pos.y);
+    }
+  }
+
+  // Greeds handle their own movement via Position.x in greed.ts.
+  // Do NOT apply velocity to greeds here.
+
+  // Update projectiles and remove those off-screen
+  for (let i = state.projectiles.length - 1; i >= 0; i--) {
+    const proj = state.projectiles[i];
+    proj.x += proj.vx * dt;
+
+    if (proj.x < 0 || proj.x >= MAP_WIDTH) {
+      removeEntity(state.world, proj.eid);
+      state.projectiles.splice(i, 1);
+    }
+  }
+
+  // Animal positions are updated by animals.ts updateAnimals(),
+  // but we include their ECS entities in collision avoidance below.
+
+  // Collision avoidance: spread overlapping units apart
+  resolveUnitOverlaps(state);
+}
+
+/**
+ * Push overlapping units apart so they maintain MIN_UNIT_SPACING.
+ * Uses a simple sort-and-sweep on the x-axis.
+ */
+function resolveUnitOverlaps(state: GameState): void {
+  const entities: { eid: Entity; x: number }[] = [];
+
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (monarchPos) {
+    entities.push({ eid: state.monarch.eid, x: monarchPos.x });
+  }
+
+  for (const unit of state.units) {
+    const pos = getPosition(state.world, unit.eid);
+    if (!pos) continue;
+    entities.push({ eid: unit.eid, x: pos.x });
+  }
+
+  if (entities.length < 2) return;
+
+  entities.sort((a, b) => a.x - b.x);
+
+  for (let i = 1; i < entities.length; i++) {
+    const prev = entities[i - 1];
+    const curr = entities[i];
+    const gap = curr.x - prev.x;
+
+    if (gap < MIN_UNIT_SPACING) {
+      const overlap = MIN_UNIT_SPACING - gap;
+      const halfPush = overlap / 2;
+
+      const prevNewX = clamp(prev.x - halfPush, 0, MAP_WIDTH - 1);
+      const currNewX = clamp(curr.x + halfPush, 0, MAP_WIDTH - 1);
+
+      prev.x = prevNewX;
+      curr.x = currNewX;
+
+      const prevPos = getPosition(state.world, prev.eid);
+      if (prevPos) setPosition(state.world, prev.eid, prevNewX, prevPos.y);
+
+      const currPos = getPosition(state.world, curr.eid);
+      if (currPos) setPosition(state.world, curr.eid, currNewX, currPos.y);
+    }
+  }
+}

--- a/kingdom/systems/spawn.ts
+++ b/kingdom/systems/spawn.ts
@@ -1,0 +1,438 @@
+/**
+ * Spawn system: spawns greed waves from portals during night,
+ * and roaming bands during the day.
+ *
+ * Final wave difficulty formula (Phase 9):
+ *   baseWaveSize = floor(dayCount / 3) + 3
+ *   islandMultiplier = [1.0, 1.25, 1.5, 1.75, 2.0, 3.0, 5.0, 2.5]
+ *   seasonMultiplier = { Spring: 1.0, Summer: 0.85, Autumn: 1.15, Winter: 1.35 }
+ *   bloodMoonMultiplier = isBloodMoon ? 3.0 : 1.0
+ *   finalWaveSize = floor(base * island * season * bloodMoon)
+ *
+ * Wave composition (normalized ratios):
+ *   greedlingRatio = max(0.3, 1.0 - dayCount * 0.01)
+ *   maskedRatio = min(0.3, dayCount * 0.005)
+ *   floaterRatio = dayCount > 15 ? min(0.15, (dayCount - 15) * 0.003) : 0
+ *   breederRatio = dayCount > 20 ? min(0.1, (dayCount - 20) * 0.002) : 0
+ *   crownStealerRatio = dayCount > 30 ? min(0.05, (dayCount - 30) * 0.001) : 0
+ *
+ * Multi-portal spawning: split proportionally, weighted by inverse distance.
+ * Spawn timing: staggered so furthest portal spawns first.
+ *
+ * Challenge island support: Skull Island edge-spawning, Plague Crawlers on island 8.
+ */
+
+import {
+  type GameState,
+  GreedType,
+  Season,
+  TimeOfDay,
+  GamePhase,
+  CAMP_CENTER_X,
+  MAP_WIDTH,
+} from '../types';
+import {
+  getActivePortals,
+  isRetaliationPending,
+  clearRetaliation,
+  getPortalDifficulty,
+  incrementPortalDifficulty,
+  getPortalSpawnMultiplier,
+  isChallengeIsland,
+  getChallengeRules,
+} from '../structures/portal';
+import { spawnGreed, triggerSunriseFlee } from '../entities/greed';
+
+const BLOOD_MOON_INTERVAL = 7;
+const BLOOD_MOON_MULTIPLIER = 3;
+const RETALIATION_MULTIPLIER = 3;
+const SPAWN_DELAY = 2.0;
+
+/** Roaming band constants */
+const ROAM_SPAWN_INTERVAL = 30; // seconds between roaming band spawns
+const ROAM_GROUP_MIN = 2;
+const ROAM_GROUP_MAX = 3;
+const ROAM_HP_SCALE = 0.5; // roaming greeds are weaker
+
+/** Seasonal constants */
+const SEASON_DAYS = 16;
+const SEASON_CYCLE = 64;
+
+/** Island wave multipliers (8 islands: 0-5 main + 6-8 challenge) */
+const ISLAND_MULTIPLIERS = [1.0, 1.25, 1.5, 1.75, 2.0, 3.0, 5.0, 2.5];
+
+/** Season wave size multipliers (Phase 9 final values) */
+const SEASON_WAVE_MULTIPLIERS: Record<number, number> = {
+  [Season.Spring]: 1.0,
+  [Season.Summer]: 0.85,
+  [Season.Autumn]: 1.15,
+  [Season.Winter]: 1.35,
+};
+
+/** Per-portal spawn queue: list of greed types still to spawn */
+const spawnQueues: Map<number, GreedType[]> = new Map();
+
+/** Per-portal countdown until next spawn */
+const spawnTimers: Map<number, number> = new Map();
+
+/** Tracks whether wave queues have been initialized for the current night */
+let nightInitialized = false;
+
+/** Whether portal difficulty was incremented this night */
+let difficultyIncrementedThisNight = false;
+
+/** Wave preview tracking */
+let wavePreviewShown = false;
+let lastDayCount = -1;
+
+/** Roaming band timer */
+let roamTimer = ROAM_SPAWN_INTERVAL;
+
+/** Track if sunrise flee has been triggered this day */
+let sunriseFleeDone = false;
+
+/** Compute the season from dayCount (fallback if state.season not set) */
+function computeSeason(dayCount: number): Season {
+  const dayInCycle = dayCount % SEASON_CYCLE;
+  const seasonIndex = Math.floor(dayInCycle / SEASON_DAYS);
+  switch (seasonIndex) {
+    case 0: return Season.Spring;
+    case 1: return Season.Summer;
+    case 2: return Season.Autumn;
+    case 3: return Season.Winter;
+    default: return Season.Spring;
+  }
+}
+
+/** Check if a given day is a seasonal blood moon (2 days before season change) */
+function isSeasonalBloodMoon(dayCount: number): boolean {
+  if (dayCount <= 0) return false;
+  const dayInCycle = dayCount % SEASON_CYCLE;
+  const dayInSeason = dayInCycle % SEASON_DAYS;
+  return dayInSeason === SEASON_DAYS - 2;
+}
+
+/** Get the seasonal wave size multiplier */
+function getSeasonMultiplier(state: GameState): number {
+  const season = state.season ?? computeSeason(state.dayCount);
+  return SEASON_WAVE_MULTIPLIERS[season] ?? 1.0;
+}
+
+/** Get the island wave size multiplier */
+function getIslandMultiplier(islandIndex: number): number {
+  if (islandIndex < 0) return 1.0;
+  if (islandIndex >= ISLAND_MULTIPLIERS.length) return ISLAND_MULTIPLIERS[ISLAND_MULTIPLIERS.length - 1];
+  return ISLAND_MULTIPLIERS[islandIndex];
+}
+
+/** Check if a given day is a blood moon (seasonal timing + every-7-days fallback) */
+export function isBloodMoon(dayCount: number): boolean {
+  if (dayCount <= 0) return false;
+  if (isSeasonalBloodMoon(dayCount)) return true;
+  return dayCount % BLOOD_MOON_INTERVAL === 0;
+}
+
+/**
+ * Calculate wave size for a specific portal using the proper formula:
+ * base = floor(dayCount / 3) + 2
+ * Apply portal difficulty, island multiplier, season multiplier, blood moon, cave multiplier.
+ */
+function getPortalWaveSize(state: GameState, portalX: number): number {
+  const base = Math.floor(state.dayCount / 3) + 3;
+  const portalDiff = getPortalDifficulty(portalX);
+  const islandMult = getIslandMultiplier(state.islandIndex);
+  const seasonMult = getSeasonMultiplier(state);
+  const bloodMoonMult = state.isBloodMoon ? BLOOD_MOON_MULTIPLIER : 1;
+  const caveMult = getPortalSpawnMultiplier(portalX, state.isBloodMoon);
+
+  return Math.floor(base * portalDiff * islandMult * seasonMult * bloodMoonMult * caveMult);
+}
+
+interface WaveComposition {
+  basicPct: number;
+  maskedPct: number;
+  floaterPct: number;
+  breederPct: number;
+  crownStealerPct: number;
+}
+
+/**
+ * Determine wave type ratios based on day count (Phase 9 final formula).
+ * Ratios are normalized to sum to 1.0.
+ * Challenge islands can override (allTypesFromNight1 = all types at once).
+ */
+function getWaveComposition(dayCount: number, _bloodMoon: boolean, islandIndex?: number): WaveComposition {
+  const challenge = islandIndex !== undefined ? getChallengeRules(islandIndex) : null;
+  const effectiveDay = challenge?.allTypesFromNight1 ? Math.max(dayCount, 40) : dayCount;
+
+  // Calculate raw ratios per Phase 9 formula
+  const greedling = Math.max(0.3, 1.0 - effectiveDay * 0.01);
+  const masked = Math.min(0.3, effectiveDay * 0.005);
+  const floater = effectiveDay > 15 ? Math.min(0.15, (effectiveDay - 15) * 0.003) : 0;
+  const breeder = effectiveDay > 20 ? Math.min(0.1, (effectiveDay - 20) * 0.002) : 0;
+  const crownStealer = effectiveDay > 30 ? Math.min(0.05, (effectiveDay - 30) * 0.001) : 0;
+
+  // Normalize to sum to 1.0
+  const total = greedling + masked + floater + breeder + crownStealer;
+  const scale = total > 0 ? 1.0 / total : 1.0;
+
+  return {
+    basicPct: greedling * scale,
+    maskedPct: masked * scale,
+    floaterPct: floater * scale,
+    breederPct: breeder * scale,
+    crownStealerPct: crownStealer * scale,
+  };
+}
+
+/** Build a spawn queue using day-based composition. */
+function buildSpawnQueue(waveSize: number, dayCount: number, islandIndex?: number): GreedType[] {
+  const bloodMoon = isBloodMoon(dayCount);
+  const comp = getWaveComposition(dayCount, bloodMoon, islandIndex);
+  const challenge = islandIndex !== undefined ? getChallengeRules(islandIndex) : null;
+  const plagueCrawlerChance = challenge?.hasPlagueCrawlers ? 0.15 : 0;
+
+  const queue: GreedType[] = [];
+  for (let i = 0; i < waveSize; i++) {
+    const roll = Math.random();
+
+    // Plague crawler substitution on challenge island 8
+    if (plagueCrawlerChance > 0 && roll < plagueCrawlerChance) {
+      queue.push(GreedType.PlagueCrawler);
+      continue;
+    }
+
+    // Adjusted roll excluding plague crawler chance
+    const adjRoll = plagueCrawlerChance > 0
+      ? (roll - plagueCrawlerChance) / (1 - plagueCrawlerChance)
+      : roll;
+    let cumulative = 0;
+
+    cumulative += comp.crownStealerPct;
+    if (adjRoll < cumulative) { queue.push(GreedType.CrownStealer); continue; }
+
+    cumulative += comp.breederPct;
+    if (adjRoll < cumulative) { queue.push(GreedType.Breeder); continue; }
+
+    cumulative += comp.floaterPct;
+    if (adjRoll < cumulative) { queue.push(GreedType.Floater); continue; }
+
+    cumulative += comp.maskedPct;
+    if (adjRoll < cumulative) { queue.push(GreedType.Masked); continue; }
+
+    queue.push(GreedType.Basic);
+  }
+
+  // Shuffle
+  for (let i = queue.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = queue[i];
+    queue[i] = queue[j];
+    queue[j] = tmp;
+  }
+
+  return queue;
+}
+
+/** Show wave preview message during dusk */
+function showWavePreview(state: GameState): void {
+  if (wavePreviewShown) return;
+
+  const activePortals = getActivePortals(state);
+  if (activePortals.length === 0) return;
+
+  let totalGreeds = 0;
+  for (const px of activePortals) {
+    totalGreeds += getPortalWaveSize(state, px);
+  }
+
+  const bloodMoon = isBloodMoon(state.dayCount);
+  const bloodMoonSuffix = bloodMoon ? ' (BLOOD MOON!)' : '';
+
+  const season = state.season ?? computeSeason(state.dayCount);
+  const seasonNames: Record<number, string> = {
+    [Season.Spring]: 'Spring',
+    [Season.Summer]: 'Summer',
+    [Season.Autumn]: 'Autumn',
+    [Season.Winter]: 'Winter',
+  };
+  const seasonName = seasonNames[season] ?? '';
+
+  state.messages.push(
+    `Wave ${state.dayCount} [${seasonName}] approaching: ~${totalGreeds} greeds from ${activePortals.length} portals${bloodMoonSuffix}`
+  );
+  wavePreviewShown = true;
+}
+
+/**
+ * Calculate spawn delay offset so distant portals spawn earlier.
+ * Greeds from further portals need more travel time to reach the kingdom by midnight.
+ */
+function getPortalSpawnOffset(portalX: number): number {
+  const distToCenter = Math.abs(portalX - CAMP_CENTER_X);
+  // ~3 tiles/sec base speed, so 200 tiles = ~67 seconds offset
+  return distToCenter / 3;
+}
+
+/** Initialize spawn queues for all active portals at night start (independent per portal) */
+function initializeNightWaves(state: GameState): void {
+  const activePortals = getActivePortals(state);
+  const challenge = getChallengeRules(state.islandIndex);
+
+  // Increment per-portal difficulty once per night
+  if (!difficultyIncrementedThisNight) {
+    incrementPortalDifficulty(state);
+    difficultyIncrementedThisNight = true;
+  }
+
+  // Skull Island (island 6): endless mode, spawn from map edges instead of portals
+  if (challenge?.endless && activePortals.length === 0) {
+    const edgePositions = [5, MAP_WIDTH - 5];
+    const edgeWaveSize = Math.floor((state.dayCount / 3 + 3) * (challenge.difficultyMultiplier));
+
+    for (const edgeX of edgePositions) {
+      const queue = buildSpawnQueue(edgeWaveSize, state.dayCount, state.islandIndex);
+      spawnQueues.set(edgeX, queue);
+      spawnTimers.set(edgeX, SPAWN_DELAY);
+    }
+
+    nightInitialized = true;
+    return;
+  }
+
+  // Calculate total inverse distance for proportional splitting
+  let totalInvDist = 0;
+  for (const px of activePortals) {
+    totalInvDist += 1 / Math.max(1, Math.abs(px - CAMP_CENTER_X));
+  }
+
+  for (const portalX of activePortals) {
+    // Proportional wave split: closer portals get slightly more
+    const invDist = 1 / Math.max(1, Math.abs(portalX - CAMP_CENTER_X));
+    const proportion = totalInvDist > 0 ? invDist / totalInvDist : 1 / activePortals.length;
+
+    const totalWave = getPortalWaveSize(state, portalX);
+    const waveSize = Math.max(1, Math.floor(totalWave * proportion * activePortals.length));
+    const queue = buildSpawnQueue(waveSize, state.dayCount, state.islandIndex);
+    spawnQueues.set(portalX, queue);
+
+    // Further portals start spawning sooner (staggered arrival)
+    const offset = getPortalSpawnOffset(portalX);
+    const adjustedDelay = Math.max(0, SPAWN_DELAY - offset * 0.01);
+    spawnTimers.set(portalX, adjustedDelay + Math.random() * SPAWN_DELAY * 0.5);
+  }
+
+  nightInitialized = true;
+}
+
+/** Add a retaliation wave to all remaining active portals */
+function triggerRetaliationWave(state: GameState): void {
+  const activePortals = getActivePortals(state);
+
+  for (const portalX of activePortals) {
+    const retaliationSize = Math.floor(getPortalWaveSize(state, portalX) * RETALIATION_MULTIPLIER);
+    const existing = spawnQueues.get(portalX) ?? [];
+    const extraQueue = buildSpawnQueue(retaliationSize, state.dayCount);
+    spawnQueues.set(portalX, [...existing, ...extraQueue]);
+  }
+
+  state.messages.push('Retaliation wave incoming from all portals!');
+  clearRetaliation();
+}
+
+/** Spawn roaming bands during the day: 2-3 weak basic greeds near active portals */
+function updateRoamingBands(state: GameState, dt: number): void {
+  if (state.timeOfDay !== TimeOfDay.Day) return;
+
+  roamTimer -= dt;
+  if (roamTimer > 0) return;
+  roamTimer = ROAM_SPAWN_INTERVAL;
+
+  const activePortals = getActivePortals(state);
+  if (activePortals.length === 0) return;
+
+  // Pick a random portal to spawn roamers from
+  const portalX = activePortals[Math.floor(Math.random() * activePortals.length)];
+  const groupSize = ROAM_GROUP_MIN + Math.floor(Math.random() * (ROAM_GROUP_MAX - ROAM_GROUP_MIN + 1));
+
+  for (let i = 0; i < groupSize; i++) {
+    const offset = (Math.random() - 0.5) * 6;
+    const greed = spawnGreed(state, portalX + offset, GreedType.Basic);
+    // Roaming greeds are weaker
+    greed.hp *= ROAM_HP_SCALE;
+  }
+}
+
+/** Process greed spawning for one frame */
+export function updateSpawning(state: GameState, dt: number): void {
+  if (state.phase !== GamePhase.Playing) return;
+
+  // Reset preview flag on new day
+  if (state.dayCount !== lastDayCount) {
+    wavePreviewShown = false;
+    difficultyIncrementedThisNight = false;
+    sunriseFleeDone = false;
+    lastDayCount = state.dayCount;
+  }
+
+  // Trigger sunrise flee when transitioning to day
+  if (state.timeOfDay === TimeOfDay.Day && !sunriseFleeDone) {
+    triggerSunriseFlee(state);
+    sunriseFleeDone = true;
+  }
+
+  // Check for retaliation regardless of time of day
+  if (isRetaliationPending()) {
+    triggerRetaliationWave(state);
+  }
+
+  // Roaming bands during the day
+  updateRoamingBands(state, dt);
+
+  // Show wave preview at dusk
+  if (state.timeOfDay === TimeOfDay.Dusk) {
+    showWavePreview(state);
+  }
+
+  if (state.timeOfDay !== TimeOfDay.Night) {
+    if (nightInitialized) {
+      // Track survived nights for challenge islands
+      if (isChallengeIsland(state.islandIndex)) {
+        state.challengeNightsSurvived += 1;
+      }
+      spawnQueues.clear();
+      spawnTimers.clear();
+      nightInitialized = false;
+    }
+    return;
+  }
+
+  // Hourglass freeze: skip spawning while active
+  if (state.hourglassFreezeTimer > 0) {
+    state.hourglassFreezeTimer -= dt;
+    return;
+  }
+
+  if (!nightInitialized) {
+    initializeNightWaves(state);
+  }
+
+  // Get all spawn sources (portals + edge positions for Skull Island)
+  const spawnSources = [...spawnQueues.keys()];
+
+  for (const sourceX of spawnSources) {
+    const queue = spawnQueues.get(sourceX);
+    if (!queue || queue.length === 0) continue;
+
+    const timer = (spawnTimers.get(sourceX) ?? 0) - dt;
+    if (timer > 0) {
+      spawnTimers.set(sourceX, timer);
+      continue;
+    }
+
+    const type = queue.shift()!;
+    spawnGreed(state, sourceX, type);
+
+    spawnTimers.set(sourceX, SPAWN_DELAY);
+  }
+}

--- a/kingdom/tsconfig.json
+++ b/kingdom/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/kingdom/types.ts
+++ b/kingdom/types.ts
@@ -1,0 +1,533 @@
+/**
+ * Kingdom - Shared types and constants
+ * All agents reference this file. DO NOT modify without coordinating.
+ */
+
+import type { World, Entity } from 'blecsd';
+
+// ─── World Constants ───────────────────────────────────────────────
+export const MAP_WIDTH = 1200;       // Total world width in tiles
+export const MAP_HEIGHT = 30;        // Total world height in tiles
+export const GROUND_Y = 22;          // Ground level (0-indexed from top)
+export const SKY_HEIGHT = 22;        // Everything above ground
+export const WATER_Y = 24;           // Water level below ground
+export const CAMP_CENTER_X = 600;    // Center of starting camp
+
+// ─── Timing ────────────────────────────────────────────────────────
+export const TARGET_FPS = 30;
+export const FRAME_TIME = 1000 / TARGET_FPS;
+export const DAY_LENGTH = 180;       // seconds per full day
+export const DAWN_START = 0.0;       // 0% of day
+export const DAY_START = 0.15;       // 15% of day
+export const DUSK_START = 0.65;      // 65% of day
+export const NIGHT_START = 0.8;      // 80% of day
+
+// ─── Economy ───────────────────────────────────────────────────────
+export const STARTING_COINS = 8;
+export const MAX_COINS = 99;
+export const COIN_DROP_COOLDOWN = 300; // ms between drops
+export const FARM_INCOME_INTERVAL = 5; // seconds
+export const HUNT_REWARD = 1;
+export const FARM_REWARD_BASE = 2;
+export const RECRUIT_COST = 1;
+export const BOW_COST = 2;
+export const HAMMER_COST = 2;
+export const WALL_COST_WOOD = 3;
+export const WALL_COST_STONE = 6;
+export const WALL_COST_IRON = 10;
+export const FARM_BUILD_COST = 5;
+export const SHRINE_COST = 4;
+export const SHIP_REPAIR_COST = 15;
+
+// ─── Movement ──────────────────────────────────────────────────────
+export const MONARCH_SPEED = 12;     // tiles per second
+export const MONARCH_SPRINT = 20;
+export const VILLAGER_SPEED = 5;
+export const BUILDER_SPEED = 4;
+export const ARCHER_SPEED = 6;
+export const GREED_SPEED_BASE = 3;
+export const GREED_SPEED_FAST = 6;
+
+// ─── Combat ────────────────────────────────────────────────────────
+export const ARROW_DAMAGE = 1;
+export const ARROW_RANGE = 15;       // tiles
+export const ARROW_COOLDOWN = 1.5;   // seconds
+export const WALL_HP_WOOD = 5;
+export const WALL_HP_STONE = 12;
+export const WALL_HP_IRON = 25;
+export const PORTAL_HP = 20;
+
+// ─── Colors (0xRRGGBBAA) ──────────────────────────────────────────
+export const COLOR_SKY_DAY = 0x4488ccff;
+export const COLOR_SKY_DUSK = 0xcc6633ff;
+export const COLOR_SKY_NIGHT = 0x111133ff;
+export const COLOR_SKY_DAWN = 0x885566ff;
+export const COLOR_GROUND = 0x228833ff;
+export const COLOR_DIRT = 0x664422ff;
+export const COLOR_WATER = 0x2244aaff;
+export const COLOR_TREE_TRUNK = 0x553311ff;
+export const COLOR_TREE_LEAVES = 0x117722ff;
+export const COLOR_WALL_WOOD = 0x886633ff;
+export const COLOR_WALL_STONE = 0x888888ff;
+export const COLOR_WALL_IRON = 0xaaaabbff;
+export const COLOR_MONARCH = 0xffdd00ff;
+export const COLOR_VILLAGER = 0xccccccff;
+export const COLOR_BUILDER = 0x8888ffff;
+export const COLOR_ARCHER = 0x44ff44ff;
+export const COLOR_FARMER = 0xddaa44ff;
+export const COLOR_GREED = 0xff2266ff;
+export const COLOR_GREED_MASK = 0xcc1155ff;
+export const COLOR_PORTAL = 0x9922ffff;
+export const COLOR_COIN = 0xffcc00ff;
+export const COLOR_HUD_BG = 0x222222ff;
+export const COLOR_HUD_TEXT = 0xfffffffe;
+export const COLOR_FARM = 0xaacc44ff;
+export const COLOR_SHRINE = 0x44ccffff;
+export const COLOR_BG = 0x000000ff;
+
+// ─── ASCII Characters ──────────────────────────────────────────────
+export const CHAR_MONARCH = '\u265A';     // chess king
+export const CHAR_VILLAGER = '\u263A';    // smiley
+export const CHAR_BUILDER = '\u2692';     // hammer and pick
+export const CHAR_ARCHER = '\u2694';      // crossed swords (bow stand-in)
+export const CHAR_FARMER = '\u2698';      // flower
+export const CHAR_GREED = '\u2620';       // skull
+export const CHAR_GREED_MASK = '\u2623';  // biohazard
+export const CHAR_PORTAL = '\u25C6';      // diamond
+export const CHAR_WALL = '\u2588';        // full block
+export const CHAR_WALL_DAMAGED = '\u2593'; // dark shade
+export const CHAR_TREE = '\u2660';        // spade (tree top)
+export const CHAR_TREE_TRUNK = '\u2502';  // vertical line
+export const CHAR_GRASS = '\u2591';       // light shade
+export const CHAR_WATER = '\u2248';       // almost equal (waves)
+export const CHAR_COIN = '\u25CF';        // filled circle
+export const CHAR_FARM = '\u2261';        // identical to
+export const CHAR_SHRINE = '\u2726';      // 4-pointed star
+export const CHAR_ARROW = '\u2192';       // right arrow
+export const CHAR_CROWN = '\u2655';       // chess queen (crown)
+export const CHAR_HORSE = '\u265E';       // chess knight
+export const CHAR_SHIP = '\u2708';        // airplane stand-in for ship
+
+// ─── Enums ─────────────────────────────────────────────────────────
+export enum TimeOfDay {
+  Dawn = 'dawn',
+  Day = 'day',
+  Dusk = 'dusk',
+  Night = 'night',
+}
+
+export enum TileType {
+  Sky = 0,
+  Grass = 1,
+  Dirt = 2,
+  Water = 3,
+  Forest = 4,
+  ClearedLand = 5,
+  Swamp = 6,
+  Mountain = 7,
+  Ruins = 8,
+}
+
+export enum StructureType {
+  None = 0,
+  WallWood = 1,
+  WallStone = 2,
+  WallIron = 3,
+  Farm = 4,
+  FarmIrrigated = 5,
+  FarmWindmill = 6,
+  BowStand = 7,
+  HammerStand = 8,
+  Shrine = 9,
+  Portal = 10,
+  Ship = 11,
+  Campfire = 12,
+  // Extended types 13-15 defined as numeric casts in wall.ts/siege.ts
+  Spikes = 16,
+  TallStone = 17,
+  HermitCottage = 18,
+  Statue = 19,
+}
+
+export enum UnitRole {
+  Monarch = 'monarch',
+  Vagrant = 'vagrant',
+  Builder = 'builder',
+  Archer = 'archer',
+  Farmer = 'farmer',
+  Knight = 'knight',
+  Pikeman = 'pikeman',
+  Squire = 'squire',
+}
+
+export enum GreedType {
+  Basic = 'basic',
+  Masked = 'masked',
+  Floater = 'floater',
+  Breeder = 'breeder',
+  CrownStealer = 'crownStealer',
+  PlagueCrawler = 'plagueCrawler',
+}
+
+export enum AIState {
+  Idle = 'idle',
+  MovingTo = 'movingTo',
+  Working = 'working',
+  Retreating = 'retreating',
+  Defending = 'defending',
+  Hunting = 'hunting',
+  Attacking = 'attacking',
+  Fleeing = 'fleeing',
+}
+
+export enum GamePhase {
+  Title = 'title',
+  IslandSelect = 'islandSelect',
+  Playing = 'playing',
+  GameOver = 'gameOver',
+  Victory = 'victory',
+}
+
+export enum MountType {
+  None = 'none',
+  Horse = 'horse',
+  Stag = 'stag',
+  Griffin = 'griffin',
+  Warhorse = 'warhorse',
+  Bear = 'bear',
+  Lizard = 'lizard',
+  Unicorn = 'unicorn',
+}
+
+export enum ConsumableType {
+  FoodCache = 'foodCache',
+  RestShrine = 'restShrine',
+  PowerWell = 'powerWell',
+}
+
+export enum Season {
+  Spring = 0,
+  Summer = 1,
+  Autumn = 2,
+  Winter = 3,
+}
+
+export enum TownCenterTier {
+  Ruins = 0,
+  Campfire = 1,
+  Camp = 2,
+  Village = 3,
+  TownHall = 4,
+  StoneFort = 5,
+  Castle = 6,
+  IronKeep = 7,
+}
+
+// ─── Island Constants ────────────────────────────────────────────
+export const ISLAND_NAMES = ['Tutorial Isle', 'Stone Coast', 'Forge Bay', 'Iron Reach', "Crown's End"];
+export const ISLAND_MAP_WIDTHS = [600, 800, 1000, 1000, 1200];
+
+export interface IslandStats {
+  portalsDestroyed: number;
+  daysVisited: number;
+  structuresBuilt: number;
+}
+
+export interface IslandSaveState {
+  dayCount: number;
+  dayTime: number;
+  monarchCoins: number;
+  mountType: MountType;
+  stamina: number;
+  portalPositions: number[];
+  structures: { type: StructureType; x: number; hp: number; maxHp: number; level: number }[];
+  townCenterTier: TownCenterTier;
+  boatState: 'wreck' | 'restoring' | 'ready' | 'launched' | 'docked' | 'departed';
+  hullPieces: number;
+  hasDog: boolean;
+}
+
+export interface MultiIslandSave {
+  version: 2;
+  currentIsland: number;
+  globalDayCount: number;
+  gems: number;
+  bankedCoins: number;
+  islandUnlocked: boolean[];
+  islandStats: IslandStats[];
+  islands: (IslandSaveState | null)[];
+}
+
+export interface MapData {
+  tiles: TileType[][];
+  portalPositions: number[];
+  structurePositions: { type: StructureType; x: number; hp: number }[];
+  vagrantCampPositions: number[];
+  mapWidth: number;
+}
+
+export const TOWN_CENTER_COSTS = [0, 1, 4, 8, 12, 15, 18, 20];
+export const TOWN_CENTER_NAMES = ['Ruins', 'Campfire', 'Camp', 'Village', 'Town Hall', 'Stone Fort', 'Castle', 'Iron Keep'];
+
+export enum TowerTier {
+  None = 0,
+  RockPlatform = 1,
+  WoodWatchtower = 2,
+  StoneTower = 3,
+  TripletTower = 4,
+  RoofedTriplet = 5,
+  QuadrupletTower = 6,
+}
+
+export const TOWER_COSTS = [0, 3, 5, 7, 9, 12, 15];
+export const TOWER_ARCHER_CAPACITY = [0, 1, 1, 2, 3, 3, 4];
+export const TOWER_NAMES = ['None', 'Rock Platform', 'Watchtower', 'Stone Tower', 'Triplet', 'Roofed Triplet', 'Quadruplet'];
+
+export enum WeatherType {
+  Clear = 0,
+  Rain = 1,
+  Snow = 2,
+  Storm = 3,
+}
+
+// ─── Component Data Interfaces ─────────────────────────────────────
+export interface UnitData {
+  eid: Entity;
+  role: UnitRole;
+  aiState: AIState;
+  targetX: number;
+  hp: number;
+  maxHp: number;
+  attackCooldown: number;
+  coins: number;
+  poisonTimer?: number;
+  poisonDps?: number;
+}
+
+export interface StructureData {
+  eid: Entity;
+  type: StructureType;
+  x: number;
+  hp: number;
+  maxHp: number;
+  level: number;
+  assignedWorkers: Entity[];
+  towerTier?: TowerTier;
+  isRoofed?: boolean;
+  farmTier?: number;
+  convertedTowerType?: number;
+  gateLocked?: boolean;
+}
+
+export interface GreedData {
+  eid: Entity;
+  type: GreedType;
+  hp: number;
+  speed: number;
+  damage: number;
+  carryingCoins: number;
+  // Masked greedling state
+  maskBroken?: boolean;
+  // Floater state
+  floaterTarget?: Entity | null;
+  isCarrying?: boolean;
+  grabTimer?: number;
+  // Breeder state
+  breederSpawnTimer?: number;
+  breederPunchTimer?: number;
+  breederSpawnCount?: number;
+  // Crown stealer state
+  hasCrown?: boolean;
+  isClimbing?: boolean;
+  climbTimer?: number;
+  // Sunrise flee state
+  isFleeing?: boolean;
+  fleeDespawnTimer?: number;
+  // Burn damage state (fire tower)
+  burnTimer?: number;
+  burnDps?: number;
+  // Plague crawler state
+  poisonOnDeath?: boolean;
+}
+
+export enum DamageType {
+  Normal = 0,
+  Piercing = 1,
+  Burn = 2,
+  AoE = 3,
+}
+
+export enum PortalType {
+  Cliff = 'cliff',
+  Dock = 'dock',
+  Cave = 'cave',
+}
+
+export interface ProjectileData {
+  eid: Entity;
+  x: number;
+  y: number;
+  vx: number;
+  damage: number;
+  owner: Entity;
+  damageType?: DamageType;
+  burnDps?: number;
+  burnDuration?: number;
+  piercing?: boolean;
+  aoeRadius?: number;
+}
+
+// ─── Game State ────────────────────────────────────────────────────
+export interface GameState {
+  world: World;
+  phase: GamePhase;
+  running: boolean;
+
+  // Time
+  dayTime: number;          // 0.0 to 1.0 within a day cycle
+  dayCount: number;
+  timeOfDay: TimeOfDay;
+  totalElapsed: number;     // total seconds elapsed
+  season: Season;
+  seasonDay: number;        // 0-15, day within current season
+
+  // Economy
+  monarchCoins: number;
+
+  // Map
+  tiles: TileType[][];      // [y][x]
+  structures: Map<number, StructureData>; // keyed by x position
+
+  // Entities
+  monarch: UnitData;
+  units: UnitData[];
+  greeds: GreedData[];
+  projectiles: ProjectileData[];
+
+  // Portals
+  portalPositions: number[]; // x positions
+
+  // Camera
+  cameraX: number;
+  viewWidth: number;
+  viewHeight: number;
+
+  // Island
+  islandIndex: number;
+  difficultyMultiplier: number;
+
+  // Input state
+  inputLeft: boolean;
+  inputRight: boolean;
+  inputSprint: boolean;
+  inputDrop: boolean;
+  lastCoinDrop: number;
+
+  // Rendering
+  needsFullRedraw: boolean;
+
+  // Messages
+  messages: string[];
+
+  // Mount
+  mountType: MountType;
+  stamina: number;
+  maxStamina: number;
+
+  // Consumables
+  consumedSpots: Set<number>;
+  consumableSpots: Map<number, ConsumableType>;
+  speedBoostTimer: number;
+
+  // Town Center
+  townCenterTier: TownCenterTier;
+  townCenterCooldown: number;
+  gems: number;
+  gemCapacity: number;
+
+  // Blood Moon
+  isBloodMoon: boolean;
+
+  // Weather
+  weather: WeatherType;
+
+  // Crown
+  crownDropped: boolean;
+  crownX: number;
+  crownY: number;
+  crownTimer: number;
+
+  // Dog companion
+  hasDog: boolean;
+  dogCaptured: boolean;
+
+  // Portal Assault
+  portalAssaultActive: boolean;
+  assaultTargetPortal: number;
+
+  // Pause
+  isPaused: boolean;
+
+  // Boat
+  boatState: 'wreck' | 'restoring' | 'ready' | 'launched' | 'docked' | 'departed';
+  hullPieces: number;
+
+  // Bear combat
+  bearAttackCooldown: number;
+
+  // Effects / Timers
+  screenShakeTimer: number;
+  gameOverTimer: number;
+  lastSaveTime: number;
+
+  // Island system
+  islandUnlocked: boolean[];
+  islandStats: IslandStats[];
+  selectedIsland: number;
+  bankedCoins: number;
+  globalDayCount: number;
+  mapWidth: number;
+
+  // Minimap
+  showMinimap: boolean;
+
+  // Sound
+  soundEnabled: boolean;
+
+  // Heir succession
+  totalHeirs: number;
+
+  // Challenge islands
+  challengeNightsSurvived: number;
+  hourglassFreezeTimer: number;
+}
+
+// ─── Tile Map Helpers ──────────────────────────────────────────────
+export function tileKey(x: number, y: number): number {
+  return y * MAP_WIDTH + x;
+}
+
+export function worldToScreen(worldX: number, cameraX: number): number {
+  return Math.round(worldX - cameraX);
+}
+
+export function screenToWorld(screenX: number, cameraX: number): number {
+  return screenX + cameraX;
+}
+
+export function isOnScreen(worldX: number, cameraX: number, viewWidth: number): boolean {
+  const sx = worldX - cameraX;
+  return sx >= 0 && sx < viewWidth;
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function distance(x1: number, x2: number): number {
+  return Math.abs(x1 - x2);
+}

--- a/kingdom/world/camera.ts
+++ b/kingdom/world/camera.ts
@@ -1,0 +1,47 @@
+/**
+ * Kingdom - Camera system
+ * Follows the monarch with smooth lerp, look-ahead in movement direction,
+ * and clamping to map bounds. Supports variable map widths per island.
+ */
+
+import {
+  type GameState,
+  MAP_WIDTH,
+  clamp,
+  lerp,
+} from '../types';
+import { getPosition, getVelocity } from 'blecsd';
+
+const CAMERA_LERP_SPEED = 0.1;
+const LOOK_AHEAD_TILES = 5;
+
+/**
+ * Update camera to follow the monarch's x position.
+ * Adds look-ahead offset in the direction of movement for better visibility.
+ * Smooth lerp toward the target, clamped to map bounds.
+ */
+export function updateCamera(state: GameState): void {
+  const monarchPos = getPosition(state.world, state.monarch.eid);
+  if (!monarchPos) return;
+
+  const effectiveMapWidth = state.mapWidth ?? MAP_WIDTH;
+
+  // Look-ahead: offset camera in movement direction
+  let lookAhead = 0;
+  const monarchVel = getVelocity(state.world, state.monarch.eid);
+  if (monarchVel) {
+    if (monarchVel.x > 0) lookAhead = LOOK_AHEAD_TILES;
+    else if (monarchVel.x < 0) lookAhead = -LOOK_AHEAD_TILES;
+  }
+
+  // Target camera centers the monarch (with look-ahead) in the viewport
+  const targetX = monarchPos.x + lookAhead - Math.floor(state.viewWidth / 2);
+  const maxCameraX = Math.max(0, effectiveMapWidth - state.viewWidth);
+  const clampedTarget = clamp(targetX, 0, maxCameraX);
+
+  // Smooth interpolation
+  state.cameraX = lerp(state.cameraX, clampedTarget, CAMERA_LERP_SPEED);
+
+  // Clamp final result
+  state.cameraX = clamp(state.cameraX, 0, maxCameraX);
+}

--- a/kingdom/world/map.ts
+++ b/kingdom/world/map.ts
@@ -1,0 +1,182 @@
+/**
+ * Kingdom - Map generation
+ * Generates the full game map: terrain, settlements, portals, and consumable spots.
+ * Supports island-specific layouts with different sizes and portal configurations.
+ */
+
+import {
+  type GameState,
+  type StructureData,
+  type MapData,
+  StructureType,
+  TowerTier,
+  ConsumableType,
+  TileType,
+  MAP_HEIGHT,
+  PORTAL_HP,
+  ISLAND_MAP_WIDTHS,
+} from '../types';
+import { generateTerrain } from './terrain';
+
+// Default (Island 1) settlement centers spread across the 600-tile map
+const ISLAND_CONFIGS: {
+  settlements: number[];
+  portals: number[];
+  foodCaches: number[];
+  restShrines: number[];
+  powerWells: number[];
+  vagrantCamps: number[];
+}[] = [
+  // Island 1: Tutorial Isle (600 tiles)
+  {
+    settlements: [100, 250, 300, 400, 500],
+    portals: [30, 200, 570],            // 2 dock portals, 1 cliff portal
+    foodCaches: [160, 350, 450],
+    restShrines: [80, 230, 480],
+    powerWells: [50, 280, 550],
+    vagrantCamps: [120, 270, 380],
+  },
+  // Island 2: Stone Coast (800 tiles)
+  {
+    settlements: [120, 300, 400, 550, 700],
+    portals: [40, 230, 500, 760],       // 3 cliff portals, 1 dock portal per side
+    foodCaches: [180, 360, 620, 680],
+    restShrines: [100, 280, 530, 680],
+    powerWells: [60, 350, 580, 740],
+    vagrantCamps: [140, 320, 420, 580, 650],
+  },
+  // Island 3: Forge Bay (1000 tiles)
+  {
+    settlements: [150, 350, 500, 700, 880],
+    portals: [40, 240, 440, 600, 800, 960],  // 4-6 cliff portals + cave portal
+    foodCaches: [200, 430, 650, 820, 920],
+    restShrines: [130, 330, 480, 680, 860],
+    powerWells: [70, 300, 550, 750, 940],
+    vagrantCamps: [170, 370, 520, 720, 850],
+  },
+  // Island 4: Iron Reach (1000 tiles)
+  {
+    settlements: [150, 350, 500, 700, 880],
+    portals: [30, 200, 380, 550, 750, 900, 970],  // No merchant, 6+ portals
+    foodCaches: [250, 450, 650, 820],
+    restShrines: [130, 330, 480, 680, 860],
+    powerWells: [80, 300, 550, 750, 940],
+    vagrantCamps: [170, 370, 520, 720, 850, 920],
+  },
+  // Island 5: Crown's End (1200 tiles)
+  {
+    settlements: [150, 400, 600, 800, 1050],
+    portals: [30, 220, 380, 540, 720, 880, 1020, 1170],  // 8+ portals
+    foodCaches: [310, 500, 725, 950, 1100],
+    restShrines: [130, 380, 580, 780, 1030],
+    powerWells: [45, 200, 450, 700, 900, 1155],
+    vagrantCamps: [170, 420, 620, 820, 1000, 1100],
+  },
+];
+
+function placeStructure(state: GameState, x: number, type: StructureType, hp: number): void {
+  state.structures.set(x, {
+    eid: 0 as any,
+    type,
+    x,
+    hp,
+    maxHp: hp,
+    level: 1,
+    assignedWorkers: [],
+    towerTier: TowerTier.None,
+    isRoofed: false,
+  });
+}
+
+/**
+ * Generate island-specific map data without modifying game state.
+ * Returns terrain tiles, portal positions, structure positions, and vagrant camp positions.
+ */
+export function generateIslandMap(islandIndex: number): MapData {
+  const clampedIndex = Math.max(0, Math.min(islandIndex, ISLAND_CONFIGS.length - 1));
+  const config = ISLAND_CONFIGS[clampedIndex]!;
+  const mapWidth = ISLAND_MAP_WIDTHS[clampedIndex] ?? 1200;
+
+  const tiles = generateTerrain(mapWidth, MAP_HEIGHT);
+
+  const structurePositions: MapData['structurePositions'] = [];
+
+  // Settlements: each gets a campfire + tool stands
+  for (const cx of config.settlements) {
+    if (cx < mapWidth) {
+      structurePositions.push({ type: StructureType.Campfire, x: cx, hp: 999 });
+      if (cx - 8 >= 0) structurePositions.push({ type: StructureType.BowStand, x: cx - 8, hp: 999 });
+      if (cx + 8 < mapWidth) structurePositions.push({ type: StructureType.HammerStand, x: cx + 8, hp: 999 });
+    }
+  }
+
+  // Portals
+  const portalPositions = config.portals.filter(x => x < mapWidth);
+  for (const px of portalPositions) {
+    structurePositions.push({ type: StructureType.Portal, x: px, hp: PORTAL_HP });
+  }
+
+  return {
+    tiles,
+    portalPositions,
+    structurePositions,
+    vagrantCampPositions: config.vagrantCamps.filter(x => x < mapWidth),
+    mapWidth,
+  };
+}
+
+/**
+ * Generate the full game map and populate the game state.
+ * Uses island-specific configuration for map layout.
+ */
+export function generateMap(state: GameState): void {
+  const islandIndex = state.islandIndex ?? 0;
+  const clampedIndex = Math.max(0, Math.min(islandIndex, ISLAND_CONFIGS.length - 1));
+  const config = ISLAND_CONFIGS[clampedIndex]!;
+  const mapWidth = ISLAND_MAP_WIDTHS[clampedIndex] ?? 1200;
+
+  // Store map width on state
+  state.mapWidth = mapWidth;
+
+  // Generate terrain grid
+  state.tiles = generateTerrain(mapWidth, MAP_HEIGHT);
+
+  // Initialize structures map
+  state.structures = new Map<number, StructureData>();
+
+  // Place settlements: each gets a campfire and tool stands
+  for (const cx of config.settlements) {
+    if (cx < mapWidth) {
+      placeStructure(state, cx, StructureType.Campfire, 999);
+      if (cx - 8 >= 0) placeStructure(state, cx - 8, StructureType.BowStand, 999);
+      if (cx + 8 < mapWidth) placeStructure(state, cx + 8, StructureType.HammerStand, 999);
+    }
+  }
+
+  // Place portals at forest edges
+  state.portalPositions = config.portals.filter(x => x < mapWidth);
+  for (const px of state.portalPositions) {
+    placeStructure(state, px, StructureType.Portal, PORTAL_HP);
+  }
+
+  // Place consumable spots across the world
+  state.consumableSpots = new Map<number, ConsumableType>();
+
+  // Food caches
+  for (const x of config.foodCaches) {
+    if (x < mapWidth) state.consumableSpots.set(x, ConsumableType.FoodCache);
+  }
+
+  // Rest shrines
+  for (const x of config.restShrines) {
+    if (x < mapWidth) state.consumableSpots.set(x, ConsumableType.RestShrine);
+  }
+
+  // Power wells
+  for (const x of config.powerWells) {
+    if (x < mapWidth) state.consumableSpots.set(x, ConsumableType.PowerWell);
+  }
+}
+
+// Re-export settlement centers for compatibility
+export const SETTLEMENT_CENTERS = ISLAND_CONFIGS[0]!.settlements;

--- a/kingdom/world/terrain.ts
+++ b/kingdom/world/terrain.ts
@@ -1,0 +1,161 @@
+/**
+ * Kingdom - Terrain generation
+ * Generates a massive varied world with multiple biomes:
+ * dense forest, plains, swamp, mountains, ruins, and settlement clearings.
+ */
+
+import {
+  TileType,
+  MAP_WIDTH,
+  GROUND_Y,
+  WATER_Y,
+} from '../types';
+
+// ─── Biome System ────────────────────────────────────────────────
+
+export enum Biome {
+  DenseForest,
+  Plains,
+  Swamp,
+  Mountain,
+  Ruins,
+  Settlement,
+}
+
+/**
+ * Determine biome for a given x position.
+ * Layout across the 1200-tile world:
+ *   0-60: Dense forest (western edge)
+ *   60-120: Plains
+ *   120-180: Settlement 1
+ *   180-260: Dense forest (portal ~220)
+ *   260-340: Swamp
+ *   340-370: Plains transition
+ *   370-430: Settlement 2
+ *   430-520: Mountain zone
+ *   520-570: Dense forest (portal ~540)
+ *   570-630: Settlement 3 (center, player start)
+ *   630-720: Plains (with ponds)
+ *   720-770: Ruins
+ *   770-830: Settlement 4
+ *   830-940: Dense forest (portal ~880)
+ *   940-1000: Ruins
+ *   1000-1020: Plains transition
+ *   1020-1080: Settlement 5
+ *   1080-1140: Plains
+ *   1140-1200: Dense forest (eastern edge)
+ */
+export function getBiome(x: number): Biome {
+  if (x < 60 || x > 1140) return Biome.DenseForest;
+
+  // Settlement zones (30-tile radius)
+  if (x >= 120 && x <= 180) return Biome.Settlement;
+  if (x >= 370 && x <= 430) return Biome.Settlement;
+  if (x >= 570 && x <= 630) return Biome.Settlement;
+  if (x >= 770 && x <= 830) return Biome.Settlement;
+  if (x >= 1020 && x <= 1080) return Biome.Settlement;
+
+  // Inter-settlement biomes
+  if (x > 180 && x < 260) return Biome.DenseForest;
+  if (x >= 260 && x <= 340) return Biome.Swamp;
+  if (x >= 430 && x <= 520) return Biome.Mountain;
+  if (x > 520 && x < 570) return Biome.DenseForest;
+  if (x >= 720 && x <= 770) return Biome.Ruins;
+  if (x > 830 && x < 940) return Biome.DenseForest;
+  if (x >= 940 && x <= 1000) return Biome.Ruins;
+
+  return Biome.Plains;
+}
+
+/**
+ * Get the ground level for a given x position.
+ * Mountains are elevated, plains/forests have occasional hills.
+ */
+export function getGroundLevel(x: number): number {
+  const biome = getBiome(x);
+  let gy = GROUND_Y;
+
+  // Mountains are elevated
+  if (biome === Biome.Mountain) {
+    gy -= 1;
+    if (Math.sin(x * 0.1) > 0.5) gy -= 1;
+  }
+
+  // Occasional hills in plains and forest
+  if (biome === Biome.Plains || biome === Biome.DenseForest) {
+    const hill = Math.sin(x * 0.05) * Math.sin(x * 0.13);
+    if (hill > 0.6) gy -= 1;
+  }
+
+  return gy;
+}
+
+/**
+ * Check if a position should be a pond (small water body on plains).
+ */
+function isPond(x: number): boolean {
+  if (x >= 670 && x <= 685 && ((x * 7 + 13) % 5 < 2)) return true;
+  if (x >= 100 && x <= 108 && ((x * 3 + 7) % 4 < 1)) return true;
+  if (x >= 1090 && x <= 1098 && ((x * 11 + 3) % 5 < 2)) return true;
+  return false;
+}
+
+/**
+ * Generate the full terrain tile grid.
+ * Uses biome zones for variety, with hills, ponds, swamps, and mountains.
+ */
+export function generateTerrain(width: number, height: number): TileType[][] {
+  const tiles: TileType[][] = [];
+
+  for (let y = 0; y < height; y++) {
+    const row: TileType[] = [];
+    for (let x = 0; x < width; x++) {
+      const biome = getBiome(x);
+      const gy = getGroundLevel(x);
+
+      if (y < gy) {
+        // Above ground
+        if (biome === Biome.DenseForest && y >= gy - 4) {
+          row.push(TileType.Forest);
+        } else if (biome === Biome.Mountain && y >= gy - 1) {
+          row.push(TileType.Mountain);
+        } else {
+          row.push(TileType.Sky);
+        }
+      } else if (y === gy) {
+        // Ground level varies by biome
+        switch (biome) {
+          case Biome.DenseForest:
+            row.push(TileType.Forest);
+            break;
+          case Biome.Swamp:
+            row.push(((x * 7 + 3) % 4 < 2) ? TileType.Swamp : TileType.Water);
+            break;
+          case Biome.Mountain:
+            row.push(TileType.Mountain);
+            break;
+          case Biome.Ruins:
+            row.push(((x * 11 + 5) % 7 < 2) ? TileType.Ruins : TileType.ClearedLand);
+            break;
+          case Biome.Settlement:
+            row.push(TileType.Grass);
+            break;
+          case Biome.Plains:
+          default:
+            row.push(isPond(x) ? TileType.Water : TileType.Grass);
+            break;
+        }
+      } else if (y === gy + 1 && biome === Biome.Swamp) {
+        // Below swamp ground: mixed water/dirt
+        row.push(((x * 5 + 7) % 3 < 1) ? TileType.Water : TileType.Dirt);
+      } else if (y < WATER_Y) {
+        row.push(TileType.Dirt);
+      } else {
+        row.push(TileType.Water);
+      }
+    }
+    tiles.push(row);
+  }
+
+  return tiles;
+}

--- a/multiplexer/package-lock.json
+++ b/multiplexer/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "multiplexer-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"bin": {
 				"multiplexer-demo": "dist/index.js"
@@ -898,9 +898,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/multiplexer/package.json
+++ b/multiplexer/package.json
@@ -13,7 +13,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/multiplexer/pnpm-lock.yaml
+++ b/multiplexer/pnpm-lock.yaml
@@ -1,0 +1,983 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  node-addon-api@7.1.1:
+    optional: true
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+    optional: true
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/roguelike/package-lock.json
+++ b/roguelike/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "roguelike-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"devDependencies": {
 				"@types/node": "^25.2.1",
@@ -892,9 +892,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/roguelike/package.json
+++ b/roguelike/package.json
@@ -10,7 +10,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/roguelike/pnpm-lock.yaml
+++ b/roguelike/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/system-monitor/package-lock.json
+++ b/system-monitor/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "system-monitor-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"bin": {
 				"system-monitor-demo": "dist/index.js"
@@ -895,9 +895,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/system-monitor/package.json
+++ b/system-monitor/package.json
@@ -13,7 +13,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/system-monitor/pnpm-lock.yaml
+++ b/system-monitor/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/telnet-server/package-lock.json
+++ b/telnet-server/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "telnet-server-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"bin": {
 				"telnet-server-demo": "dist/index.js"
@@ -895,9 +895,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/telnet-server/package.json
+++ b/telnet-server/package.json
@@ -13,7 +13,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/telnet-server/pnpm-lock.yaml
+++ b/telnet-server/pnpm-lock.yaml
@@ -1,0 +1,965 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}

--- a/terminal/package-lock.json
+++ b/terminal/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "terminal-example",
 			"version": "0.0.1",
 			"dependencies": {
-				"blecsd": "^0.1.1"
+				"blecsd": "^0.2.0"
 			},
 			"bin": {
 				"terminal-demo": "dist/index.js"
@@ -898,9 +898,9 @@
 			"license": "MPL-2.0"
 		},
 		"node_modules/blecsd": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.1.1.tgz",
-			"integrity": "sha512-3BbrRlM377Y1GM1qapbOPKea5sZUOCRt3Uac9Z9UPtWEYdkEnqvB22i60/+171FZdgmfxiXpp1sxq8p3kCMUew==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/blecsd/-/blecsd-0.2.0.tgz",
+			"integrity": "sha512-48pZRL3UNYHxFpB370p7xiy2oNBkHrEyX21+ZlvOeNj/abgvlyv1aLElTY4N6h8xvf+86PcRB+u+oZ3U18GsKQ==",
 			"license": "MIT",
 			"dependencies": {
 				"bitecs": "^0.4.0",

--- a/terminal/package.json
+++ b/terminal/package.json
@@ -13,7 +13,7 @@
 		"dev": "tsx index.ts"
 	},
 	"dependencies": {
-		"blecsd": "^0.1.1"
+		"blecsd": "file:../../blECSd"
 	},
 	"devDependencies": {
 		"@types/node": "^25.2.1",

--- a/terminal/pnpm-lock.yaml
+++ b/terminal/pnpm-lock.yaml
@@ -1,0 +1,983 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      blecsd:
+        specifier: file:../../blECSd
+        version: file:../../blECSd
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.1
+        version: 25.2.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bitecs@0.4.0:
+    resolution: {integrity: sha512-ho6Zop/L79DRTnBAfakPpGPuX7y0+lAjX06CpaAW+5tnAc7BH3L3RlSrWAXAqwnQGDZ10GsoxaxyTTsddlun3g==}
+
+  blecsd@file:../../blECSd:
+    resolution: {directory: ../../blECSd, type: directory}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
+
+  acorn@8.15.0: {}
+
+  any-promise@1.3.0: {}
+
+  bitecs@0.4.0: {}
+
+  blecsd@file:../../blECSd:
+    dependencies:
+      bitecs: 0.4.0
+      zod: 4.3.6
+
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.57.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  node-addon-api@7.1.1:
+    optional: true
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+    optional: true
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.21.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.21.0
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.21.0)
+      resolve-from: 5.0.0
+      rollup: 4.57.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@7.16.0: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

- Updates all 18 example projects to use `file:../../blECSd` for the local 0.3.0 build
- Fixes breaking API changes in `setRenderBuffer` (now requires `DirtyTracker` + `ScreenBufferData`)
- Adds required `world` parameter to widget accessor functions (`getProgressPercentage`, `isProgressComplete`, `renderProgressString`, `onProgressComplete`, `getSelectedLabel`, `getHighlightedIndex`, `onSelectChange`, `getSliderValue`, `getSliderPercentage`, `renderSliderString`, `onSliderChange`, `setTableDisplay`, `getDataRows`, `renderTableLines`)
- Removes unused imports (`getData`, `getColumns`) from table-demo
- Includes new example projects: `claude-chat`, `kingdom`
- Includes pre-existing doom and agent-orchestrator 0.3.0 migration changes

## Test plan

- [x] All 18 examples pass `tsc --noEmit` against blECSd 0.3.0
- [ ] Spot-check run a few examples (`3d-cube`, `ascii-clock`, `demos`) to verify runtime behavior